### PR TITLE
feat: Set LOCAL_MCP_PORT in environment for local MCP server connectivity tests

### DIFF
--- a/apps/e2e/demo-e2e-remote/e2e/remote.e2e.test.ts
+++ b/apps/e2e/demo-e2e-remote/e2e/remote.e2e.test.ts
@@ -58,6 +58,7 @@ test.describe('Remote MCP Server Orchestration E2E', () => {
     port: 3098,
     logLevel: 'debug',
     startupTimeout: 60000, // Give gateway more time to connect to local server
+    env: { LOCAL_MCP_PORT: '3099' }, // Match the port where local MCP server is started
   });
 
   test('basic connectivity test', async ({ mcp }) => {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated test environment configuration to improve remote gateway testing setup.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->