### PR TITLE
fix(ci): fix publish to npm flow and revert 0.3.0 publication

### DIFF
--- a/.github/workflows/publish-on-next-close.yml
+++ b/.github/workflows/publish-on-next-close.yml
@@ -206,7 +206,7 @@ jobs:
         run: |
           set -euo pipefail
           echo "Using Nx Release to publish only selected projects via npm trusted publishing..."
-          yarn nx release publish --projects="${{ steps.publishable.outputs.projects }}" --yes
+          yarn nx release publish --yes
 
       # -------------------------------
       # 7) Create GitHub Release

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,23 +1,3 @@
-## [v0.3.0] - 2025-11-15
-
-### feat
-
-- Add stage-aware `FlowHooksOf(...)` helpers so you can orchestrate Will/Stage/Did/Around instrumentation across tool
-  and HTTP flows.
-
-### fix
-
-- Stringify OpenAPI adapter request bodies before issuing non-GET calls so remote APIs receive JSON payloads.
-
-### docs
-
-- Document hook-driven flow-stage customization in the Mintlify guide.
-
-### ci
-
-- Automate Mintlify doc and changelog sync on `next/*` release branches.
-- Harden release branch creation and publish workflows to keep the release train unblocked.
-
 ## 0.2.5 (2025-11-06)
 
 This was a version bump only, there were no code changes.

--- a/apps/demo/src/apps/expenses/index.ts
+++ b/apps/demo/src/apps/expenses/index.ts
@@ -1,11 +1,10 @@
 import {App} from '@frontmcp/sdk';
 
 import {ExpenseConfigProvider,} from './provders';
-// import {CachePlugin} from '@frontmcp/plugins';
 import {OpenapiAdapter} from "@frontmcp/adapters";
 import CreateExpenseTool from './tools/create-expense.tool';
 import GetExpenseTool from './tools/get-expense-fun.tool';
-import {AddTool} from "./tools/add.tool";
+import AddTool from "./tools/add.tool";
 import AuthorizationPlugin from "./plugins/authorization.plugin";
 import {CachePlugin} from "@frontmcp/plugins";
 

--- a/docs/updates.mdx
+++ b/docs/updates.mdx
@@ -5,22 +5,6 @@ icon: 'sparkles'
 mode: 'center'
 ---
 
-<Update label="FrontMCP 0.3.0" description="November 2025" tags={["Releases"]}>
-    <Card
-        title="FrontMCP 0.3.0: Instrument every stage"
-        href="https://github.com/agentfront/frontmcp/releases/tag/v0.3.0"
-        cta="Read the release notes"
-    >
-        Flow instrumentation gets easier in 0.3.0 thanks to typed hook helpers, plus workflow and adapter polish.
-
-        - 🪝 <strong>Stage-aware Flow Hooks</strong>: use <code>FlowHooksOf(...)</code> (and <code>ToolHook</code>/<code>HttpHook</code>) to register Will/Stage/Did/Around handlers with explicit priorities.
-        - 📘 <strong>Hook guide</strong>: the new "Customize Flow Stages" walkthrough shows how to enforce policy, redact data, and emit telemetry.
-        - 🛠️ <strong>OpenAPI adapter fix</strong>: JSON request bodies now stay JSON—no more <code>[object Object]</code> payloads reaching your upstreams.
-        - 🔄 <strong>Release automation</strong>: Codex keeps docs and changelog in sync while hardened workflows unblock publish runs.
-    </Card>
-
-</Update>
-
 <Update label="FrontMCP 0.2.0" description="November 2025" tags={["Releases"]}>
     <Card
         title="FrontMCP 0.2.0: Create. Inspect. Dev—faster."

--- a/libs/adapters/package.json
+++ b/libs/adapters/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@frontmcp/adapters",
-  "version": "0.3.0",
+  "version": "0.2.5",
   "description": "Adapters for the FrontMCP framework",
   "author": "AgentFront <info@agentfront.dev>",
   "homepage": "https://docs.agentfront.dev",
@@ -33,7 +33,7 @@
   },
   "dependencies": {
     "tslib": "^2.3.0",
-    "@frontmcp/sdk": "^0.3.0",
+    "@frontmcp/sdk": "^0.2.5",
     "openapi-mcp-generator": "^3.2.0",
     "json-schema-to-zod": "^2.6.1"
   }

--- a/libs/cli/package.json
+++ b/libs/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontmcp",
-  "version": "0.3.0",
+  "version": "0.2.5",
   "description": "FrontMCP command line interface",
   "author": "AgentFront <info@agentfront.dev>",
   "homepage": "https://docs.agentfront.dev",
@@ -30,9 +30,9 @@
     "prepare": "npm run build"
   },
   "dependencies": {
-    "@frontmcp/sdk": "^0.3.0",
-    "@frontmcp/plugins": "^0.3.0",
-    "@frontmcp/adapters": "^0.3.0"
+    "@frontmcp/sdk": "^0.2.5",
+    "@frontmcp/plugins": "^0.2.5",
+    "@frontmcp/adapters": "^0.2.5"
   },
   "devDependencies": {
     "typescript": "^5.5.3",

--- a/libs/cli/src/index.ts
+++ b/libs/cli/src/index.ts
@@ -1,0 +1,1 @@
+export const name = 'forntmcp-cli'

--- a/libs/plugins/package.json
+++ b/libs/plugins/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@frontmcp/plugins",
-  "version": "0.3.0",
+  "version": "0.2.5",
   "description": "FrontMCP plugins to extend the SDK",
   "author": "AgentFront <info@agentfront.dev>",
   "homepage": "https://docs.agentfront.dev",
@@ -33,6 +33,6 @@
   },
   "dependencies": {
     "tslib": "^2.3.0",
-    "@frontmcp/sdk": "^0.3.0"
+    "@frontmcp/sdk": "^0.2.5"
   }
 }

--- a/libs/sdk/package.json
+++ b/libs/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@frontmcp/sdk",
-  "version": "0.3.0",
+  "version": "0.2.5",
   "description": "FrontMCP SDK",
   "author": "AgentFront <info@agentfront.dev>",
   "homepage": "https://docs.agentfront.dev",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@frontmcp/source",
-  "version": "0.3.0",
+  "version": "0.2.5",
   "license": "MIT",
   "scripts": {
     "dev": "nx serve demo"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Downgraded package versions to v0.2.5 across all modules.
  * Updated all internal dependencies to align with v0.2.5.
  * Simplified npm publishing workflow by removing project filtering.

* **Documentation**
  * Removed v0.3.0 release notes from changelog and release documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->