### PR TITLE
fix: Update default authentication mode to public and remove warning for unauthenticated usage

### DIFF
--- a/libs/sdk/src/auth/auth.registry.ts
+++ b/libs/sdk/src/auth/auth.registry.ts
@@ -36,9 +36,7 @@ import { orchestratedAuthContextExtension } from './authorization/orchestrated.c
  * Default auth options when none provided - public mode with all tools open
  */
 const DEFAULT_AUTH_OPTIONS: AuthOptionsInput = {
-  mode: 'orchestrated',
-  type: 'local',
-  allowDefaultPublic: true,
+  mode: 'public',
 };
 
 export class AuthRegistry

--- a/libs/sdk/src/scope/scope.instance.ts
+++ b/libs/sdk/src/scope/scope.instance.ts
@@ -408,12 +408,6 @@ export class Scope extends ScopeEntry {
 
     await this.auth.ready;
     this.logger.info('Initializing multi-app scope', this.metadata);
-    if (!this.metadata.auth) {
-      // log a large warning about using FrontMcp without authentication
-      this.logger.warn(
-        `\n\n*******************************\n  WARNING: FrontMcp is running without authentication. \n  This is a security risk and should only be used in development environments. \n*******************************\n\n`,
-      );
-    }
   }
 
   private get defaultScopeProviders() {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Default authentication configuration simplified to public mode, changing from the previous orchestrated/local setup with additional type and allowlist settings.
  * Removed runtime security warning that appeared during initialization when authentication metadata was not configured, reducing initialization-time logging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->