### PR TITLE
feat: implement MCPB build target with validation and packaging support

### DIFF
--- a/apps/e2e/demo-e2e-mcpb/e2e/helpers/archive.ts
+++ b/apps/e2e/demo-e2e-mcpb/e2e/helpers/archive.ts
@@ -1,6 +1,6 @@
-import * as fs from 'fs';
-
 import type { Entry, ZipFile } from 'yauzl';
+
+import { readFileBuffer, sha256Hex } from '@frontmcp/utils';
 
 const yauzl = require('yauzl') as typeof import('yauzl');
 
@@ -46,7 +46,11 @@ export function readArchive(archivePath: string): Promise<ArchiveContents> {
           reject(new Error('manifest.json missing from archive'));
           return;
         }
-        resolve({ entries, manifest: JSON.parse(manifestRaw) });
+        try {
+          resolve({ entries, manifest: JSON.parse(manifestRaw) });
+        } catch (err) {
+          reject(new Error(`Invalid manifest.json: ${(err as Error).message}`));
+        }
       });
       zip.on('error', reject);
     });
@@ -55,7 +59,6 @@ export function readArchive(archivePath: string): Promise<ArchiveContents> {
 
 /** SHA-256 of the archive contents as lowercase hex. */
 export async function sha256File(filePath: string): Promise<string> {
-  const { createHash } = await import('crypto');
-  const buf = fs.readFileSync(filePath);
-  return createHash('sha256').update(buf).digest('hex');
+  const buf = await readFileBuffer(filePath);
+  return sha256Hex(buf);
 }

--- a/apps/e2e/demo-e2e-mcpb/e2e/helpers/archive.ts
+++ b/apps/e2e/demo-e2e-mcpb/e2e/helpers/archive.ts
@@ -1,0 +1,61 @@
+import * as fs from 'fs';
+
+import type { Entry, ZipFile } from 'yauzl';
+
+const yauzl = require('yauzl') as typeof import('yauzl');
+
+export interface ArchiveContents {
+  entries: string[];
+  manifest: Record<string, unknown>;
+}
+
+/** Open a .mcpb archive and return its entry list + parsed manifest.json. */
+export function readArchive(archivePath: string): Promise<ArchiveContents> {
+  return new Promise<ArchiveContents>((resolve, reject) => {
+    yauzl.open(archivePath, { lazyEntries: true }, (err: Error | null, zip: ZipFile | undefined) => {
+      if (err || !zip) {
+        reject(err || new Error('yauzl returned no handle'));
+        return;
+      }
+      const entries: string[] = [];
+      let manifestRaw = '';
+
+      zip.readEntry();
+      zip.on('entry', (entry: Entry) => {
+        entries.push(entry.fileName);
+        if (entry.fileName === 'manifest.json') {
+          zip.openReadStream(entry, (streamErr, stream) => {
+            if (streamErr || !stream) {
+              reject(streamErr || new Error('Failed to open manifest.json'));
+              return;
+            }
+            const chunks: Buffer[] = [];
+            stream.on('data', (chunk: Buffer) => chunks.push(chunk));
+            stream.on('end', () => {
+              manifestRaw = Buffer.concat(chunks).toString('utf-8');
+              zip.readEntry();
+            });
+            stream.on('error', reject);
+          });
+        } else {
+          zip.readEntry();
+        }
+      });
+      zip.on('end', () => {
+        if (!manifestRaw) {
+          reject(new Error('manifest.json missing from archive'));
+          return;
+        }
+        resolve({ entries, manifest: JSON.parse(manifestRaw) });
+      });
+      zip.on('error', reject);
+    });
+  });
+}
+
+/** SHA-256 of the archive contents as lowercase hex. */
+export async function sha256File(filePath: string): Promise<string> {
+  const { createHash } = await import('crypto');
+  const buf = fs.readFileSync(filePath);
+  return createHash('sha256').update(buf).digest('hex');
+}

--- a/apps/e2e/demo-e2e-mcpb/e2e/helpers/mcpb-build.ts
+++ b/apps/e2e/demo-e2e-mcpb/e2e/helpers/mcpb-build.ts
@@ -1,0 +1,103 @@
+import { execFileSync } from 'child_process';
+import * as fs from 'fs';
+import * as path from 'path';
+
+const APP_NAME = 'mcpb-demo';
+const APP_VERSION = '1.2.3';
+
+const FIXTURE_DIR = path.resolve(__dirname, '../../fixture');
+const ROOT_DIR = path.resolve(FIXTURE_DIR, '../../../..');
+const FRONTMCP_BIN = path.join(ROOT_DIR, 'libs', 'cli', 'dist', 'src', 'core', 'cli.js');
+const DIST_DIR = path.join(FIXTURE_DIR, 'dist');
+const MCPB_DIR = path.join(DIST_DIR, 'mcpb');
+const ARCHIVE_PATH = path.join(MCPB_DIR, `${APP_NAME}-${APP_VERSION}.mcpb`);
+
+let buildDone = false;
+
+export function getAppName(): string {
+  return APP_NAME;
+}
+
+export function getAppVersion(): string {
+  return APP_VERSION;
+}
+
+export function getFixtureDir(): string {
+  return FIXTURE_DIR;
+}
+
+export function getDistDir(): string {
+  return DIST_DIR;
+}
+
+export function getMcpbDir(): string {
+  return MCPB_DIR;
+}
+
+export function getArchivePath(): string {
+  return ARCHIVE_PATH;
+}
+
+export function getFrontmcpBin(): string {
+  return FRONTMCP_BIN;
+}
+
+/**
+ * Run `frontmcp build --target mcpb` inside the fixture directory. Idempotent
+ * across tests in the same Jest worker — subsequent calls return immediately.
+ */
+export async function ensureBuild(extraArgs: string[] = []): Promise<string> {
+  if (buildDone && extraArgs.length === 0) return ARCHIVE_PATH;
+
+  // Clear any prior artifacts to guarantee a fresh build.
+  if (fs.existsSync(DIST_DIR)) {
+    fs.rmSync(DIST_DIR, { recursive: true, force: true });
+  }
+
+  console.log('[e2e:mcpb] Building MCPB archive...');
+  execFileSync('node', [FRONTMCP_BIN, 'build', '--target', 'mcpb', ...extraArgs], {
+    cwd: FIXTURE_DIR,
+    stdio: 'pipe',
+    timeout: 150000,
+    env: { ...process.env, NODE_ENV: 'production' },
+  });
+  console.log('[e2e:mcpb] Build complete.');
+
+  buildDone = extraArgs.length === 0;
+  return ARCHIVE_PATH;
+}
+
+/** Force the next ensureBuild() call to rebuild even if a prior build ran. */
+export function resetBuildCache(): void {
+  buildDone = false;
+}
+
+export interface CliResult {
+  stdout: string;
+  stderr: string;
+  exitCode: number;
+}
+
+/** Run the workspace `frontmcp` CLI from an arbitrary cwd, collecting output. */
+export function runFrontmcp(args: string[], cwd: string = FIXTURE_DIR): CliResult {
+  try {
+    const stdout = execFileSync('node', [FRONTMCP_BIN, ...args], {
+      cwd,
+      timeout: 60000,
+      encoding: 'utf-8',
+      env: { ...process.env, NODE_ENV: 'test' },
+    });
+    return { stdout: stdout.toString(), stderr: '', exitCode: 0 };
+  } catch (err: unknown) {
+    const error = err as {
+      stdout?: string | Buffer;
+      stderr?: string | Buffer;
+      status?: number;
+    };
+    return {
+      stdout: (error.stdout || '').toString(),
+      stderr: (error.stderr || '').toString(),
+      exitCode: error.status ?? 1,
+    };
+  }
+}

--- a/apps/e2e/demo-e2e-mcpb/e2e/helpers/mcpb-build.ts
+++ b/apps/e2e/demo-e2e-mcpb/e2e/helpers/mcpb-build.ts
@@ -1,6 +1,7 @@
 import { execFileSync } from 'child_process';
-import * as fs from 'fs';
 import * as path from 'path';
+
+import { fileExists, rm } from '@frontmcp/utils';
 
 const APP_NAME = 'mcpb-demo';
 const APP_VERSION = '1.2.3';
@@ -50,8 +51,8 @@ export async function ensureBuild(extraArgs: string[] = []): Promise<string> {
   if (buildDone && extraArgs.length === 0) return ARCHIVE_PATH;
 
   // Clear any prior artifacts to guarantee a fresh build.
-  if (fs.existsSync(DIST_DIR)) {
-    fs.rmSync(DIST_DIR, { recursive: true, force: true });
+  if (await fileExists(DIST_DIR)) {
+    await rm(DIST_DIR, { recursive: true, force: true });
   }
 
   console.log('[e2e:mcpb] Building MCPB archive...');

--- a/apps/e2e/demo-e2e-mcpb/e2e/mcpb-build.e2e.spec.ts
+++ b/apps/e2e/demo-e2e-mcpb/e2e/mcpb-build.e2e.spec.ts
@@ -1,4 +1,4 @@
-import * as fs from 'fs';
+import { fileExists, stat } from '@frontmcp/utils';
 
 import { readArchive, sha256File } from './helpers/archive';
 import {
@@ -15,15 +15,15 @@ describe('frontmcp build --target mcpb', () => {
     await ensureBuild();
   });
 
-  it('produces the .mcpb archive at the expected path', () => {
-    expect(fs.existsSync(getArchivePath())).toBe(true);
-    const size = fs.statSync(getArchivePath()).size;
+  it('produces the .mcpb archive at the expected path', async () => {
+    expect(await fileExists(getArchivePath())).toBe(true);
+    const { size } = await stat(getArchivePath());
     expect(size).toBeGreaterThan(0);
   });
 
-  it('removes the __stage intermediate directory after zipping', () => {
+  it('removes the __stage intermediate directory after zipping', async () => {
     const stageDir = `${getMcpbDir()}/__stage`;
-    expect(fs.existsSync(stageDir)).toBe(false);
+    expect(await fileExists(stageDir)).toBe(false);
   });
 
   it('produces a v0.3 manifest with the expected metadata', async () => {

--- a/apps/e2e/demo-e2e-mcpb/e2e/mcpb-build.e2e.spec.ts
+++ b/apps/e2e/demo-e2e-mcpb/e2e/mcpb-build.e2e.spec.ts
@@ -1,0 +1,86 @@
+import * as fs from 'fs';
+
+import { readArchive, sha256File } from './helpers/archive';
+import {
+  ensureBuild,
+  getAppName,
+  getAppVersion,
+  getArchivePath,
+  getMcpbDir,
+  resetBuildCache,
+} from './helpers/mcpb-build';
+
+describe('frontmcp build --target mcpb', () => {
+  beforeAll(async () => {
+    await ensureBuild();
+  });
+
+  it('produces the .mcpb archive at the expected path', () => {
+    expect(fs.existsSync(getArchivePath())).toBe(true);
+    const size = fs.statSync(getArchivePath()).size;
+    expect(size).toBeGreaterThan(0);
+  });
+
+  it('removes the __stage intermediate directory after zipping', () => {
+    const stageDir = `${getMcpbDir()}/__stage`;
+    expect(fs.existsSync(stageDir)).toBe(false);
+  });
+
+  it('produces a v0.3 manifest with the expected metadata', async () => {
+    const { manifest } = await readArchive(getArchivePath());
+    expect(manifest['manifest_version']).toBe('0.3');
+    expect(manifest['name']).toBe(getAppName());
+    expect(manifest['version']).toBe(getAppVersion());
+    expect(manifest['display_name']).toBe('MCPB Demo');
+    expect(manifest['license']).toBe('Apache-2.0');
+    expect(manifest['author']).toEqual({
+      name: 'FrontMCP E2E',
+      email: 'e2e@agentfront.dev',
+    });
+  });
+
+  it('enumerates user tools and marks prompts as generated', async () => {
+    const { manifest } = await readArchive(getArchivePath());
+    const tools = manifest['tools'] as Array<{ name: string; description: string }>;
+    expect(tools).toBeDefined();
+    const toolNames = tools.map((t) => t.name).sort();
+    expect(toolNames).toEqual(['echo', 'greet']);
+    expect(manifest['tools_generated']).toBe(false);
+    expect(manifest['prompts_generated']).toBe(true);
+  });
+
+  it('wires the stdio server entry under ${__dirname}/server/index.js', async () => {
+    const { manifest, entries } = await readArchive(getArchivePath());
+    const server = manifest['server'] as {
+      type: string;
+      entry_point: string;
+      mcp_config: { command: string; args: string[] };
+    };
+    expect(server.type).toBe('node');
+    expect(server.entry_point).toBe('server/index.js');
+    expect(server.mcp_config.command).toBe('node');
+    expect(server.mcp_config.args).toEqual(['${__dirname}/server/index.js']);
+    expect(entries).toContain('server/index.js');
+    expect(entries).toContain('server/package.json');
+    expect(entries).toContain('manifest.json');
+  });
+
+  it('reports compatibility defaults (platforms + node runtime)', async () => {
+    const { manifest } = await readArchive(getArchivePath());
+    const compat = manifest['compatibility'] as {
+      platforms?: string[];
+      runtimes?: { node?: string };
+    };
+    expect(compat.platforms?.sort()).toEqual(['darwin', 'linux', 'win32']);
+    expect(compat.runtimes?.node).toBeDefined();
+  });
+
+  it('emits a deterministic archive (byte-identical across back-to-back builds)', async () => {
+    const first = await sha256File(getArchivePath());
+    // Force a completely fresh rebuild from clean state
+    resetBuildCache();
+    await ensureBuild();
+    const second = await sha256File(getArchivePath());
+    expect(second).toBe(first);
+  });
+});

--- a/apps/e2e/demo-e2e-mcpb/e2e/mcpb-validate.e2e.spec.ts
+++ b/apps/e2e/demo-e2e-mcpb/e2e/mcpb-validate.e2e.spec.ts
@@ -1,0 +1,40 @@
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+import { ensureBuild, getArchivePath, runFrontmcp } from './helpers/mcpb-build';
+
+describe('frontmcp mcpb validate', () => {
+  beforeAll(async () => {
+    await ensureBuild();
+  });
+
+  it('reports a valid archive produced by the build target', () => {
+    const result = runFrontmcp(['mcpb', 'validate', getArchivePath()]);
+    expect(result.exitCode).toBe(0);
+    const combined = result.stdout + result.stderr;
+    expect(combined).toContain('archive is valid');
+    expect(combined).toContain('name=mcpb-demo');
+    expect(combined).toContain('version=1.2.3');
+  });
+
+  it('exits non-zero and reports the error for a missing archive', () => {
+    const missing = path.join(os.tmpdir(), 'does-not-exist.mcpb');
+    const result = runFrontmcp(['mcpb', 'validate', missing]);
+    expect(result.exitCode).not.toBe(0);
+    expect(result.stdout + result.stderr).toContain('Cannot open archive');
+  });
+
+  it('rejects an archive that is not a valid ZIP', () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'mcpb-e2e-'));
+    try {
+      const bogus = path.join(tmpDir, 'bogus.mcpb');
+      fs.writeFileSync(bogus, 'not a zip archive');
+      const result = runFrontmcp(['mcpb', 'validate', bogus]);
+      expect(result.exitCode).not.toBe(0);
+      expect(result.stdout + result.stderr).toContain('Cannot open archive');
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+});

--- a/apps/e2e/demo-e2e-mcpb/e2e/mcpb-validate.e2e.spec.ts
+++ b/apps/e2e/demo-e2e-mcpb/e2e/mcpb-validate.e2e.spec.ts
@@ -1,6 +1,7 @@
-import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
+
+import { mkdtemp, rm, writeFile } from '@frontmcp/utils';
 
 import { ensureBuild, getArchivePath, runFrontmcp } from './helpers/mcpb-build';
 
@@ -19,22 +20,22 @@ describe('frontmcp mcpb validate', () => {
   });
 
   it('exits non-zero and reports the error for a missing archive', () => {
-    const missing = path.join(os.tmpdir(), 'does-not-exist.mcpb');
+    const missing = path.join(os.tmpdir(), `frontmcp-missing-${Date.now()}-${process.pid}.mcpb`);
     const result = runFrontmcp(['mcpb', 'validate', missing]);
     expect(result.exitCode).not.toBe(0);
     expect(result.stdout + result.stderr).toContain('Cannot open archive');
   });
 
-  it('rejects an archive that is not a valid ZIP', () => {
-    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'mcpb-e2e-'));
+  it('rejects an archive that is not a valid ZIP', async () => {
+    const tmpDir = await mkdtemp(path.join(os.tmpdir(), 'mcpb-e2e-'));
     try {
       const bogus = path.join(tmpDir, 'bogus.mcpb');
-      fs.writeFileSync(bogus, 'not a zip archive');
+      await writeFile(bogus, 'not a zip archive');
       const result = runFrontmcp(['mcpb', 'validate', bogus]);
       expect(result.exitCode).not.toBe(0);
       expect(result.stdout + result.stderr).toContain('Cannot open archive');
     } finally {
-      fs.rmSync(tmpDir, { recursive: true, force: true });
+      await rm(tmpDir, { recursive: true, force: true });
     }
   });
 });

--- a/apps/e2e/demo-e2e-mcpb/fixture/frontmcp.config.js
+++ b/apps/e2e/demo-e2e-mcpb/fixture/frontmcp.config.js
@@ -1,0 +1,53 @@
+/**
+ * FrontMCP config for the MCPB e2e fixture.
+ *
+ * Uses the `deployments[]` (v1) config shape so the mcpb target picks up its
+ * dedicated metadata via `findDeployment(config, 'mcpb')`. Top-level esbuild
+ * externals live under `build.esbuild.external` (also part of the v1 schema).
+ *
+ * Setup-step translation is covered by unit integration tests — kept out of
+ * the fixture to stay inside the strict v1 schema.
+ */
+module.exports = {
+  name: 'mcpb-demo',
+  version: '1.2.3',
+  entry: './src/main.ts',
+  nodeVersion: '>=22.0.0',
+  build: {
+    esbuild: {
+      external: [
+        '@frontmcp/sdk',
+        '@frontmcp/di',
+        '@frontmcp/utils',
+        '@frontmcp/auth',
+        '@frontmcp/storage-sqlite',
+        '@frontmcp/uipack',
+        '@frontmcp/uipack/*',
+        '@frontmcp/ui',
+        '@frontmcp/ui/*',
+        '@frontmcp/adapters',
+        '@frontmcp/adapters/*',
+        'reflect-metadata',
+        'zod',
+        '@modelcontextprotocol/sdk',
+        '@modelcontextprotocol/sdk/*',
+      ],
+    },
+  },
+  deployments: [
+    {
+      target: 'mcpb',
+      displayName: 'MCPB Demo',
+      longDescription: '# MCPB Demo\n\nE2E fixture for the MCPB build target.',
+      author: { name: 'FrontMCP E2E', email: 'e2e@agentfront.dev' },
+      license: 'Apache-2.0',
+      homepage: 'https://docs.agentfront.dev',
+      keywords: ['mcpb', 'e2e'],
+      compatibility: {
+        platforms: ['darwin', 'linux', 'win32'],
+        runtimes: { node: '>=22.0.0' },
+      },
+      deterministic: true,
+    },
+  ],
+};

--- a/apps/e2e/demo-e2e-mcpb/fixture/package.json
+++ b/apps/e2e/demo-e2e-mcpb/fixture/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "mcpb-demo",
+  "version": "1.2.3",
+  "description": "MCPB e2e fixture — exercises frontmcp build --target mcpb",
+  "author": "FrontMCP E2E <e2e@agentfront.dev>",
+  "license": "Apache-2.0",
+  "homepage": "https://docs.agentfront.dev",
+  "keywords": [
+    "mcpb",
+    "e2e",
+    "fixture"
+  ],
+  "main": "./src/main.ts",
+  "private": true
+}

--- a/apps/e2e/demo-e2e-mcpb/fixture/src/apps/mcpb-demo/index.ts
+++ b/apps/e2e/demo-e2e-mcpb/fixture/src/apps/mcpb-demo/index.ts
@@ -1,0 +1,11 @@
+import { App } from '@frontmcp/sdk';
+
+import EchoTool from './tools/echo.tool';
+import GreetTool from './tools/greet.tool';
+
+@App({
+  name: 'McpbDemo',
+  description: 'Minimal fixture exercising the MCPB build target',
+  tools: [GreetTool, EchoTool],
+})
+export class McpbDemoApp {}

--- a/apps/e2e/demo-e2e-mcpb/fixture/src/apps/mcpb-demo/tools/echo.tool.ts
+++ b/apps/e2e/demo-e2e-mcpb/fixture/src/apps/mcpb-demo/tools/echo.tool.ts
@@ -1,0 +1,16 @@
+import { z } from 'zod';
+
+import { Tool, ToolContext } from '@frontmcp/sdk';
+
+@Tool({
+  name: 'echo',
+  description: 'Echo a message back verbatim',
+  inputSchema: {
+    message: z.string(),
+  },
+})
+export default class EchoTool extends ToolContext {
+  async execute(input: { message: string }) {
+    return { message: input.message };
+  }
+}

--- a/apps/e2e/demo-e2e-mcpb/fixture/src/apps/mcpb-demo/tools/greet.tool.ts
+++ b/apps/e2e/demo-e2e-mcpb/fixture/src/apps/mcpb-demo/tools/greet.tool.ts
@@ -1,0 +1,17 @@
+import { z } from 'zod';
+
+import { Tool, ToolContext } from '@frontmcp/sdk';
+
+@Tool({
+  name: 'greet',
+  description: 'Greet someone by name',
+  inputSchema: {
+    name: z.string().describe('Name to greet'),
+  },
+})
+export default class GreetTool extends ToolContext {
+  async execute(input: { name: string }) {
+    const apiBase = process.env['API_BASE'] ?? 'https://api.example.com';
+    return { message: `Hello, ${input.name}! (via ${apiBase})` };
+  }
+}

--- a/apps/e2e/demo-e2e-mcpb/fixture/src/main.ts
+++ b/apps/e2e/demo-e2e-mcpb/fixture/src/main.ts
@@ -1,0 +1,14 @@
+import 'reflect-metadata';
+
+import { FrontMcp, LogLevel } from '@frontmcp/sdk';
+
+import { McpbDemoApp } from './apps/mcpb-demo';
+
+@FrontMcp({
+  info: { name: 'mcpb-demo', version: '1.2.3' },
+  apps: [McpbDemoApp],
+  logging: { level: LogLevel.Warn, enableConsole: false },
+  auth: { mode: 'public' as const },
+  serve: false,
+})
+export default class McpbDemoServer {}

--- a/apps/e2e/demo-e2e-mcpb/jest.e2e.config.ts
+++ b/apps/e2e/demo-e2e-mcpb/jest.e2e.config.ts
@@ -1,0 +1,43 @@
+import { createRequire } from 'module';
+
+import type { Config } from '@jest/types';
+
+const require = createRequire(import.meta.url);
+const e2eCoveragePreset: Config.InitialOptions = require('../../../jest.e2e.coverage.preset.js');
+
+const config: Config.InitialOptions = {
+  displayName: 'demo-e2e-mcpb',
+  preset: '../../../jest.preset.js',
+  testEnvironment: 'node',
+  testMatch: ['<rootDir>/e2e/**/*.e2e.spec.ts'],
+  testTimeout: 180000,
+  maxWorkers: 1,
+  setupFilesAfterEnv: ['<rootDir>/../../../libs/testing/src/setup.ts'],
+  transformIgnorePatterns: ['node_modules/(?!(jose)/)'],
+  transform: {
+    '^.+\\.[tj]s$': [
+      '@swc/jest',
+      {
+        jsc: {
+          parser: {
+            syntax: 'typescript',
+            decorators: true,
+          },
+          transform: {
+            decoratorMetadata: true,
+          },
+          target: 'es2022',
+        },
+      },
+    ],
+  },
+  moduleNameMapper: {
+    '^@frontmcp/testing$': '<rootDir>/../../../libs/testing/src/index.ts',
+    '^@frontmcp/sdk$': '<rootDir>/../../../libs/sdk/src/index.ts',
+    '^@frontmcp/adapters$': '<rootDir>/../../../libs/adapters/src/index.ts',
+  },
+  ...e2eCoveragePreset,
+  coverageDirectory: '../../../coverage/e2e/demo-e2e-mcpb',
+};
+
+export default config;

--- a/apps/e2e/demo-e2e-mcpb/project.json
+++ b/apps/e2e/demo-e2e-mcpb/project.json
@@ -1,0 +1,41 @@
+{
+  "name": "demo-e2e-mcpb",
+  "$schema": "../../../node_modules/nx/schemas/project-schema.json",
+  "sourceRoot": "apps/e2e/demo-e2e-mcpb/fixture/src",
+  "projectType": "application",
+  "tags": ["scope:demo", "type:e2e", "feature:mcpb"],
+  "targets": {
+    "build": {
+      "executor": "nx:run-commands",
+      "dependsOn": [{ "projects": ["cli"], "target": "build" }],
+      "options": {
+        "command": "node ../../../../libs/cli/dist/src/core/cli.js build --target mcpb",
+        "cwd": "apps/e2e/demo-e2e-mcpb/fixture"
+      },
+      "outputs": ["{projectRoot}/fixture/dist"]
+    },
+    "test": {
+      "executor": "@nx/jest:jest",
+      "outputs": ["{workspaceRoot}/coverage/apps/e2e/demo-e2e-mcpb"],
+      "options": {
+        "jestConfig": "apps/e2e/demo-e2e-mcpb/jest.e2e.config.ts",
+        "runInBand": true
+      }
+    },
+    "test:e2e": {
+      "executor": "@nx/jest:jest",
+      "outputs": ["{workspaceRoot}/coverage/apps/e2e/demo-e2e-mcpb-e2e"],
+      "options": {
+        "jestConfig": "apps/e2e/demo-e2e-mcpb/jest.e2e.config.ts",
+        "runInBand": true
+      }
+    },
+    "typecheck-e2e": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "tsc --noEmit -p tsconfig.e2e.json",
+        "cwd": "apps/e2e/demo-e2e-mcpb"
+      }
+    }
+  }
+}

--- a/apps/e2e/demo-e2e-mcpb/tsconfig.app.json
+++ b/apps/e2e/demo-e2e-mcpb/tsconfig.app.json
@@ -1,0 +1,13 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../../dist/out-tsc",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "types": ["node"],
+    "emitDecoratorMetadata": true,
+    "experimentalDecorators": true
+  },
+  "exclude": ["jest.config.ts", "jest.e2e.config.ts", "fixture/src/**/*.spec.ts", "e2e/**/*.ts"],
+  "include": ["fixture/src/**/*.ts"]
+}

--- a/apps/e2e/demo-e2e-mcpb/tsconfig.e2e.json
+++ b/apps/e2e/demo-e2e-mcpb/tsconfig.e2e.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "types": ["node", "jest"]
+  },
+  "include": ["e2e/**/*.ts"]
+}

--- a/apps/e2e/demo-e2e-mcpb/tsconfig.json
+++ b/apps/e2e/demo-e2e-mcpb/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "esModuleInterop": true,
+    "experimentalDecorators": true,
+    "emitDecoratorMetadata": true
+  },
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.app.json"
+    }
+  ],
+  "extends": "../../../tsconfig.base.json"
+}

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -140,6 +140,7 @@
                   "frontmcp/deployment/unix-socket",
                   "frontmcp/deployment/mcp-clients",
                   "frontmcp/deployment/serverless",
+                  "frontmcp/deployment/mcpb",
                   "frontmcp/deployment/health-checks",
                   "frontmcp/deployment/high-availability",
                   "frontmcp/deployment/frontmcp-config",

--- a/docs/frontmcp/deployment/frontmcp-config.mdx
+++ b/docs/frontmcp/deployment/frontmcp-config.mdx
@@ -67,17 +67,41 @@ Each entry in `deployments` defines a build target with independent settings:
 | `browser` | Browser bundle | In-memory | Memory only |
 | `cli` | Standalone binary | stdio | SQLite, memory |
 | `sdk` | Library for embedding | Direct (in-process) | Configurable |
+| `mcpb` | MCP Bundle archive (see [MCPB](/frontmcp/deployment/mcpb)) | stdio | SQLite, memory |
 
 ### Deployment Target Fields
 
 | Field | Type | Description |
 | --- | --- | --- |
-| `target` | string | One of the 8 target types above |
+| `target` | string | One of the 9 target types above |
 | `server` | ServerConfig | HTTP, CORS, CSP, and security header settings |
 | `ha` | HaConfig | HA settings (distributed target only) |
 | `cli` | CliConfig | CLI-specific settings (cli target only) |
 | `js` | boolean | Generate .js bundle instead of native binary (cli target) |
 | `env` | Record | Per-target environment variables |
+
+### MCPB-Only Fields
+
+The `mcpb` target supports additional fields for [MCP Bundle](/frontmcp/deployment/mcpb) metadata:
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `displayName` | string | Human-friendly bundle title shown in the installer |
+| `longDescription` | string | Markdown description for the extension details page |
+| `author` | `{ name, email?, url? }` | Overrides parsed `package.json.author` |
+| `license` | string | SPDX license identifier |
+| `homepage` | string | Project homepage URL |
+| `repository` | string \| `{ type, url }` | Source repository |
+| `documentation` | string | Documentation URL |
+| `support` | string | Support / issues URL |
+| `icon` | string | Icon path relative to project root (PNG) |
+| `keywords` | string[] | Keywords for client search |
+| `privacyPolicies` | string[] | Privacy policy URLs for external services this server talks to |
+| `compatibility` | object | `{ claude_desktop?, platforms?, runtimes? }` constraints |
+| `userConfig` | Record | MCPB `user_config` overrides (type, min/max, etc.) — merged with translated `setup.steps` |
+| `sea` | `{ enabled?, mergeFrom? }` | Build SEA binary for the host and/or merge pre-built binaries |
+| `includeNodeModules` | boolean | Include `server/node_modules/` in the archive (off by default) |
+| `deterministic` | boolean | Produce byte-identical archives across runs (defaults to `true`) |
 
 ## Server Configuration
 

--- a/docs/frontmcp/deployment/mcpb.mdx
+++ b/docs/frontmcp/deployment/mcpb.mdx
@@ -1,0 +1,323 @@
+---
+title: MCP Bundles (MCPB)
+slug: deployment/mcpb
+icon: box-archive
+description: Package a FrontMCP server as a .mcpb archive that Claude Desktop and other MCPB-aware clients can install with one click.
+---
+
+FrontMCP can emit a [**MCP Bundle**](https://github.com/modelcontextprotocol/mcpb)
+(`.mcpb`) — a ZIP archive with a declarative `manifest.json` that describes the
+server's metadata, tools, user-configurable inputs, and runtime command. Clients
+such as Claude Desktop double-click the bundle; the host extracts it and starts
+the server over stdio.
+
+<Info>
+  MCPB targets **spec v0.3**. Archives are portable across macOS, Linux, and
+  Windows. FrontMCP emits the `node` server type by default, with optional SEA
+  binaries for offline execution.
+</Info>
+
+## When to use MCPB
+
+<Tabs>
+<Tab title="Use MCPB when">
+- You ship an MCP server to end users who install via Claude Desktop, Cursor,
+  or another MCPB-aware client — no CLI, no `npx`, no registry.
+- You want a single signed artifact with a stable hash you can attach to a
+  GitHub release.
+- You need a `user_config` form so users can supply tokens/paths during install
+  rather than editing JSON.
+</Tab>
+<Tab title="Use `--target cli` when">
+- You're distributing a full interactive CLI (subcommands per tool, session
+  management, OAuth flows).
+- Your primary consumers are scripts and humans, not MCP clients.
+</Tab>
+<Tab title="Use `--target node` / serverless when">
+- You're hosting the server yourself as an HTTP endpoint.
+- You need Vercel, Lambda, Cloudflare Workers, or a distributed deployment.
+</Tab>
+</Tabs>
+
+## Quick start
+
+```bash
+# Basic bundle — produces dist/mcpb/{name}-{version}.mcpb
+frontmcp build --target mcpb
+
+# Include a SEA binary for the host platform (offline-capable install)
+frontmcp build --target mcpb --sea
+
+# Merge pre-built cross-platform binaries from a CI matrix
+frontmcp build --target mcpb --merge-from ./ci-bins
+
+# Validate an existing archive
+frontmcp mcpb validate dist/mcpb/my-server-1.0.0.mcpb
+```
+
+## Output layout
+
+```
+dist/mcpb/
+  my-server-1.0.0.mcpb              # ZIP archive — the distributable artifact
+  __stage/                          # intermediate staging (removed by default)
+    manifest.json                   # MCPB v0.3 manifest
+    server/
+      index.js                      # esbuild single-file CJS bundle
+      package.json                  # minimal CJS marker
+      _skills/                      # present when the server ships skills
+    bin/
+      darwin-arm64/my-server        # present when --sea or --merge-from
+      win32-x64/my-server.exe
+    icon.png                        # present when resolved
+    README.md                       # present when README.md exists in cwd
+```
+
+The archive is **deterministic by default** — two back-to-back builds produce
+byte-identical output (fixed mtime, lexicographic entry ordering). FrontMCP
+logs the `sha256` of every archive it emits so you can attach it to release
+notes.
+
+## Configuration
+
+MCPB metadata lives alongside your other deployment targets in `frontmcp.config`:
+
+```ts frontmcp.config.ts
+import { defineConfig } from 'frontmcp';
+
+export default defineConfig({
+  name: 'my-server',
+  version: '1.2.3',
+  nodeVersion: '>=22.0.0',
+  deployments: [
+    {
+      target: 'mcpb',
+      displayName: 'My Server',
+      longDescription: '# My Server\n\nReads your calendar.',
+      author: { name: 'Acme', email: 'hello@acme.dev' },
+      license: 'Apache-2.0',
+      homepage: 'https://acme.dev/my-server',
+      repository: 'https://github.com/acme/my-server',
+      icon: 'assets/icon.png',
+      keywords: ['calendar', 'scheduling'],
+      compatibility: {
+        claude_desktop: '>=1.0.0',
+        platforms: ['darwin', 'linux', 'win32'],
+        runtimes: { node: '>=22.0.0' },
+      },
+      sea: { enabled: true },
+    },
+  ],
+});
+```
+
+Unset fields fall back to `package.json` — `name`, `version`, `description`,
+`author`, `license`, `homepage`, `repository`, `keywords`, and an `icon.png`
+in the project root are all detected automatically.
+
+## Tools and prompts
+
+FrontMCP boots your server in a **schema-extraction** mode at build time
+(`FRONTMCP_SCHEMA_EXTRACT=1`) to enumerate tools, resources, prompts, and
+skills without starting the HTTP transport. The manifest emits:
+
+- `tools[]` — every user-defined tool with its `name` and `description`
+  (system tools like `execute-job` / `register-workflow` are filtered out)
+- `tools_generated: false` — consumers can trust the static list
+- `prompts[]` — prompt names + descriptions
+- `prompts_generated: true` — FrontMCP prompts resolve via `execute()`; MCPB's
+  static `text` field cannot represent JS logic, so consumers query
+  `prompts/get` at runtime for the rendered template
+
+<Note>
+Skills travel with the bundle. The build copies each skill's `SKILL.md` and
+`references/` / `examples/` / `scripts/` / `assets/` directories into
+`server/_skills/<skill>--<asset>/` and emits a runtime manifest so your code
+resolves them via `__dirname` after the host extracts the archive.
+</Note>
+
+## User configuration
+
+If your exec config defines a [`setup.steps`](/frontmcp/deployment/frontmcp-config)
+questionnaire, FrontMCP translates each step into MCPB `user_config` entries and
+wires them back into `mcp_config.env` via `${user_config.KEY}` references:
+
+```json manifest.json (excerpt)
+{
+  "server": {
+    "mcp_config": {
+      "command": "node",
+      "args": ["${__dirname}/server/index.js"],
+      "env": {
+        "API_TOKEN": "${user_config.apiToken}",
+        "MAX_ITEMS": "${user_config.maxItems}"
+      }
+    }
+  },
+  "user_config": {
+    "apiToken": {
+      "type": "string",
+      "title": "API Token",
+      "description": "Token for calling the external API",
+      "required": true,
+      "sensitive": true
+    },
+    "maxItems": {
+      "type": "number",
+      "title": "Max items",
+      "default": 25,
+      "min": 1,
+      "max": 100
+    }
+  }
+}
+```
+
+Claude Desktop shows each entry in the install dialog and re-runs the server
+with the user's answers as environment variables — matching FrontMCP's existing
+`.env` convention so the same code path works in dev and in the bundled server.
+
+Type resolution:
+
+| FrontMCP schema                               | MCPB `type`           |
+| --------------------------------------------- | --------------------- |
+| `z.string()`                                  | `string`              |
+| `z.number()` / `z.number().int()`             | `number`              |
+| `z.boolean()`                                 | `boolean`             |
+| `z.array(z.string())`                         | `string` + `multiple` |
+| `userConfig.key.type: 'directory'` override   | `directory`           |
+| `userConfig.key.type: 'file'` override        | `file`                |
+
+Defaults are stripped automatically when `sensitive: true` so secrets never
+leak into the manifest.
+
+<Warning>
+`setup.steps` with `showWhen` (conditional visibility) or `next` (branching)
+have no MCPB equivalent — MCPB forms are flat key/value. The generator logs a
+warning and renders those steps unconditionally.
+</Warning>
+
+## SEA binaries and platform overrides
+
+Pass `--sea` (or set `sea.enabled` in config) to ship a [Node.js
+single-executable](https://nodejs.org/api/single-executable-applications.html)
+alongside the bundled JS. FrontMCP emits a `platform_overrides` block in
+`mcp_config` that routes each supported OS/arch to its binary:
+
+```json
+"mcp_config": {
+  "command": "node",
+  "args": ["${__dirname}/server/index.js"],
+  "platform_overrides": {
+    "darwin-arm64": { "command": "${__dirname}/bin/darwin-arm64/my-server", "args": [] },
+    "linux-x64":    { "command": "${__dirname}/bin/linux-x64/my-server",    "args": [] },
+    "win32-x64":    { "command": "${__dirname}/bin/win32-x64/my-server.exe", "args": [] }
+  }
+}
+```
+
+Platforms without a binary fall through to the Node command — the bundled JS
+runs on any machine with Node installed.
+
+### Cross-platform archives
+
+Node SEA can only build for the **host** OS/arch in a single pass. To ship a
+single `.mcpb` that runs binary-only on every platform, run builds in a CI
+matrix and assemble them with `--merge-from`:
+
+```yaml .github/workflows/release.yml (excerpt)
+jobs:
+  build-sea:
+    strategy:
+      matrix:
+        include:
+          - os: macos-latest
+            arch: arm64
+            key: darwin-arm64
+          - os: macos-13
+            arch: x64
+            key: darwin-x64
+          - os: ubuntu-latest
+            arch: x64
+            key: linux-x64
+          - os: windows-latest
+            arch: x64
+            key: win32-x64
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+      - run: yarn install --frozen-lockfile
+      - run: npx frontmcp build --target mcpb --sea --stage-only
+      - uses: actions/upload-artifact@v4
+        with:
+          name: sea-${{ matrix.key }}
+          path: dist/mcpb/__stage/bin/${{ matrix.key }}/*
+
+  pack:
+    needs: build-sea
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/download-artifact@v4
+        with: { path: ci-bins }
+      - run: npx frontmcp build --target mcpb --merge-from ci-bins
+      - uses: softprops/action-gh-release@v2
+        with: { files: dist/mcpb/*.mcpb }
+```
+
+## CLI flags
+
+| Flag                   | Description                                                              |
+| ---------------------- | ------------------------------------------------------------------------ |
+| `--target mcpb`        | Selects the MCPB target                                                  |
+| `-o, --out-dir <dir>`  | Output root — the archive lands at `{out-dir}/mcpb/{name}-{version}.mcpb`|
+| `-e, --entry <path>`   | Manually specify the server entry file                                   |
+| `--sea`                | Also build an SEA binary for the host platform                           |
+| `--merge-from <dir>`   | Merge pre-built cross-platform binaries from `{dir}/{platform}/{name}`   |
+| `--icon <path>`        | Override the icon path                                                   |
+| `--no-deterministic`   | Disable deterministic archive output (use for diagnostics only)          |
+| `--stage-only`         | Leave the staging directory intact and skip zipping                      |
+
+## Validate an archive
+
+Use the `mcpb validate` subcommand before attaching an archive to a release:
+
+```bash
+$ frontmcp mcpb validate dist/mcpb/my-server-1.2.3.mcpb
+[mcpb:validate] dist/mcpb/my-server-1.2.3.mcpb
+[mcpb:validate] name=my-server version=1.2.3
+[mcpb:validate] tools=7 prompts=2 user_config=2
+[mcpb:validate] archive is valid
+```
+
+The validator checks that the archive:
+
+- opens as a ZIP and contains a `manifest.json`
+- parses against the MCPB v0.3 schema
+- points `server.entry_point` to a file actually present in the archive
+- uses only allow-listed `${…}` substitutions
+  (`__dirname`, `HOME`, `DESKTOP`, `DOCUMENTS`, `DOWNLOADS`, `pathSeparator`,
+  and declared `user_config` keys)
+- has an accessible icon if one is declared
+- has no zip-slip paths or absolute paths where `${__dirname}/…` is expected
+- binaries referenced in `platform_overrides` exist under `bin/`
+
+Warnings fire for archives over 50 MB, for declarations of `node_modules/`,
+and for absolute paths that should probably be `${__dirname}/…`.
+
+## Troubleshooting
+
+| Symptom                                            | Cause / Fix                                                                                                           |
+| -------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------- |
+| `@frontmcp/sdk is required for schema extraction` | Make sure `@frontmcp/sdk` is installed and not excluded from the bundle.                                              |
+| Archive > 100 MB                                   | Set `build.esbuild.external` for native/optional deps, or drop `--sea` to ship node-only.                             |
+| `Unknown substitution variable`                    | Only the allow-listed variables above and declared `user_config` keys are valid.                                      |
+| `entry_point is not present in the archive`        | A custom entry or bundler config moved the server file; re-run without overrides or set `--entry` correctly.           |
+| `platform_overrides.darwin-arm64.command` missing  | `--merge-from` layout must be `{dir}/{platform}/{name}[.exe]` — check the folder names against MCPB platform keys.     |
+| Two builds produce different SHA-256s              | `--no-deterministic` or `deterministic: false` was set, or an input file had a changing timestamp embedded in content. |
+
+## Reference
+
+- [MCPB specification](https://github.com/modelcontextprotocol/mcpb) — upstream
+- [`frontmcp.config`](/frontmcp/deployment/frontmcp-config) — deployment target reference
+- [Production builds](/frontmcp/deployment/production-build) — for Node-hosted deployments

--- a/docs/frontmcp/features/deployment-targets.mdx
+++ b/docs/frontmcp/features/deployment-targets.mdx
@@ -7,12 +7,13 @@ description: Deploy to Node.js, Vercel, AWS Lambda, or Cloudflare Workers
 
 FrontMCP supports multiple deployment targets out of the box. The same `@FrontMcp` server code deploys to any platform — only the build adapter and infrastructure config change.
 
-| Target                 | Runtime      | Session Storage      | Cold Start             | Best For                  |
-| ---------------------- | ------------ | -------------------- | ---------------------- | ------------------------- |
-| **Node.js / Docker**   | Long-running | In-memory or Redis   | None                   | Full-featured servers     |
-| **Vercel**             | Serverless   | Vercel KV or Redis   | Low (~50–250 ms)       | Edge-first deployments    |
-| **AWS Lambda**         | Serverless   | Redis / DynamoDB     | Moderate (~100–500 ms) | AWS-native infrastructure |
-| **Cloudflare Workers** | Edge         | KV / Durable Objects | Minimal (~1–10 ms)     | Ultra-low latency         |
+| Target                 | Runtime          | Session Storage      | Cold Start             | Best For                            |
+| ---------------------- | ---------------- | -------------------- | ---------------------- | ----------------------------------- |
+| **Node.js / Docker**   | Long-running     | In-memory or Redis   | None                   | Full-featured servers               |
+| **Vercel**             | Serverless       | Vercel KV or Redis   | Low (~50–250 ms)       | Edge-first deployments              |
+| **AWS Lambda**         | Serverless       | Redis / DynamoDB     | Moderate (~100–500 ms) | AWS-native infrastructure           |
+| **Cloudflare Workers** | Edge             | KV / Durable Objects | Minimal (~1–10 ms)     | Ultra-low latency                   |
+| **MCP Bundle (MCPB)**  | Client-spawned   | SQLite / memory      | N/A (user machine)     | One-click installs in Claude Desktop |
 
 > **Note:** Cold-start timings are approximate ranges that vary by provider, region, bundle size, and workload.
 
@@ -25,6 +26,9 @@ FrontMCP supports multiple deployment targets out of the box. The same `@FrontMc
   </Card>
   <Card title="Serverless" icon="cloud" href="/frontmcp/deployment/serverless">
     Vercel, Lambda, and Cloudflare deployment
+  </Card>
+  <Card title="MCP Bundle (MCPB)" icon="box-archive" href="/frontmcp/deployment/mcpb">
+    Package a one-click `.mcpb` archive for Claude Desktop
   </Card>
   <Card title="Redis Setup" icon="database" href="/frontmcp/deployment/redis-setup">
     Configure session and token storage

--- a/docs/frontmcp/getting-started/cli-reference.mdx
+++ b/docs/frontmcp/getting-started/cli-reference.mdx
@@ -21,6 +21,8 @@ Commands for building, testing, and debugging your FrontMCP server.
 | `build`              | Compile entry with TypeScript (tsc)                           |
 | `build --target node` | Build distributable executable bundle (esbuild)               |
 | `build --target cli`  | Build CLI executable with subcommands per tool                |
+| `build --target mcpb` | Package server as an `.mcpb` archive for MCPB-aware clients   |
+| `mcpb validate <path>` | Validate a `.mcpb` archive against the MCPB v0.3 spec        |
 | `test`               | Run E2E tests with auto-injected Jest configuration           |
 | `init`               | Create or fix a tsconfig.json suitable for FrontMCP           |
 | `doctor`             | Check Node/npm versions and tsconfig requirements. Use `--fix` to auto-repair (installs missing deps, creates app directories) |
@@ -95,8 +97,13 @@ See [ESM Packages](/frontmcp/servers/esm-packages) for full documentation on ESM
 
 | Option                 | Description                                                                      |
 | ---------------------- | -------------------------------------------------------------------------------- |
-| `--target <target>`    | Build target: `node`, `cli`, `vercel`, `lambda`, `cloudflare`        |
+| `--target <target>`    | Build target: `node`, `cli`, `sdk`, `browser`, `vercel`, `lambda`, `cloudflare`, `distributed`, `mcpb` |
 | `--js`                 | Emit plain JavaScript bundle instead of SEA (use with `--target cli`)            |
+| `--sea`                | Also build a single-executable binary for the host platform (use with `--target mcpb`) |
+| `--merge-from <dir>`   | Merge cross-platform SEA binaries from `{dir}/{platform}/{name}` (use with `--target mcpb`) |
+| `--icon <path>`        | Override the icon path included in the archive (use with `--target mcpb`)        |
+| `--no-deterministic`   | Disable deterministic archive output (use with `--target mcpb`)                  |
+| `--stage-only`         | Leave the MCPB staging directory intact and skip zipping (use with `--target mcpb`) |
 
 ### Start Options
 

--- a/libs/cli/README.md
+++ b/libs/cli/README.md
@@ -51,6 +51,13 @@ npx frontmcp create my-app
 | `frontmcp uninstall <name>` | Remove an installed MCP app                     |
 | `frontmcp configure <name>` | Re-run setup questionnaire for an installed app |
 
+### MCP Bundles (MCPB)
+
+| Command                         | Description                                                            |
+| ------------------------------- | ---------------------------------------------------------------------- |
+| `frontmcp build --target mcpb`  | Package the server into a `.mcpb` archive (MCPB v0.3 spec)             |
+| `frontmcp mcpb validate <path>` | Verify an existing `.mcpb` archive against the MCPB v0.3 specification |
+
 ## Options Reference
 
 ### General
@@ -157,6 +164,60 @@ frontmcp inspector                  # Launch MCP Inspector UI
 frontmcp build --exec               # Single-file executable bundle
 frontmcp build --exec --cli         # CLI with subcommands per tool
 ```
+
+### MCP Bundles (`.mcpb`)
+
+The `mcpb` target produces a ZIP archive that can be loaded directly into Claude
+Desktop (and other MCPB-aware clients) without any install step — the host app
+extracts the archive and starts the server via stdio.
+
+```bash
+frontmcp build --target mcpb                         # basic node bundle
+frontmcp build --target mcpb --sea                   # include a SEA binary for this OS/arch
+frontmcp build --target mcpb --merge-from ./ci-bins  # merge pre-built cross-platform binaries
+frontmcp build --target mcpb --stage-only            # leave the staging directory for inspection
+frontmcp mcpb validate dist/mcpb/myapp-1.0.0.mcpb    # verify an archive
+```
+
+`frontmcp.config`:
+
+```ts
+import { defineConfig } from 'frontmcp';
+
+export default defineConfig({
+  name: 'my-server',
+  version: '1.2.3',
+  deployments: [
+    {
+      target: 'mcpb',
+      displayName: 'My Server',
+      author: { name: 'Acme', email: 'hello@acme.dev' },
+      license: 'Apache-2.0',
+      homepage: 'https://acme.dev/my-server',
+      repository: 'https://github.com/acme/my-server',
+      icon: 'assets/icon.png',
+      compatibility: {
+        claude_desktop: '>=1.0.0',
+        platforms: ['darwin', 'linux', 'win32'],
+        runtimes: { node: '>=22.0.0' },
+      },
+      sea: { enabled: true },
+    },
+  ],
+});
+```
+
+Fields not declared in the deployment fall back to the project `package.json`
+(name, version, description, author, license, homepage, repository, keywords).
+FrontMCP `setup.steps` are automatically translated to MCPB `user_config` and
+exposed as environment variables at runtime via `${user_config.KEY}`
+substitution in `mcp_config.env`. Conditional visibility / branching steps
+(`showWhen`, `next`) have no MCPB equivalent — the generator logs a warning
+and renders them unconditionally.
+
+Cross-platform SEA binaries require a CI matrix build (Node SEA only builds
+for the host OS/arch in a single pass). Use `--merge-from <dir>` to assemble
+pre-built binaries organized as `{mergeFromDir}/{platform}/{appName}[.exe]`.
 
 ### Generated CLI Features
 

--- a/libs/cli/package.json
+++ b/libs/cli/package.json
@@ -42,11 +42,15 @@
     "tslib": "^2.3.0",
     "vectoriadb": "^2.2.0",
     "@rspack/core": "^1.7.6",
-    "esbuild": "^0.27.3"
+    "esbuild": "^0.27.3",
+    "yauzl": "^3.2.0",
+    "yazl": "^3.3.1"
   },
   "devDependencies": {
     "typescript": "^5.5.3",
     "tsx": "^4.20.6",
-    "@types/node": "^24.0.0"
+    "@types/node": "^24.0.0",
+    "@types/yauzl": "^2.10.3",
+    "@types/yazl": "^2.4.5"
   }
 }

--- a/libs/cli/src/commands/build/exec/__tests__/skill-assets.spec.ts
+++ b/libs/cli/src/commands/build/exec/__tests__/skill-assets.spec.ts
@@ -1,0 +1,70 @@
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { copySkillAssets } from '../skill-assets';
+import type { ExtractedSkillAsset } from '../cli-runtime/schema-extractor';
+
+describe('copySkillAssets', () => {
+  let tmpDir: string;
+  let srcDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'skill-assets-'));
+    srcDir = fs.mkdtempSync(path.join(os.tmpdir(), 'skill-src-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+    fs.rmSync(srcDir, { recursive: true, force: true });
+  });
+
+  it('returns zero when no assets provided', () => {
+    const result = copySkillAssets(tmpDir, []);
+    expect(result.copiedCount).toBe(0);
+    expect(result.skillsDir).toBe('');
+    expect(fs.existsSync(path.join(tmpDir, '_skills'))).toBe(false);
+  });
+
+  it('copies instruction file with flat naming', () => {
+    const instr = path.join(srcDir, 'SKILL.md');
+    fs.writeFileSync(instr, '# hi');
+
+    const result = copySkillAssets(tmpDir, [
+      { skillName: 'greet', instructionFile: instr },
+    ]);
+
+    expect(result.copiedCount).toBe(1);
+    const dest = path.join(tmpDir, '_skills', 'greet--SKILL.md');
+    expect(fs.existsSync(dest)).toBe(true);
+    expect(fs.readFileSync(dest, 'utf-8')).toBe('# hi');
+  });
+
+  it('copies resource directories recursively and emits manifest', () => {
+    const refDir = path.join(srcDir, 'references');
+    fs.mkdirSync(refDir, { recursive: true });
+    fs.writeFileSync(path.join(refDir, 'r.md'), 'ref');
+
+    const asset: ExtractedSkillAsset = {
+      skillName: 'alpha',
+      resourceDirs: { references: refDir },
+    };
+
+    const result = copySkillAssets(tmpDir, [asset]);
+
+    expect(result.copiedCount).toBe(1);
+    const copied = path.join(tmpDir, '_skills', 'alpha--references', 'r.md');
+    expect(fs.existsSync(copied)).toBe(true);
+
+    const manifest = JSON.parse(
+      fs.readFileSync(path.join(tmpDir, '_skills', 'manifest.json'), 'utf-8'),
+    );
+    expect(manifest.alpha.references).toBe('_skills/alpha--references');
+  });
+
+  it('skips missing instruction files without throwing', () => {
+    const result = copySkillAssets(tmpDir, [
+      { skillName: 'ghost', instructionFile: '/does/not/exist.md' },
+    ]);
+    expect(result.copiedCount).toBe(0);
+  });
+});

--- a/libs/cli/src/commands/build/exec/index.ts
+++ b/libs/cli/src/commands/build/exec/index.ts
@@ -15,7 +15,7 @@
 
 import * as path from 'path';
 import * as fs from 'fs';
-import { ParsedArgs } from '../../../core/args';
+import { type ParsedArgs } from '../../../core/args';
 import { c } from '../../../core/colors';
 import { resolveEntry } from '../../../shared/fs';
 import { loadExecConfig, normalizeConfig } from './config';
@@ -142,54 +142,11 @@ export async function buildExec(opts: ParsedArgs & { cli?: boolean; sea?: boolea
     if (capabilities.jobs) console.log(`${c('cyan', '[build:exec]')} capability: jobs`);
     if (capabilities.workflows) console.log(`${c('cyan', '[build:exec]')} capability: workflows`);
 
-    // Copy skill content files into _skills/ directory with a manifest.
-    // Uses a flat structure to avoid path traversal issues when skills
-    // reference files outside their own directory (e.g., '../../../docs/guide.md').
-    if (schema.skillAssets.length > 0) {
-      const skillsDir = path.join(outDir, '_skills');
-      fs.mkdirSync(skillsDir, { recursive: true });
-
-      const manifest: Record<string, { instructions?: string; references?: string; examples?: string; scripts?: string; assets?: string }> = {};
-      let copiedCount = 0;
-
-      for (const asset of schema.skillAssets) {
-        const entry: (typeof manifest)[string] = {};
-
-        // Copy instruction file
-        if (asset.instructionFile && fs.existsSync(asset.instructionFile)) {
-          const filename = path.basename(asset.instructionFile);
-          const dest = path.join(skillsDir, `${asset.skillName}--${filename}`);
-          fs.copyFileSync(asset.instructionFile, dest);
-          entry.instructions = `_skills/${asset.skillName}--${filename}`;
-          copiedCount++;
-        }
-
-        // Copy resource directories
-        if (asset.resourceDirs) {
-          for (const [key, dirPath] of Object.entries(asset.resourceDirs)) {
-            if (dirPath && fs.existsSync(dirPath) && fs.statSync(dirPath).isDirectory()) {
-              const destDir = path.join(skillsDir, `${asset.skillName}--${key}`);
-              fs.cpSync(dirPath, destDir, { recursive: true });
-              entry[key as keyof typeof entry] = `_skills/${asset.skillName}--${key}`;
-              copiedCount++;
-            }
-          }
-        }
-
-        if (Object.keys(entry).length > 0) {
-          manifest[asset.skillName] = entry;
-        }
-      }
-
-      // Write manifest so runtime can resolve paths
-      fs.writeFileSync(
-        path.join(skillsDir, 'manifest.json'),
-        JSON.stringify(manifest, null, 2),
-      );
-
-      if (copiedCount > 0) {
-        console.log(`${c('green', '[build:exec]')} copied ${copiedCount} skill content file(s) to _skills/`);
-      }
+    // Copy skill content files via shared helper (flat _skills/ layout).
+    const { copySkillAssets } = await import('./skill-assets.js');
+    const { copiedCount } = copySkillAssets(outDir, schema.skillAssets);
+    if (copiedCount > 0) {
+      console.log(`${c('green', '[build:exec]')} copied ${copiedCount} skill content file(s) to _skills/`);
     }
 
     // Log tool name conflicts

--- a/libs/cli/src/commands/build/exec/skill-assets.ts
+++ b/libs/cli/src/commands/build/exec/skill-assets.ts
@@ -1,0 +1,82 @@
+/**
+ * Skill asset staging — copies skill instruction files and resource directories
+ * into a flat `_skills/` layout so they can be packaged alongside the compiled
+ * server bundle.
+ *
+ * The flat layout (`<skill>--<file>` naming) is deliberate: skills often
+ * reference files outside their own directory (e.g., `../../docs/guide.md`),
+ * which would produce path-traversal issues if we preserved the original tree.
+ *
+ * Consumers (exec runner, MCPB stage) resolve paths via the emitted
+ * `manifest.json` so they don't depend on the flat layout directly.
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+import type { ExtractedSkillAsset } from './cli-runtime/schema-extractor';
+
+export interface SkillAssetsResult {
+  /** Absolute path to the created `_skills/` directory (empty string if no assets copied). */
+  skillsDir: string;
+  /** Total number of files/directories copied. */
+  copiedCount: number;
+}
+
+/**
+ * Copy skill instruction files + resource dirs into `{outDir}/_skills/` and
+ * emit a manifest.json mapping each skill's assets back to their relative path.
+ *
+ * Safe to call with an empty list — returns `{ skillsDir: '', copiedCount: 0 }`
+ * without creating anything.
+ */
+export function copySkillAssets(
+  outDir: string,
+  skillAssets: ExtractedSkillAsset[],
+): SkillAssetsResult {
+  if (skillAssets.length === 0) {
+    return { skillsDir: '', copiedCount: 0 };
+  }
+
+  const skillsDir = path.join(outDir, '_skills');
+  fs.mkdirSync(skillsDir, { recursive: true });
+
+  const manifest: Record<
+    string,
+    { instructions?: string; references?: string; examples?: string; scripts?: string; assets?: string }
+  > = {};
+  let copiedCount = 0;
+
+  for (const asset of skillAssets) {
+    const entry: (typeof manifest)[string] = {};
+
+    if (asset.instructionFile && fs.existsSync(asset.instructionFile)) {
+      const filename = path.basename(asset.instructionFile);
+      const dest = path.join(skillsDir, `${asset.skillName}--${filename}`);
+      fs.copyFileSync(asset.instructionFile, dest);
+      entry.instructions = `_skills/${asset.skillName}--${filename}`;
+      copiedCount++;
+    }
+
+    if (asset.resourceDirs) {
+      for (const [key, dirPath] of Object.entries(asset.resourceDirs)) {
+        if (dirPath && fs.existsSync(dirPath) && fs.statSync(dirPath).isDirectory()) {
+          const destDir = path.join(skillsDir, `${asset.skillName}--${key}`);
+          fs.cpSync(dirPath, destDir, { recursive: true });
+          entry[key as keyof typeof entry] = `_skills/${asset.skillName}--${key}`;
+          copiedCount++;
+        }
+      }
+    }
+
+    if (Object.keys(entry).length > 0) {
+      manifest[asset.skillName] = entry;
+    }
+  }
+
+  fs.writeFileSync(
+    path.join(skillsDir, 'manifest.json'),
+    JSON.stringify(manifest, null, 2),
+  );
+
+  return { skillsDir, copiedCount };
+}

--- a/libs/cli/src/commands/build/index.ts
+++ b/libs/cli/src/commands/build/index.ts
@@ -169,6 +169,10 @@ async function buildSingleTarget(
       const { buildBrowser } = await import('./browser/index.js');
       return buildBrowser(targetOpts);
     }
+    case 'mcpb': {
+      const { buildMcpb } = await import('./mcpb/index.js');
+      return buildMcpb(targetOpts, config);
+    }
     case 'vercel':
     case 'lambda':
     case 'cloudflare':
@@ -177,7 +181,7 @@ async function buildSingleTarget(
       return runAdapterBuild(targetOpts, adapter);
     }
     default:
-      throw new Error(`Unknown build target: ${target}. Available: cli, node, sdk, browser, cloudflare, vercel, lambda, distributed`);
+      throw new Error(`Unknown build target: ${target}. Available: cli, node, sdk, browser, cloudflare, vercel, lambda, distributed, mcpb`);
   }
 }
 

--- a/libs/cli/src/commands/build/mcpb/__tests__/binary.spec.ts
+++ b/libs/cli/src/commands/build/mcpb/__tests__/binary.spec.ts
@@ -1,0 +1,79 @@
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import {
+  binaryFileName,
+  buildPlatformOverrides,
+  mergeBinariesFrom,
+  resolveHostPlatform,
+  MCPB_PLATFORM_KEYS,
+} from '../binary';
+
+describe('resolveHostPlatform', () => {
+  it('resolves darwin/arm64', () => {
+    expect(resolveHostPlatform('darwin', 'arm64')).toBe('darwin-arm64');
+  });
+  it('resolves linux/x64', () => {
+    expect(resolveHostPlatform('linux', 'x64')).toBe('linux-x64');
+  });
+  it('returns undefined for unsupported combinations', () => {
+    expect(resolveHostPlatform('linux', 'mips64el' as NodeJS.Architecture)).toBeUndefined();
+  });
+});
+
+describe('binaryFileName', () => {
+  it('appends .exe on win32', () => {
+    expect(binaryFileName('demo', 'win32-x64')).toBe('demo.exe');
+  });
+  it('leaves unix names alone', () => {
+    expect(binaryFileName('demo', 'darwin-arm64')).toBe('demo');
+    expect(binaryFileName('demo', 'linux-x64')).toBe('demo');
+  });
+});
+
+describe('mergeBinariesFrom', () => {
+  let tmp: string;
+  beforeEach(() => {
+    tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'mcpb-merge-'));
+  });
+  afterEach(() => {
+    fs.rmSync(tmp, { recursive: true, force: true });
+  });
+
+  it('returns empty for missing directory', () => {
+    expect(mergeBinariesFrom(path.join(tmp, 'ghost'), 'demo')).toEqual([]);
+  });
+
+  it('collects binaries across supported platforms', () => {
+    for (const platform of MCPB_PLATFORM_KEYS) {
+      const dir = path.join(tmp, platform);
+      fs.mkdirSync(dir, { recursive: true });
+      const file = binaryFileName('demo', platform);
+      fs.writeFileSync(path.join(dir, file), 'binary');
+    }
+    const result = mergeBinariesFrom(tmp, 'demo');
+    expect(result.map((r) => r.platform).sort()).toEqual([...MCPB_PLATFORM_KEYS].sort());
+  });
+
+  it('ignores unrecognized platform folders', () => {
+    fs.mkdirSync(path.join(tmp, 'haiku-ppc'), { recursive: true });
+    fs.writeFileSync(path.join(tmp, 'haiku-ppc', 'demo'), 'bin');
+    expect(mergeBinariesFrom(tmp, 'demo')).toEqual([]);
+  });
+});
+
+describe('buildPlatformOverrides', () => {
+  it('emits ${__dirname}/bin/... commands with empty args', () => {
+    const overrides = buildPlatformOverrides([
+      { platform: 'darwin-arm64', srcPath: '/tmp/demo', fileName: 'demo' },
+      { platform: 'win32-x64', srcPath: 'C:\\tmp\\demo.exe', fileName: 'demo.exe' },
+    ]);
+    expect(overrides['darwin-arm64'].command).toBe('${__dirname}/bin/darwin-arm64/demo');
+    expect(overrides['win32-x64'].command).toBe('${__dirname}/bin/win32-x64/demo.exe');
+    expect(overrides['darwin-arm64'].args).toEqual([]);
+  });
+
+  it('returns empty object for no entries', () => {
+    expect(buildPlatformOverrides([])).toEqual({});
+  });
+});

--- a/libs/cli/src/commands/build/mcpb/__tests__/build-mcpb.integration.spec.ts
+++ b/libs/cli/src/commands/build/mcpb/__tests__/build-mcpb.integration.spec.ts
@@ -1,0 +1,191 @@
+/**
+ * Integration test for the buildMcpb() pipeline.
+ *
+ * Mocks the heavy stages (tsc, esbuild, schema extraction, SEA) and verifies
+ * that the MCPB-specific stages (stage layout, manifest generation, zip, and
+ * round-trip validation) produce a spec-compliant `.mcpb` archive.
+ */
+
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+jest.mock('@frontmcp/utils', () => ({
+  ensureDir: jest.fn().mockResolvedValue(undefined),
+  fileExists: jest.fn().mockResolvedValue(false),
+  runCmd: jest.fn().mockResolvedValue(undefined),
+}));
+
+jest.mock('../../../../core/colors', () => ({
+  c: (_color: string, text: string) => text,
+}));
+
+jest.mock('../../../../core/tsconfig', () => ({
+  REQUIRED_DECORATOR_FIELDS: { target: 'ES2022' },
+}));
+
+jest.mock('../../../../shared/fs', () => ({
+  resolveEntry: jest.fn().mockResolvedValue('/fake/src/main.ts'),
+}));
+
+jest.mock('../../exec/esbuild-bundler', () => ({
+  bundleWithEsbuild: jest.fn(),
+  formatSize: (n: number) => `${n} B`,
+}));
+
+jest.mock('../../exec/config', () => {
+  const actual = jest.requireActual('../../exec/config');
+  return {
+    ...actual,
+    loadExecConfig: jest.fn(),
+  };
+});
+
+jest.mock('../../exec/cli-runtime/schema-extractor', () => ({
+  extractSchemas: jest.fn(),
+  SYSTEM_TOOL_NAMES: new Set<string>(),
+}));
+
+import { buildMcpb } from '../index';
+import { validateMcpb } from '../validate';
+import { loadExecConfig } from '../../exec/config';
+import { bundleWithEsbuild } from '../../exec/esbuild-bundler';
+import { extractSchemas } from '../../exec/cli-runtime/schema-extractor';
+
+const mockLoadExecConfig = loadExecConfig as jest.Mock;
+const mockBundleWithEsbuild = bundleWithEsbuild as jest.Mock;
+const mockExtractSchemas = extractSchemas as jest.Mock;
+
+describe('buildMcpb integration', () => {
+  let tmp: string;
+  let projectRoot: string;
+  const originalCwd = process.cwd();
+
+  beforeEach(() => {
+    tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'mcpb-e2e-'));
+    projectRoot = path.join(tmp, 'project');
+    fs.mkdirSync(projectRoot, { recursive: true });
+
+    fs.writeFileSync(
+      path.join(projectRoot, 'package.json'),
+      JSON.stringify({
+        name: 'demo-app',
+        version: '1.2.3',
+        description: 'Demo MCP server',
+        author: 'Ada <ada@example.com>',
+        license: 'MIT',
+      }),
+    );
+    fs.writeFileSync(path.join(projectRoot, 'README.md'), '# Demo\n');
+    fs.writeFileSync(path.join(projectRoot, 'icon.png'), 'fake-png');
+
+    process.chdir(projectRoot);
+
+    mockLoadExecConfig.mockResolvedValue({
+      name: 'demo-app',
+      version: '1.2.3',
+      nodeVersion: '>=22.0.0',
+      setup: {
+        steps: [
+          {
+            id: 'api-token',
+            prompt: 'API Token',
+            description: 'Token for calling the API',
+            jsonSchema: { type: 'string' },
+            sensitive: true,
+          },
+          {
+            id: 'max-items',
+            prompt: 'Max items',
+            jsonSchema: { type: 'number', minimum: 1, maximum: 100, default: 25 },
+          },
+        ],
+      },
+    });
+
+    mockBundleWithEsbuild.mockImplementation(async (_entry: string, outDir: string) => {
+      const bundlePath = path.join(outDir, 'demo-app.bundle.js');
+      fs.mkdirSync(outDir, { recursive: true });
+      fs.writeFileSync(bundlePath, 'module.exports = function () {};');
+      return { bundlePath, bundleSize: 34 };
+    });
+
+    mockExtractSchemas.mockResolvedValue({
+      tools: [
+        { name: 'greet', description: 'Say hi', inputSchema: {} },
+        { name: 'farewell', description: 'Say bye', inputSchema: {} },
+      ],
+      resources: [],
+      resourceTemplates: [],
+      prompts: [{ name: 'welcome', description: 'Welcome message' }],
+      jobs: [],
+      capabilities: { skills: false, jobs: false, workflows: false },
+      skillAssets: [],
+    });
+  });
+
+  afterEach(() => {
+    process.chdir(originalCwd);
+    fs.rmSync(tmp, { recursive: true, force: true });
+    jest.clearAllMocks();
+  });
+
+  it('produces a validatable .mcpb archive with manifest + tools + user_config', async () => {
+    await buildMcpb({ _: [], outDir: 'dist/mcpb' });
+
+    const archivePath = path.join(projectRoot, 'dist', 'mcpb', 'demo-app-1.2.3.mcpb');
+    expect(fs.existsSync(archivePath)).toBe(true);
+
+    const validation = await validateMcpb(archivePath);
+    expect(validation.errors).toEqual([]);
+    expect(validation.ok).toBe(true);
+
+    const manifest = validation.manifest!;
+    expect(manifest.name).toBe('demo-app');
+    expect(manifest.version).toBe('1.2.3');
+    expect(manifest.author).toEqual({ name: 'Ada', email: 'ada@example.com' });
+    expect(manifest.license).toBe('MIT');
+    expect(manifest.tools?.map((t) => t.name).sort()).toEqual(['farewell', 'greet']);
+    expect(manifest.prompts_generated).toBe(true);
+    expect(manifest.server.type).toBe('node');
+    expect(manifest.server.entry_point).toBe('server/index.js');
+    expect(manifest.server.mcp_config.env).toEqual({
+      API_TOKEN: '${user_config.apiToken}',
+      MAX_ITEMS: '${user_config.maxItems}',
+    });
+    expect(manifest.user_config?.apiToken.sensitive).toBe(true);
+    expect(manifest.user_config?.maxItems.min).toBe(1);
+    expect(manifest.user_config?.maxItems.max).toBe(100);
+
+    // Archive contains expected entries
+    expect(validation.entries).toContain('manifest.json');
+    expect(validation.entries).toContain('server/index.js');
+    expect(validation.entries).toContain('server/package.json');
+    expect(validation.entries).toContain('icon.png');
+    expect(validation.entries).toContain('README.md');
+
+    // Stage dir cleaned up
+    expect(fs.existsSync(path.join(projectRoot, 'dist', 'mcpb', '__stage'))).toBe(false);
+  });
+
+  it('leaves the stage directory intact when --stage-only is set', async () => {
+    await buildMcpb({ _: [], outDir: 'dist/mcpb', stageOnly: true });
+
+    const stageDir = path.join(projectRoot, 'dist', 'mcpb', '__stage');
+    expect(fs.existsSync(stageDir)).toBe(true);
+    expect(fs.existsSync(path.join(stageDir, 'manifest.json'))).toBe(true);
+    expect(fs.existsSync(path.join(stageDir, 'server', 'index.js'))).toBe(true);
+  });
+
+  it('produces deterministic archives across back-to-back builds', async () => {
+    await buildMcpb({ _: [], outDir: 'dist/mcpb' });
+    const archivePath = path.join(projectRoot, 'dist', 'mcpb', 'demo-app-1.2.3.mcpb');
+    const hashA = fs.readFileSync(archivePath);
+
+    // Second build (fresh bundle stubbed identically)
+    await buildMcpb({ _: [], outDir: 'dist/mcpb' });
+    const hashB = fs.readFileSync(archivePath);
+
+    expect(hashA.equals(hashB)).toBe(true);
+  });
+});

--- a/libs/cli/src/commands/build/mcpb/__tests__/manifest.spec.ts
+++ b/libs/cli/src/commands/build/mcpb/__tests__/manifest.spec.ts
@@ -1,0 +1,281 @@
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import type { ExtractedSchema } from '../../exec/cli-runtime/schema-extractor';
+import {
+  generateMcpbManifest,
+  loadPackageJsonMeta,
+  mcpbManifestSchema,
+  normalizeRepository,
+  parseAuthor,
+  resolveIconPath,
+} from '../manifest';
+
+function emptySchema(partial: Partial<ExtractedSchema> = {}): ExtractedSchema {
+  return {
+    tools: [],
+    resources: [],
+    resourceTemplates: [],
+    prompts: [],
+    jobs: [],
+    capabilities: { skills: false, jobs: false, workflows: false },
+    skillAssets: [],
+    ...partial,
+  };
+}
+
+describe('parseAuthor', () => {
+  it('returns unknown for empty input', () => {
+    expect(parseAuthor(undefined)).toEqual({ name: 'unknown' });
+  });
+
+  it('parses npm-style string with email + url', () => {
+    expect(parseAuthor('Ada Lovelace <ada@example.com> (https://ada.example)')).toEqual({
+      name: 'Ada Lovelace',
+      email: 'ada@example.com',
+      url: 'https://ada.example',
+    });
+  });
+
+  it('handles string with name only', () => {
+    expect(parseAuthor('Grace Hopper')).toEqual({ name: 'Grace Hopper' });
+  });
+
+  it('passes through object authors', () => {
+    expect(parseAuthor({ name: 'Team' })).toEqual({ name: 'Team' });
+  });
+
+  it('falls back when author is a non-parsable value', () => {
+    expect(parseAuthor(42)).toEqual({ name: '42' });
+  });
+});
+
+describe('normalizeRepository', () => {
+  it('normalizes string to git', () => {
+    expect(normalizeRepository('https://github.com/acme/foo')).toEqual({
+      type: 'git',
+      url: 'https://github.com/acme/foo',
+    });
+  });
+
+  it('keeps existing type', () => {
+    expect(normalizeRepository({ type: 'svn', url: 'svn://example' })).toEqual({
+      type: 'svn',
+      url: 'svn://example',
+    });
+  });
+
+  it('returns undefined for missing url', () => {
+    expect(normalizeRepository(undefined)).toBeUndefined();
+    expect(normalizeRepository({} as never)).toBeUndefined();
+  });
+});
+
+describe('resolveIconPath', () => {
+  let tmp: string;
+  beforeEach(() => {
+    tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'mcpb-icon-'));
+  });
+  afterEach(() => {
+    fs.rmSync(tmp, { recursive: true, force: true });
+  });
+
+  it('prefers deployment icon', () => {
+    fs.writeFileSync(path.join(tmp, 'logo.png'), 'x');
+    expect(resolveIconPath(tmp, 'logo.png')).toBe('logo.png');
+  });
+
+  it('falls back to icon.png in cwd', () => {
+    fs.writeFileSync(path.join(tmp, 'icon.png'), 'x');
+    expect(resolveIconPath(tmp)).toBe('icon.png');
+  });
+
+  it('returns undefined when nothing matches', () => {
+    expect(resolveIconPath(tmp)).toBeUndefined();
+  });
+});
+
+describe('loadPackageJsonMeta', () => {
+  let tmp: string;
+  beforeEach(() => {
+    tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'mcpb-pkg-'));
+  });
+  afterEach(() => {
+    fs.rmSync(tmp, { recursive: true, force: true });
+  });
+
+  it('returns empty when package.json is absent', () => {
+    expect(loadPackageJsonMeta(tmp)).toEqual({});
+  });
+
+  it('returns empty when package.json is invalid JSON', () => {
+    fs.writeFileSync(path.join(tmp, 'package.json'), '{ not json');
+    expect(loadPackageJsonMeta(tmp)).toEqual({});
+  });
+
+  it('parses valid package.json', () => {
+    fs.writeFileSync(
+      path.join(tmp, 'package.json'),
+      JSON.stringify({ name: 'x', version: '1.0.0', author: 'Ada' }),
+    );
+    expect(loadPackageJsonMeta(tmp)).toEqual({ name: 'x', version: '1.0.0', author: 'Ada' });
+  });
+});
+
+describe('generateMcpbManifest', () => {
+  let tmp: string;
+  beforeEach(() => {
+    tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'mcpb-gen-'));
+  });
+  afterEach(() => {
+    fs.rmSync(tmp, { recursive: true, force: true });
+  });
+
+  it('produces a schema-valid minimal manifest', () => {
+    const manifest = generateMcpbManifest({
+      name: 'demo',
+      version: '1.0.0',
+      cwd: tmp,
+      schema: emptySchema(),
+      userConfig: {},
+      userConfigEnv: {},
+    });
+
+    expect(manifest.manifest_version).toBe('0.3');
+    expect(manifest.name).toBe('demo');
+    expect(manifest.server.type).toBe('node');
+    expect(manifest.server.entry_point).toBe('server/index.js');
+    expect(manifest.server.mcp_config.command).toBe('node');
+    expect(manifest.server.mcp_config.args).toEqual(['${__dirname}/server/index.js']);
+    expect(manifest.tools_generated).toBe(false);
+    expect(manifest.prompts_generated).toBe(true);
+
+    const parsed = mcpbManifestSchema.safeParse(manifest);
+    expect(parsed.success).toBe(true);
+  });
+
+  it('populates fields from package.json fallbacks', () => {
+    fs.writeFileSync(
+      path.join(tmp, 'package.json'),
+      JSON.stringify({
+        name: 'demo',
+        version: '1.0.0',
+        description: 'Hello world',
+        author: 'Ada <ada@example.com>',
+        license: 'MIT',
+        homepage: 'https://demo.example',
+        repository: 'https://github.com/demo/repo',
+        keywords: ['a', 'b'],
+      }),
+    );
+    const manifest = generateMcpbManifest({
+      name: 'demo',
+      version: '1.0.0',
+      cwd: tmp,
+      schema: emptySchema(),
+      userConfig: {},
+      userConfigEnv: {},
+    });
+
+    expect(manifest.description).toBe('Hello world');
+    expect(manifest.author).toEqual({ name: 'Ada', email: 'ada@example.com' });
+    expect(manifest.license).toBe('MIT');
+    expect(manifest.homepage).toBe('https://demo.example');
+    expect(manifest.repository).toEqual({ type: 'git', url: 'https://github.com/demo/repo' });
+    expect(manifest.keywords).toEqual(['a', 'b']);
+  });
+
+  it('filters system tools and emits user tool list', () => {
+    const manifest = generateMcpbManifest({
+      name: 'demo',
+      version: '1.0.0',
+      cwd: tmp,
+      schema: emptySchema({
+        tools: [
+          { name: 'greet', description: 'Say hi', inputSchema: {} },
+          { name: 'execute-job', description: 'system', inputSchema: {} },
+          { name: 'register-workflow', description: 'system', inputSchema: {} },
+        ],
+      }),
+      userConfig: {},
+      userConfigEnv: {},
+    });
+
+    expect(manifest.tools).toEqual([{ name: 'greet', description: 'Say hi' }]);
+  });
+
+  it('emits env + user_config when provided', () => {
+    const manifest = generateMcpbManifest({
+      name: 'demo',
+      version: '1.0.0',
+      cwd: tmp,
+      schema: emptySchema(),
+      userConfig: {
+        apiKey: { type: 'string', title: 'API Key', required: true, sensitive: true },
+      },
+      userConfigEnv: { API_KEY: '${user_config.apiKey}' },
+    });
+
+    expect(manifest.server.mcp_config.env).toEqual({ API_KEY: '${user_config.apiKey}' });
+    expect(manifest.user_config?.apiKey.sensitive).toBe(true);
+  });
+
+  it('includes platform_overrides when provided', () => {
+    const manifest = generateMcpbManifest({
+      name: 'demo',
+      version: '1.0.0',
+      cwd: tmp,
+      schema: emptySchema(),
+      userConfig: {},
+      userConfigEnv: {},
+      platformOverrides: {
+        'darwin-arm64': { command: '${__dirname}/bin/darwin-arm64/demo', args: [] },
+      },
+    });
+
+    expect(manifest.server.mcp_config.platform_overrides).toBeDefined();
+    expect(manifest.server.mcp_config.platform_overrides?.['darwin-arm64'].command).toContain(
+      'darwin-arm64/demo',
+    );
+  });
+
+  it('defaults compatibility to all three platforms and provided nodeVersion', () => {
+    const manifest = generateMcpbManifest({
+      name: 'demo',
+      version: '1.0.0',
+      cwd: tmp,
+      nodeVersion: '>=24.0.0',
+      schema: emptySchema(),
+      userConfig: {},
+      userConfigEnv: {},
+    });
+
+    expect(manifest.compatibility?.platforms?.sort()).toEqual(['darwin', 'linux', 'win32']);
+    expect(manifest.compatibility?.runtimes?.node).toBe('>=24.0.0');
+  });
+
+  it('overrides from deployment take precedence over package.json', () => {
+    fs.writeFileSync(
+      path.join(tmp, 'package.json'),
+      JSON.stringify({ name: 'demo', description: 'pkg desc', license: 'MIT' }),
+    );
+    const manifest = generateMcpbManifest({
+      name: 'demo',
+      version: '1.0.0',
+      cwd: tmp,
+      schema: emptySchema(),
+      userConfig: {},
+      userConfigEnv: {},
+      deployment: {
+        target: 'mcpb',
+        longDescription: 'Override markdown',
+        license: 'Apache-2.0',
+        author: { name: 'Override' },
+      },
+    });
+
+    expect(manifest.long_description).toBe('Override markdown');
+    expect(manifest.license).toBe('Apache-2.0');
+    expect(manifest.author).toEqual({ name: 'Override' });
+  });
+});

--- a/libs/cli/src/commands/build/mcpb/__tests__/user-config.spec.ts
+++ b/libs/cli/src/commands/build/mcpb/__tests__/user-config.spec.ts
@@ -1,0 +1,137 @@
+import { idToCamelKey, setupStepsToUserConfig } from '../user-config';
+
+describe('idToCamelKey', () => {
+  it('handles kebab case', () => {
+    expect(idToCamelKey('api-token')).toBe('apiToken');
+  });
+  it('handles snake case', () => {
+    expect(idToCamelKey('max_items')).toBe('maxItems');
+  });
+  it('handles SCREAMING_SNAKE', () => {
+    expect(idToCamelKey('REDIS_URL')).toBe('redisUrl');
+  });
+  it('falls back to "value" when input is empty', () => {
+    expect(idToCamelKey('')).toBe('value');
+  });
+});
+
+describe('setupStepsToUserConfig', () => {
+  it('returns empty when no steps and no deployment override', () => {
+    const result = setupStepsToUserConfig(undefined);
+    expect(result.userConfig).toEqual({});
+    expect(result.env).toEqual({});
+    expect(result.warnings).toEqual([]);
+  });
+
+  it('translates string step to user_config string entry', () => {
+    const result = setupStepsToUserConfig([
+      {
+        id: 'api-token',
+        prompt: 'API Token',
+        description: 'Token for API access',
+        jsonSchema: { type: 'string' },
+        sensitive: true,
+      },
+    ]);
+    expect(result.userConfig.apiToken).toEqual({
+      type: 'string',
+      title: 'API Token',
+      description: 'Token for API access',
+      sensitive: true,
+      required: true,
+    });
+    expect(result.env).toEqual({ API_TOKEN: '${user_config.apiToken}' });
+  });
+
+  it('maps number schemas with bounds', () => {
+    const result = setupStepsToUserConfig([
+      {
+        id: 'max-items',
+        prompt: 'Max Items',
+        jsonSchema: { type: 'number', minimum: 1, maximum: 100, default: 10 },
+      },
+    ]);
+    expect(result.userConfig.maxItems).toMatchObject({
+      type: 'number',
+      min: 1,
+      max: 100,
+      default: 10,
+    });
+  });
+
+  it('maps boolean schemas', () => {
+    const result = setupStepsToUserConfig([
+      { id: 'enabled', prompt: 'Enabled?', jsonSchema: { type: 'boolean', default: true } },
+    ]);
+    expect(result.userConfig.enabled.type).toBe('boolean');
+    expect(result.userConfig.enabled.default).toBe(true);
+  });
+
+  it('sets multiple:true for array schemas', () => {
+    const result = setupStepsToUserConfig([
+      {
+        id: 'paths',
+        prompt: 'Paths',
+        jsonSchema: { type: 'array', items: { type: 'string' } },
+      },
+    ]);
+    expect(result.userConfig.paths.type).toBe('string');
+    expect(result.userConfig.paths.multiple).toBe(true);
+  });
+
+  it('emits warning for showWhen/next branching', () => {
+    const result = setupStepsToUserConfig([
+      { id: 'a', prompt: 'A', jsonSchema: { type: 'string' }, next: 'b' },
+      { id: 'b', prompt: 'B', jsonSchema: { type: 'string' }, showWhen: { a: 'yes' } },
+    ]);
+    expect(result.warnings.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it('drops default when sensitive', () => {
+    const result = setupStepsToUserConfig([
+      {
+        id: 'secret',
+        prompt: 'Secret',
+        jsonSchema: { type: 'string', default: 'do-not-commit' },
+        sensitive: true,
+      },
+    ]);
+    expect(result.userConfig.secret.default).toBeUndefined();
+  });
+
+  it('honors deployment.userConfig.type overrides (e.g., directory)', () => {
+    const result = setupStepsToUserConfig(
+      [{ id: 'workspace', prompt: 'Workspace', jsonSchema: { type: 'string' } }],
+      {
+        target: 'mcpb',
+        userConfig: {
+          workspace: { type: 'directory', title: 'Workspace dir' },
+        },
+      },
+    );
+    expect(result.userConfig.workspace.type).toBe('directory');
+  });
+
+  it('merges deployment-only user_config entries not backed by a step', () => {
+    const result = setupStepsToUserConfig(undefined, {
+      target: 'mcpb',
+      userConfig: {
+        extra: { type: 'boolean', title: 'Extra' },
+      },
+    });
+    expect(result.userConfig.extra.title).toBe('Extra');
+  });
+
+  it('uses step.env for env key when provided', () => {
+    const result = setupStepsToUserConfig([
+      {
+        id: 'api-token',
+        env: 'MY_TOKEN',
+        prompt: 'Token',
+        jsonSchema: { type: 'string' },
+      },
+    ]);
+    expect(Object.keys(result.env)).toEqual(['MY_TOKEN']);
+    expect(result.env.MY_TOKEN).toBe('${user_config.apiToken}');
+  });
+});

--- a/libs/cli/src/commands/build/mcpb/__tests__/validate.spec.ts
+++ b/libs/cli/src/commands/build/mcpb/__tests__/validate.spec.ts
@@ -1,0 +1,169 @@
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { createDeterministicZip } from '../zip';
+import { validateMcpb } from '../validate';
+
+async function makeArchive(
+  fileMap: Record<string, string>,
+  archivePath: string,
+): Promise<void> {
+  const stage = fs.mkdtempSync(path.join(os.tmpdir(), 'mcpb-stage-'));
+  try {
+    for (const [rel, content] of Object.entries(fileMap)) {
+      const abs = path.join(stage, rel);
+      fs.mkdirSync(path.dirname(abs), { recursive: true });
+      fs.writeFileSync(abs, content);
+    }
+    await createDeterministicZip(stage, archivePath);
+  } finally {
+    fs.rmSync(stage, { recursive: true, force: true });
+  }
+}
+
+const baseManifest = () => ({
+  manifest_version: '0.3',
+  name: 'demo',
+  version: '1.0.0',
+  description: 'Demo',
+  author: { name: 'Tester' },
+  server: {
+    type: 'node',
+    entry_point: 'server/index.js',
+    mcp_config: { command: 'node', args: ['${__dirname}/server/index.js'] },
+  },
+});
+
+describe('validateMcpb', () => {
+  let tmp: string;
+  beforeEach(() => {
+    tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'mcpb-validate-'));
+  });
+  afterEach(() => {
+    fs.rmSync(tmp, { recursive: true, force: true });
+  });
+
+  it('rejects a non-existent archive', async () => {
+    const result = await validateMcpb(path.join(tmp, 'missing.mcpb'));
+    expect(result.ok).toBe(false);
+    expect(result.errors[0]).toMatch(/Cannot open archive/);
+  });
+
+  it('accepts a valid archive', async () => {
+    const archive = path.join(tmp, 'ok.mcpb');
+    await makeArchive(
+      {
+        'manifest.json': JSON.stringify(baseManifest()),
+        'server/index.js': 'console.log("hi")',
+      },
+      archive,
+    );
+    const result = await validateMcpb(archive);
+    expect(result.ok).toBe(true);
+    expect(result.errors).toEqual([]);
+  });
+
+  it('fails when manifest.json is missing', async () => {
+    const archive = path.join(tmp, 'no-manifest.mcpb');
+    await makeArchive({ 'server/index.js': 'hi' }, archive);
+    const result = await validateMcpb(archive);
+    expect(result.ok).toBe(false);
+    expect(result.errors.some((e) => e.includes('manifest.json is missing'))).toBe(true);
+  });
+
+  it('fails when entry_point is not in the archive', async () => {
+    const archive = path.join(tmp, 'missing-entry.mcpb');
+    await makeArchive({ 'manifest.json': JSON.stringify(baseManifest()) }, archive);
+    const result = await validateMcpb(archive);
+    expect(result.ok).toBe(false);
+    expect(result.errors.some((e) => e.includes('entry_point'))).toBe(true);
+  });
+
+  it('fails on unknown substitution variable', async () => {
+    const manifest = baseManifest();
+    manifest.server.mcp_config.args = ['${MYSTERY_VAR}'];
+    const archive = path.join(tmp, 'bad-var.mcpb');
+    await makeArchive(
+      {
+        'manifest.json': JSON.stringify(manifest),
+        'server/index.js': 'hi',
+      },
+      archive,
+    );
+    const result = await validateMcpb(archive);
+    expect(result.ok).toBe(false);
+    expect(result.errors.some((e) => e.includes('MYSTERY_VAR'))).toBe(true);
+  });
+
+  it('fails on dangling user_config reference', async () => {
+    const manifest = baseManifest() as unknown as Record<string, unknown>;
+    (manifest.server as { mcp_config: { env: Record<string, string> } }).mcp_config.env = {
+      API: '${user_config.missing}',
+    };
+    const archive = path.join(tmp, 'bad-ref.mcpb');
+    await makeArchive(
+      {
+        'manifest.json': JSON.stringify(manifest),
+        'server/index.js': 'hi',
+      },
+      archive,
+    );
+    const result = await validateMcpb(archive);
+    expect(result.ok).toBe(false);
+    expect(result.errors.some((e) => e.includes('user_config.missing'))).toBe(true);
+  });
+
+  it('resolves user_config reference when declared', async () => {
+    const manifest = baseManifest() as unknown as Record<string, unknown>;
+    (manifest.server as { mcp_config: { env: Record<string, string> } }).mcp_config.env = {
+      API: '${user_config.apiKey}',
+    };
+    manifest.user_config = {
+      apiKey: { type: 'string', title: 'API Key' },
+    };
+    const archive = path.join(tmp, 'with-cfg.mcpb');
+    await makeArchive(
+      {
+        'manifest.json': JSON.stringify(manifest),
+        'server/index.js': 'hi',
+      },
+      archive,
+    );
+    const result = await validateMcpb(archive);
+    expect(result.ok).toBe(true);
+  });
+
+  it('fails on invalid manifest_version absence', async () => {
+    const manifest = baseManifest() as unknown as Record<string, unknown>;
+    delete manifest.manifest_version;
+    const archive = path.join(tmp, 'no-version.mcpb');
+    await makeArchive(
+      {
+        'manifest.json': JSON.stringify(manifest),
+        'server/index.js': 'hi',
+      },
+      archive,
+    );
+    const result = await validateMcpb(archive);
+    expect(result.ok).toBe(false);
+    expect(result.errors.some((e) => e.includes('manifest_version'))).toBe(true);
+  });
+
+  it('validates platform_overrides binary references exist', async () => {
+    const manifest = baseManifest() as unknown as Record<string, unknown>;
+    (manifest.server as { mcp_config: Record<string, unknown> }).mcp_config.platform_overrides = {
+      'darwin-arm64': { command: '${__dirname}/bin/darwin-arm64/demo', args: [] },
+    };
+    const archive = path.join(tmp, 'bad-binary.mcpb');
+    await makeArchive(
+      {
+        'manifest.json': JSON.stringify(manifest),
+        'server/index.js': 'hi',
+      },
+      archive,
+    );
+    const result = await validateMcpb(archive);
+    expect(result.ok).toBe(false);
+    expect(result.errors.some((e) => e.includes('darwin-arm64'))).toBe(true);
+  });
+});

--- a/libs/cli/src/commands/build/mcpb/__tests__/zip.spec.ts
+++ b/libs/cli/src/commands/build/mcpb/__tests__/zip.spec.ts
@@ -1,0 +1,93 @@
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { createDeterministicZip, listFilesForArchive } from '../zip';
+import { validateMcpb } from '../validate';
+import { mcpbManifestSchema } from '../manifest';
+
+describe('listFilesForArchive', () => {
+  let tmp: string;
+  beforeEach(() => {
+    tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'mcpb-list-'));
+  });
+  afterEach(() => {
+    fs.rmSync(tmp, { recursive: true, force: true });
+  });
+
+  it('lists files recursively and sorts lexicographically', () => {
+    fs.mkdirSync(path.join(tmp, 'server'));
+    fs.writeFileSync(path.join(tmp, 'server', 'index.js'), 'a');
+    fs.writeFileSync(path.join(tmp, 'manifest.json'), 'b');
+    fs.mkdirSync(path.join(tmp, 'bin', 'darwin-arm64'), { recursive: true });
+    fs.writeFileSync(path.join(tmp, 'bin', 'darwin-arm64', 'demo'), 'c');
+
+    const files = listFilesForArchive(tmp).map((f) => f.archivePath);
+    expect(files).toEqual(['bin/darwin-arm64/demo', 'manifest.json', 'server/index.js']);
+  });
+});
+
+describe('createDeterministicZip', () => {
+  let tmp: string;
+  beforeEach(() => {
+    tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'mcpb-zip-'));
+  });
+  afterEach(() => {
+    fs.rmSync(tmp, { recursive: true, force: true });
+  });
+
+  function seedStage(name: string): { stageDir: string; archivePath: string } {
+    const stageDir = path.join(tmp, name, '__stage');
+    fs.mkdirSync(path.join(stageDir, 'server'), { recursive: true });
+    fs.writeFileSync(path.join(stageDir, 'server', 'index.js'), 'console.log("hi")');
+    const manifest = {
+      manifest_version: '0.3',
+      name: 'demo',
+      version: '1.0.0',
+      description: 'Demo',
+      author: { name: 'Tester' },
+      server: {
+        type: 'node',
+        entry_point: 'server/index.js',
+        mcp_config: { command: 'node', args: ['${__dirname}/server/index.js'] },
+      },
+    };
+    // sanity-check our fixture matches the schema
+    expect(mcpbManifestSchema.safeParse(manifest).success).toBe(true);
+    fs.writeFileSync(path.join(stageDir, 'manifest.json'), JSON.stringify(manifest, null, 2));
+    return { stageDir, archivePath: path.join(tmp, `${name}.mcpb`) };
+  }
+
+  it('produces a zip that validates end-to-end', async () => {
+    const { stageDir, archivePath } = seedStage('valid');
+    const result = await createDeterministicZip(stageDir, archivePath);
+    expect(result.size).toBeGreaterThan(0);
+    expect(result.entries.sort()).toEqual(['manifest.json', 'server/index.js']);
+
+    const validation = await validateMcpb(archivePath);
+    expect(validation.errors).toEqual([]);
+    expect(validation.ok).toBe(true);
+  });
+
+  it('two back-to-back builds produce identical SHA-256 (deterministic mode)', async () => {
+    const first = seedStage('det-a');
+    const second = seedStage('det-b');
+    const a = await createDeterministicZip(first.stageDir, first.archivePath);
+    const b = await createDeterministicZip(second.stageDir, second.archivePath);
+    expect(a.sha256).toBe(b.sha256);
+  });
+
+  it('includes files in lexicographic order in the entry list', async () => {
+    const { stageDir, archivePath } = seedStage('order');
+    fs.mkdirSync(path.join(stageDir, 'bin', 'darwin-arm64'), { recursive: true });
+    fs.writeFileSync(path.join(stageDir, 'bin', 'darwin-arm64', 'demo'), 'binary');
+    fs.writeFileSync(path.join(stageDir, 'icon.png'), 'png');
+
+    const result = await createDeterministicZip(stageDir, archivePath);
+    expect(result.entries).toEqual([
+      'bin/darwin-arm64/demo',
+      'icon.png',
+      'manifest.json',
+      'server/index.js',
+    ]);
+  });
+});

--- a/libs/cli/src/commands/build/mcpb/binary.ts
+++ b/libs/cli/src/commands/build/mcpb/binary.ts
@@ -1,0 +1,84 @@
+/**
+ * SEA binary integration for the MCPB target.
+ *
+ * - `resolveHostPlatform()` maps the current process to an MCPB platform key.
+ * - `mergeBinariesFrom()` scans a directory of pre-built CI binaries organized
+ *   as `{platform}/{name}[.exe]` and reports what's available.
+ * - `buildPlatformOverrides()` produces the `mcp_config.platform_overrides`
+ *   block that routes the MCPB consumer to the binary matching its OS/arch.
+ *
+ * Note: Node SEA can only build for the host OS/arch in a single pass. True
+ * multi-platform archives need a CI matrix; the `mergeFrom` mechanism is how
+ * those per-platform outputs get assembled into one `.mcpb`.
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+import type { McpbMcpConfig } from './manifest';
+import type { McpbPlatformKey } from './constants';
+
+export const MCPB_PLATFORM_KEYS: McpbPlatformKey[] = [
+  'darwin-arm64',
+  'darwin-x64',
+  'linux-arm64',
+  'linux-x64',
+  'win32-x64',
+];
+
+/** Map the current Node.js process to its MCPB platform key. */
+export function resolveHostPlatform(
+  platform: NodeJS.Platform = process.platform,
+  arch: string = process.arch,
+): McpbPlatformKey | undefined {
+  const key = `${platform}-${arch}` as McpbPlatformKey;
+  return MCPB_PLATFORM_KEYS.includes(key) ? key : undefined;
+}
+
+/** Windows needs `.exe` appended to the binary name. */
+export function binaryFileName(appName: string, platform: McpbPlatformKey): string {
+  return platform.startsWith('win32') ? `${appName}.exe` : appName;
+}
+
+export interface BinaryEntry {
+  platform: McpbPlatformKey;
+  /** Absolute path of the source binary on disk. */
+  srcPath: string;
+  /** Destination filename (e.g., myapp or myapp.exe). */
+  fileName: string;
+}
+
+/**
+ * Scan `{mergeFromDir}/{platform}/{name}` paths and return the binaries found.
+ * Silently skips entries with unknown platform folders.
+ */
+export function mergeBinariesFrom(mergeFromDir: string, appName: string): BinaryEntry[] {
+  if (!fs.existsSync(mergeFromDir) || !fs.statSync(mergeFromDir).isDirectory()) {
+    return [];
+  }
+  const results: BinaryEntry[] = [];
+  for (const platform of MCPB_PLATFORM_KEYS) {
+    const file = binaryFileName(appName, platform);
+    const candidate = path.join(mergeFromDir, platform, file);
+    if (fs.existsSync(candidate) && fs.statSync(candidate).isFile()) {
+      results.push({ platform, srcPath: candidate, fileName: file });
+    }
+  }
+  return results;
+}
+
+/**
+ * Build the mcp_config.platform_overrides block for the given set of platform
+ * binaries. Each override points at `${__dirname}/bin/{platform}/{file}`.
+ */
+export function buildPlatformOverrides(
+  entries: BinaryEntry[],
+): Record<string, McpbMcpConfig> {
+  const overrides: Record<string, McpbMcpConfig> = {};
+  for (const { platform, fileName } of entries) {
+    overrides[platform] = {
+      command: `\${__dirname}/bin/${platform}/${fileName}`,
+      args: [],
+    };
+  }
+  return overrides;
+}

--- a/libs/cli/src/commands/build/mcpb/constants.ts
+++ b/libs/cli/src/commands/build/mcpb/constants.ts
@@ -1,0 +1,42 @@
+/**
+ * MCPB (MCP Bundles) constants — spec v0.3
+ * https://github.com/modelcontextprotocol/mcpb/blob/main/MANIFEST.md
+ */
+
+/** Spec version emitted in every generated manifest. */
+export const MCPB_MANIFEST_VERSION = '0.3';
+
+/** Default Node.js version constraint for the bundled runtime. */
+export const DEFAULT_NODE_COMPAT = '>=22.0.0';
+
+/** Default compatibility platforms when none are declared. */
+export const DEFAULT_PLATFORMS = ['darwin', 'linux', 'win32'] as const;
+
+/** Whitelist of variable substitutions allowed inside mcp_config fields. */
+export const ALLOWED_SUBSTITUTION_VARS = new Set([
+  '__dirname',
+  'HOME',
+  'DESKTOP',
+  'DOCUMENTS',
+  'DOWNLOADS',
+  'pathSeparator',
+  '/', // alias for pathSeparator
+]);
+
+/** Prefix that indicates a user_config reference (${user_config.KEY}). */
+export const USER_CONFIG_PREFIX = 'user_config.';
+
+/** Deterministic mtime applied to every archive entry for reproducible builds. */
+export const DETERMINISTIC_MTIME = new Date('2000-01-01T00:00:00Z');
+
+/** Platform keys recognized by MCPB platform_overrides. */
+export type McpbPlatformKey =
+  | 'darwin-arm64'
+  | 'darwin-x64'
+  | 'linux-arm64'
+  | 'linux-x64'
+  | 'win32-x64';
+
+/** Archive size warning thresholds (bytes). */
+export const ARCHIVE_SIZE_WARN = 50 * 1024 * 1024; // 50 MB
+export const ARCHIVE_SIZE_ERROR = 100 * 1024 * 1024; // 100 MB

--- a/libs/cli/src/commands/build/mcpb/index.ts
+++ b/libs/cli/src/commands/build/mcpb/index.ts
@@ -1,0 +1,269 @@
+/**
+ * buildMcpb() — produce a `.mcpb` archive (MCP Bundle, spec v0.3).
+ *
+ * Pipeline:
+ *   1. Load exec config, resolve entry, compile TypeScript (reuses exec).
+ *   2. Bundle via esbuild (reuses exec's bundler).
+ *   3. Extract tool/prompt/skill schema from the compiled bundle.
+ *   4. Optionally build an SEA binary for the host platform.
+ *   5. Stage the MCPB layout on disk (manifest + server/ + bin/ + icon + README).
+ *   6. Deterministic zip → {outDir}/{name}-{version}.mcpb
+ *   7. Clean up intermediates unless --stage-only.
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+import { ensureDir, fileExists, runCmd } from '@frontmcp/utils';
+import type { ParsedArgs } from '../../../core/args';
+import { c } from '../../../core/colors';
+import { resolveEntry } from '../../../shared/fs';
+import { REQUIRED_DECORATOR_FIELDS } from '../../../core/tsconfig';
+import { findDeployment, type FrontMcpConfigParsed } from '../../../config';
+import type { McpbDeployment } from '../../../config/frontmcp-config.types';
+import { loadExecConfig, normalizeConfig } from '../exec/config';
+import { bundleWithEsbuild, formatSize } from '../exec/esbuild-bundler';
+import { buildPlatformOverrides, mergeBinariesFrom, resolveHostPlatform, binaryFileName, type BinaryEntry } from './binary';
+import { generateMcpbManifest, resolveIconPath } from './manifest';
+import { setupStepsToUserConfig } from './user-config';
+import { stageMcpbDirectory, writeManifest } from './stage';
+import { createDeterministicZip } from './zip';
+import { ARCHIVE_SIZE_ERROR, ARCHIVE_SIZE_WARN } from './constants';
+import { getSelfVersion } from '../../../core/version';
+
+export interface BuildMcpbOptions extends ParsedArgs {
+  /** Resolved MCPB deployment config (from frontmcp.config if present). */
+  mcpbDeployment?: McpbDeployment;
+}
+
+export async function buildMcpb(
+  opts: BuildMcpbOptions,
+  configParsed?: FrontMcpConfigParsed,
+): Promise<void> {
+  const cwd = process.cwd();
+  const outDir = path.resolve(cwd, opts.outDir || 'dist');
+
+  console.log(`${c('cyan', '[build:mcpb]')} Building MCP Bundle...`);
+
+  // 1. Resolve exec + mcpb config
+  const rawConfig = await loadExecConfig(cwd);
+  const execConfig = normalizeConfig(rawConfig);
+
+  // When a v1 frontmcp.config is present, its build.esbuild / build.dependencies
+  // win — the legacy loader returns the raw file without merging these.
+  if (configParsed?.build?.esbuild) {
+    execConfig.esbuild = {
+      ...(execConfig.esbuild ?? {}),
+      ...configParsed.build.esbuild,
+    };
+  }
+  if (configParsed?.build?.dependencies?.nativeAddons) {
+    execConfig.dependencies = {
+      ...(execConfig.dependencies ?? {}),
+      nativeAddons: [
+        ...(execConfig.dependencies?.nativeAddons ?? []),
+        ...configParsed.build.dependencies.nativeAddons,
+      ],
+    };
+  }
+  if (configParsed?.nodeVersion) {
+    execConfig.nodeVersion = configParsed.nodeVersion;
+  }
+
+  const mcpbDeployment =
+    opts.mcpbDeployment
+    ?? (configParsed ? (findDeployment(configParsed, 'mcpb') as McpbDeployment | undefined) : undefined);
+
+  console.log(`${c('cyan', '[build:mcpb]')} name: ${execConfig.name}`);
+  console.log(`${c('cyan', '[build:mcpb]')} version: ${execConfig.version}`);
+
+  // 2. Resolve entry
+  const entry = await resolveEntry(cwd, execConfig.entry || opts.entry);
+  console.log(`${c('cyan', '[build:mcpb]')} entry: ${path.relative(cwd, entry)}`);
+
+  // 3. TypeScript compile (same as exec pipeline)
+  await ensureDir(outDir);
+  const tsconfigPath = path.join(cwd, 'tsconfig.json');
+  const hasTsconfig = await fileExists(tsconfigPath);
+  const tscArgs: string[] = ['-y', 'tsc'];
+  if (hasTsconfig) {
+    tscArgs.push('--project', tsconfigPath);
+  } else {
+    tscArgs.push(entry);
+    tscArgs.push('--rootDir', path.dirname(entry));
+    tscArgs.push('--experimentalDecorators', '--emitDecoratorMetadata');
+    tscArgs.push('--target', REQUIRED_DECORATOR_FIELDS.target);
+  }
+  tscArgs.push('--module', 'commonjs', '--outDir', outDir, '--skipLibCheck');
+  await runCmd('npx', tscArgs);
+  console.log(`${c('green', '[build:mcpb]')} TypeScript compiled`);
+
+  // 4. esbuild bundle → dist/{name}.bundle.js
+  const compiledEntry = path.join(outDir, path.basename(entry).replace(/\.tsx?$/, '.js'));
+  const bundleResult = await bundleWithEsbuild(compiledEntry, outDir, execConfig);
+  console.log(
+    `${c('green', '[build:mcpb]')} bundle: ${path.relative(cwd, bundleResult.bundlePath)} (${formatSize(bundleResult.bundleSize)})`,
+  );
+
+  // 5. Schema extraction
+  const { extractSchemas, SYSTEM_TOOL_NAMES } = await import('../exec/cli-runtime/schema-extractor.js');
+  const schema = await extractSchemas(bundleResult.bundlePath);
+  const userToolCount = schema.tools.filter((t) => !SYSTEM_TOOL_NAMES.has(t.name)).length;
+  console.log(
+    `${c('cyan', '[build:mcpb]')} extracted: ${userToolCount} tools, ${schema.resources.length} resources, ${schema.prompts.length} prompts`,
+  );
+
+  // 6. SEA binaries (optional)
+  const seaRequested = !!(opts.sea || mcpbDeployment?.sea?.enabled);
+  const mergeFrom = opts.mergeFrom ?? mcpbDeployment?.sea?.mergeFrom;
+  const binaries: BinaryEntry[] = [];
+
+  if (seaRequested) {
+    const hostPlatform = resolveHostPlatform();
+    if (!hostPlatform) {
+      console.log(
+        `${c('yellow', '[build:mcpb]')} Unknown host platform ${process.platform}-${process.arch}; skipping SEA build`,
+      );
+    } else {
+      console.log(`${c('cyan', '[build:mcpb]')} building SEA binary for ${hostPlatform}...`);
+      const seaBundleName = `${execConfig.name}.sea-temp`;
+      const seaBundle = await bundleWithEsbuild(compiledEntry, outDir, execConfig, {
+        selfContained: true,
+        outputName: seaBundleName,
+      });
+      const { buildSea } = await import('../exec/sea-builder.js');
+      const seaResult = await buildSea(seaBundle.bundlePath, outDir, execConfig.name);
+      fs.unlinkSync(seaBundle.bundlePath);
+      binaries.push({
+        platform: hostPlatform,
+        srcPath: seaResult.executablePath,
+        fileName: binaryFileName(execConfig.name, hostPlatform),
+      });
+      console.log(
+        `${c('green', '[build:mcpb]')} SEA binary: ${path.relative(cwd, seaResult.executablePath)} (${formatSize(seaResult.executableSize)})`,
+      );
+    }
+  }
+
+  if (mergeFrom) {
+    const absMergeDir = path.isAbsolute(mergeFrom) ? mergeFrom : path.resolve(cwd, mergeFrom);
+    const merged = mergeBinariesFrom(absMergeDir, execConfig.name);
+    if (merged.length === 0) {
+      console.log(`${c('yellow', '[build:mcpb]')} mergeFrom "${absMergeDir}" produced no binaries`);
+    } else {
+      console.log(
+        `${c('cyan', '[build:mcpb]')} merging ${merged.length} cross-platform binaries from ${path.relative(cwd, absMergeDir)}`,
+      );
+      // Replace any duplicate platform entries from the local SEA build with merge-from versions.
+      for (const bin of merged) {
+        const idx = binaries.findIndex((b) => b.platform === bin.platform);
+        if (idx >= 0) binaries.splice(idx, 1);
+        binaries.push(bin);
+      }
+    }
+  }
+
+  // 7. Translate setup steps → user_config + env
+  const { userConfig, env: userConfigEnv, warnings } = setupStepsToUserConfig(
+    execConfig.setup?.steps,
+    mcpbDeployment,
+  );
+  for (const w of warnings) {
+    console.log(`${c('yellow', '[build:mcpb]')} ${w}`);
+  }
+
+  // 8. Stage — outDir is already {dist}/mcpb (set by buildSingleTarget per-target layout)
+  const stageDir = path.join(outDir, '__stage');
+  if (fs.existsSync(stageDir)) {
+    fs.rmSync(stageDir, { recursive: true, force: true });
+  }
+  const iconOverride = opts.icon ?? mcpbDeployment?.icon;
+  const iconAbs = resolveIconPath(cwd, iconOverride);
+  const iconAbsPath = iconAbs ? path.resolve(cwd, iconAbs) : undefined;
+
+  const stageResult = stageMcpbDirectory({
+    stageDir,
+    cwd,
+    serverBundlePath: bundleResult.bundlePath,
+    name: execConfig.name,
+    version: execConfig.version,
+    schema,
+    iconPath: iconAbsPath,
+    binaries,
+  });
+  if (stageResult.skillAssetCount > 0) {
+    console.log(`${c('green', '[build:mcpb]')} copied ${stageResult.skillAssetCount} skill asset(s) to server/_skills/`);
+  }
+  if (stageResult.hasIcon) {
+    console.log(`${c('green', '[build:mcpb]')} icon: ${iconAbs}`);
+  }
+
+  // 9. Manifest
+  const platformOverrides = buildPlatformOverrides(binaries);
+  const manifest = generateMcpbManifest({
+    name: execConfig.name,
+    version: execConfig.version,
+    nodeVersion: execConfig.nodeVersion,
+    cwd,
+    deployment: mcpbDeployment,
+    schema,
+    userConfig,
+    userConfigEnv,
+    platformOverrides,
+    hasIcon: stageResult.hasIcon,
+    cliVersion: getSelfVersion(),
+  });
+  writeManifest(stageDir, manifest);
+  console.log(`${c('green', '[build:mcpb]')} wrote manifest.json`);
+
+  // 10. Zip (unless --stage-only)
+  if (opts.stageOnly) {
+    console.log(`${c('yellow', '[build:mcpb]')} --stage-only set; leaving ${path.relative(cwd, stageDir)} for inspection`);
+    cleanupIntermediates(outDir, ['__stage']);
+    return;
+  }
+
+  const archivePath = path.join(outDir, `${execConfig.name}-${execConfig.version}.mcpb`);
+  const zipResult = await createDeterministicZip(stageDir, archivePath, {
+    deterministic: !opts.noDeterministic && (mcpbDeployment?.deterministic ?? true),
+  });
+  console.log(
+    `${c('green', '[build:mcpb]')} ${path.relative(cwd, zipResult.archivePath)} (${formatSize(zipResult.size)})`,
+  );
+  console.log(`${c('gray', '[build:mcpb]')} sha256: ${zipResult.sha256}`);
+
+  if (zipResult.size > ARCHIVE_SIZE_ERROR) {
+    console.log(
+      `${c('yellow', '[build:mcpb]')} Archive is ${(zipResult.size / 1024 / 1024).toFixed(1)} MB — consider tuning externals`,
+    );
+  } else if (zipResult.size > ARCHIVE_SIZE_WARN) {
+    console.log(`${c('yellow', '[build:mcpb]')} Archive is ${(zipResult.size / 1024 / 1024).toFixed(1)} MB`);
+  }
+
+  // 11. Cleanup
+  fs.rmSync(stageDir, { recursive: true, force: true });
+  cleanupIntermediates(outDir, [`${execConfig.name}-${execConfig.version}.mcpb`]);
+
+  console.log(`\n${c('green', 'MCPB build completed.')}`);
+  console.log(`${c('gray', 'Install:')} open ${path.relative(cwd, zipResult.archivePath)}`);
+}
+
+/**
+ * Remove files/dirs in outDir that aren't in the keep-list.
+ *
+ * The tsc + esbuild stages write intermediates directly into outDir (same
+ * pattern as the exec target uses). We keep the archive and — in stage-only
+ * mode — the `__stage/` directory so the user can inspect it.
+ */
+function cleanupIntermediates(outDir: string, keep: string[]): void {
+  if (!fs.existsSync(outDir)) return;
+  const keepSet = new Set(keep);
+  for (const entry of fs.readdirSync(outDir)) {
+    if (keepSet.has(entry)) continue;
+    const full = path.join(outDir, entry);
+    try {
+      fs.rmSync(full, { recursive: true, force: true });
+    } catch {
+      // best-effort — a race with an external process shouldn't fail the build
+    }
+  }
+}

--- a/libs/cli/src/commands/build/mcpb/index.ts
+++ b/libs/cli/src/commands/build/mcpb/index.ts
@@ -23,7 +23,7 @@ import type { McpbDeployment } from '../../../config/frontmcp-config.types';
 import { loadExecConfig, normalizeConfig } from '../exec/config';
 import { bundleWithEsbuild, formatSize } from '../exec/esbuild-bundler';
 import { buildPlatformOverrides, mergeBinariesFrom, resolveHostPlatform, binaryFileName, type BinaryEntry } from './binary';
-import { generateMcpbManifest, resolveIconPath } from './manifest';
+import { generateMcpbManifest, loadPackageJsonMeta, resolveIconPath } from './manifest';
 import { setupStepsToUserConfig } from './user-config';
 import { stageMcpbDirectory, writeManifest } from './stage';
 import { createDeterministicZip } from './zip';
@@ -43,6 +43,12 @@ export async function buildMcpb(
   const outDir = path.resolve(cwd, opts.outDir || 'dist');
 
   console.log(`${c('cyan', '[build:mcpb]')} Building MCP Bundle...`);
+
+  // Snapshot outDir before any build work so cleanup only removes artifacts
+  // this build produced — files the user had sitting there are preserved.
+  const preExistingEntries = fs.existsSync(outDir)
+    ? new Set<string>(fs.readdirSync(outDir))
+    : new Set<string>();
 
   // 1. Resolve exec + mcpb config
   const rawConfig = await loadExecConfig(cwd);
@@ -177,7 +183,8 @@ export async function buildMcpb(
     fs.rmSync(stageDir, { recursive: true, force: true });
   }
   const iconOverride = opts.icon ?? mcpbDeployment?.icon;
-  const iconAbs = resolveIconPath(cwd, iconOverride);
+  const pkgMeta = loadPackageJsonMeta(cwd);
+  const iconAbs = resolveIconPath(cwd, iconOverride, pkgMeta.icon);
   const iconAbsPath = iconAbs ? path.resolve(cwd, iconAbs) : undefined;
 
   const stageResult = stageMcpbDirectory({
@@ -218,7 +225,7 @@ export async function buildMcpb(
   // 10. Zip (unless --stage-only)
   if (opts.stageOnly) {
     console.log(`${c('yellow', '[build:mcpb]')} --stage-only set; leaving ${path.relative(cwd, stageDir)} for inspection`);
-    cleanupIntermediates(outDir, ['__stage']);
+    cleanupIntermediates(outDir, preExistingEntries, ['__stage']);
     return;
   }
 
@@ -241,24 +248,28 @@ export async function buildMcpb(
 
   // 11. Cleanup
   fs.rmSync(stageDir, { recursive: true, force: true });
-  cleanupIntermediates(outDir, [`${execConfig.name}-${execConfig.version}.mcpb`]);
+  cleanupIntermediates(outDir, preExistingEntries, [`${execConfig.name}-${execConfig.version}.mcpb`]);
 
   console.log(`\n${c('green', 'MCPB build completed.')}`);
   console.log(`${c('gray', 'Install:')} open ${path.relative(cwd, zipResult.archivePath)}`);
 }
 
 /**
- * Remove files/dirs in outDir that aren't in the keep-list.
+ * Remove intermediates this build produced, leaving pre-existing files and the
+ * keep-list alone. The tsc + esbuild stages write intermediates directly into
+ * outDir (same pattern as the exec target uses); we keep the archive and — in
+ * stage-only mode — the `__stage/` directory so the user can inspect it.
  *
- * The tsc + esbuild stages write intermediates directly into outDir (same
- * pattern as the exec target uses). We keep the archive and — in stage-only
- * mode — the `__stage/` directory so the user can inspect it.
+ * `preExisting` is the set of entries that were in `outDir` before the build
+ * started. Anything in that set is preserved unconditionally so a shared
+ * outDir (e.g., `--out-dir dist` alongside other targets) is not clobbered.
  */
-function cleanupIntermediates(outDir: string, keep: string[]): void {
+function cleanupIntermediates(outDir: string, preExisting: Set<string>, keep: string[]): void {
   if (!fs.existsSync(outDir)) return;
   const keepSet = new Set(keep);
   for (const entry of fs.readdirSync(outDir)) {
     if (keepSet.has(entry)) continue;
+    if (preExisting.has(entry)) continue;
     const full = path.join(outDir, entry);
     try {
       fs.rmSync(full, { recursive: true, force: true });

--- a/libs/cli/src/commands/build/mcpb/manifest.ts
+++ b/libs/cli/src/commands/build/mcpb/manifest.ts
@@ -190,7 +190,7 @@ export function loadPackageJsonMeta(cwd: string): PackageJsonMeta {
  */
 export function parseAuthor(author: unknown): McpbAuthor {
   if (!author) return { name: 'unknown' };
-  if (typeof author === 'object' && author !== null && 'name' in author) {
+  if (typeof author === 'object' && 'name' in author) {
     const a = author as McpbAuthor;
     return {
       name: a.name,

--- a/libs/cli/src/commands/build/mcpb/manifest.ts
+++ b/libs/cli/src/commands/build/mcpb/manifest.ts
@@ -1,0 +1,374 @@
+/**
+ * MCPB manifest generator + Zod schema for the emitted manifest.
+ *
+ * Source priority when resolving fields:
+ *   deployment.* (frontmcp.config)  >  package.json  >  hard defaults
+ *
+ * See https://github.com/modelcontextprotocol/mcpb/blob/main/MANIFEST.md
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+import { z } from '@frontmcp/lazy-zod';
+import { type ExtractedSchema, SYSTEM_TOOL_NAMES } from '../exec/cli-runtime/schema-extractor';
+import type {
+  McpbAuthor,
+  McpbCompatibility,
+  McpbDeployment,
+  McpbRepository,
+  McpbUserConfigEntry,
+} from '../../../config/frontmcp-config.types';
+import {
+  DEFAULT_NODE_COMPAT,
+  DEFAULT_PLATFORMS,
+  MCPB_MANIFEST_VERSION,
+} from './constants';
+
+// ============================================
+// Emitted manifest shape (MCPB v0.3 subset we produce)
+// ============================================
+
+export interface McpbMcpConfig {
+  command: string;
+  args?: string[];
+  env?: Record<string, string>;
+  platform_overrides?: Record<string, McpbMcpConfig>;
+}
+
+export interface McpbManifest {
+  manifest_version: string;
+  name: string;
+  version: string;
+  description: string;
+  display_name?: string;
+  long_description?: string;
+  author: McpbAuthor;
+  license?: string;
+  homepage?: string;
+  repository?: { type: string; url: string };
+  documentation?: string;
+  support?: string;
+  icon?: string;
+  keywords?: string[];
+  privacy_policies?: string[];
+  compatibility?: McpbCompatibility;
+  server: {
+    type: 'node' | 'python' | 'binary' | 'uv';
+    entry_point: string;
+    mcp_config: McpbMcpConfig;
+  };
+  tools?: Array<{ name: string; description: string }>;
+  tools_generated?: boolean;
+  prompts?: Array<{ name: string; description?: string }>;
+  prompts_generated?: boolean;
+  user_config?: Record<string, McpbUserConfigEntry>;
+  _meta?: Record<string, unknown>;
+}
+
+// ============================================
+// Zod schema (used by validate.ts)
+// ============================================
+
+const authorSchema = z
+  .object({
+    name: z.string(),
+    email: z.string().optional(),
+    url: z.string().optional(),
+  })
+  .strict();
+
+const userConfigEntrySchema = z
+  .object({
+    type: z.enum(['string', 'number', 'boolean', 'directory', 'file']),
+    title: z.string(),
+    description: z.string().optional(),
+    required: z.boolean().optional(),
+    default: z.union([z.string(), z.number(), z.boolean()]).optional(),
+    multiple: z.boolean().optional(),
+    sensitive: z.boolean().optional(),
+    min: z.number().optional(),
+    max: z.number().optional(),
+  })
+  .strict();
+
+const mcpConfigSchema: z.ZodType<McpbMcpConfig> = z.lazy(() =>
+  z
+    .object({
+      command: z.string(),
+      args: z.array(z.string()).optional(),
+      env: z.record(z.string(), z.string()).optional(),
+      platform_overrides: z.record(z.string(), mcpConfigSchema).optional(),
+    })
+    .strict(),
+);
+
+export const mcpbManifestSchema = z
+  .object({
+    manifest_version: z.string(),
+    name: z.string().min(1),
+    version: z.string().min(1),
+    description: z.string(),
+    display_name: z.string().optional(),
+    long_description: z.string().optional(),
+    author: authorSchema,
+    license: z.string().optional(),
+    homepage: z.string().optional(),
+    repository: z
+      .object({ type: z.string(), url: z.string() })
+      .strict()
+      .optional(),
+    documentation: z.string().optional(),
+    support: z.string().optional(),
+    icon: z.string().optional(),
+    keywords: z.array(z.string()).optional(),
+    privacy_policies: z.array(z.string()).optional(),
+    compatibility: z
+      .object({
+        claude_desktop: z.string().optional(),
+        platforms: z.array(z.enum(['darwin', 'win32', 'linux'])).optional(),
+        runtimes: z
+          .object({ node: z.string().optional(), python: z.string().optional() })
+          .strict()
+          .optional(),
+      })
+      .strict()
+      .optional(),
+    server: z
+      .object({
+        type: z.enum(['node', 'python', 'binary', 'uv']),
+        entry_point: z.string(),
+        mcp_config: mcpConfigSchema,
+      })
+      .strict(),
+    tools: z
+      .array(z.object({ name: z.string(), description: z.string() }).strict())
+      .optional(),
+    tools_generated: z.boolean().optional(),
+    prompts: z
+      .array(
+        z
+          .object({ name: z.string(), description: z.string().optional() })
+          .strict(),
+      )
+      .optional(),
+    prompts_generated: z.boolean().optional(),
+    user_config: z.record(z.string(), userConfigEntrySchema).optional(),
+    _meta: z.record(z.string(), z.unknown()).optional(),
+  })
+  .strict();
+
+// ============================================
+// Sources + helpers
+// ============================================
+
+export interface PackageJsonMeta {
+  name?: string;
+  version?: string;
+  description?: string;
+  author?: string | McpbAuthor;
+  license?: string;
+  homepage?: string;
+  repository?: string | { type?: string; url?: string };
+  keywords?: string[];
+  icon?: string;
+}
+
+/** Read and parse package.json from the given directory. Returns {} if absent. */
+export function loadPackageJsonMeta(cwd: string): PackageJsonMeta {
+  const pkgPath = path.join(cwd, 'package.json');
+  if (!fs.existsSync(pkgPath)) return {};
+  try {
+    return JSON.parse(fs.readFileSync(pkgPath, 'utf-8')) as PackageJsonMeta;
+  } catch {
+    return {};
+  }
+}
+
+/**
+ * Parse npm-style "Name <email> (url)" into an McpbAuthor.
+ * Falls back to `{ name: <raw> }` when parsing fails.
+ */
+export function parseAuthor(author: unknown): McpbAuthor {
+  if (!author) return { name: 'unknown' };
+  if (typeof author === 'object' && author !== null && 'name' in author) {
+    const a = author as McpbAuthor;
+    return {
+      name: a.name,
+      ...(a.email ? { email: a.email } : {}),
+      ...(a.url ? { url: a.url } : {}),
+    };
+  }
+  if (typeof author !== 'string') {
+    return { name: String(author) };
+  }
+  const match = author.match(/^([^<(]+?)(?:\s*<([^>]+)>)?(?:\s*\(([^)]+)\))?$/);
+  if (!match || !match[1]) return { name: author };
+  const [, name, email, url] = match;
+  return {
+    name: name.trim(),
+    ...(email ? { email: email.trim() } : {}),
+    ...(url ? { url: url.trim() } : {}),
+  };
+}
+
+/** Normalize repository field (string → {type, url}). */
+export function normalizeRepository(
+  repo: McpbRepository | PackageJsonMeta['repository'] | undefined,
+): { type: string; url: string } | undefined {
+  if (!repo) return undefined;
+  if (typeof repo === 'string') {
+    return { type: 'git', url: repo };
+  }
+  if (typeof repo === 'object' && repo.url) {
+    return { type: repo.type || 'git', url: repo.url };
+  }
+  return undefined;
+}
+
+/** Resolve first-existing icon path. */
+export function resolveIconPath(cwd: string, deploymentIcon?: string, pkgIcon?: string): string | undefined {
+  const candidates = [deploymentIcon, pkgIcon, 'icon.png', 'assets/icon.png'].filter(
+    (x): x is string => !!x,
+  );
+  for (const rel of candidates) {
+    if (fs.existsSync(path.resolve(cwd, rel))) {
+      return rel;
+    }
+  }
+  return undefined;
+}
+
+// ============================================
+// Generator input + output
+// ============================================
+
+export interface GenerateMcpbManifestInput {
+  /** Resolved server name. */
+  name: string;
+  /** Resolved server version. */
+  version: string;
+  /** Optional resolved node version range (e.g., ">=22.0.0"). */
+  nodeVersion?: string;
+  /** Project root. Used for icon resolution and package.json fallback. */
+  cwd: string;
+  /** Deployment config from frontmcp.config (may be undefined). */
+  deployment?: McpbDeployment;
+  /** Schema extracted from the compiled server bundle. */
+  schema: ExtractedSchema;
+  /** env → user_config reference map built by user-config.ts. */
+  userConfigEnv: Record<string, string>;
+  /** user_config entries built by user-config.ts. */
+  userConfig: Record<string, McpbUserConfigEntry>;
+  /** platform_overrides from binary.ts (may be empty). */
+  platformOverrides?: Record<string, McpbMcpConfig>;
+  /** Whether an icon was copied into the staged archive root. */
+  hasIcon?: boolean;
+  /** Tool name of the CLI version emitting this manifest (for _meta). */
+  cliVersion?: string;
+}
+
+/** Produce the final MCPB manifest object. */
+export function generateMcpbManifest(input: GenerateMcpbManifestInput): McpbManifest {
+  const {
+    name,
+    version,
+    cwd,
+    deployment,
+    schema,
+    userConfig,
+    userConfigEnv,
+    platformOverrides,
+    hasIcon,
+    cliVersion,
+  } = input;
+
+  const pkg = loadPackageJsonMeta(cwd);
+
+  const description = deployment?.longDescription?.split('\n')[0]?.trim()
+    || pkg.description
+    || '';
+
+  const author = deployment?.author || parseAuthor(pkg.author);
+  const license = deployment?.license ?? pkg.license;
+  const homepage = deployment?.homepage ?? pkg.homepage;
+  const repository = normalizeRepository(deployment?.repository ?? pkg.repository);
+  const keywords = deployment?.keywords ?? pkg.keywords;
+  const icon = hasIcon ? 'icon.png' : undefined;
+
+  const nodeVersion = deployment?.compatibility?.runtimes?.node
+    ?? input.nodeVersion
+    ?? DEFAULT_NODE_COMPAT;
+
+  const compatibility: McpbCompatibility = {
+    ...(deployment?.compatibility?.claude_desktop
+      ? { claude_desktop: deployment.compatibility.claude_desktop }
+      : {}),
+    platforms: deployment?.compatibility?.platforms ?? [...DEFAULT_PLATFORMS],
+    runtimes: {
+      ...(deployment?.compatibility?.runtimes?.python
+        ? { python: deployment.compatibility.runtimes.python }
+        : {}),
+      node: nodeVersion,
+    },
+  };
+
+  const tools = schema.tools
+    .filter((t) => !SYSTEM_TOOL_NAMES.has(t.name))
+    .map((t) => ({ name: t.name, description: t.description || '' }));
+
+  const prompts = schema.prompts.map((p) => ({
+    name: p.name,
+    ...(p.description ? { description: p.description } : {}),
+  }));
+
+  const mcpConfig: McpbMcpConfig = {
+    command: 'node',
+    args: ['${__dirname}/server/index.js'],
+    ...(Object.keys(userConfigEnv).length > 0 ? { env: userConfigEnv } : {}),
+    ...(platformOverrides && Object.keys(platformOverrides).length > 0
+      ? { platform_overrides: platformOverrides }
+      : {}),
+  };
+
+  const manifest: McpbManifest = {
+    manifest_version: MCPB_MANIFEST_VERSION,
+    name,
+    version,
+    description,
+    ...(deployment?.displayName ? { display_name: deployment.displayName } : {}),
+    ...(deployment?.longDescription
+      ? { long_description: deployment.longDescription }
+      : {}),
+    author,
+    ...(license ? { license } : {}),
+    ...(homepage ? { homepage } : {}),
+    ...(repository ? { repository } : {}),
+    ...(deployment?.documentation ? { documentation: deployment.documentation } : {}),
+    ...(deployment?.support ? { support: deployment.support } : {}),
+    ...(icon ? { icon } : {}),
+    ...(keywords && keywords.length > 0 ? { keywords } : {}),
+    ...(deployment?.privacyPolicies && deployment.privacyPolicies.length > 0
+      ? { privacy_policies: deployment.privacyPolicies }
+      : {}),
+    compatibility,
+    server: {
+      type: 'node',
+      entry_point: 'server/index.js',
+      mcp_config: mcpConfig,
+    },
+    tools,
+    tools_generated: false,
+    prompts,
+    // FrontMCP prompts resolve dynamically via execute() — MCPB's static `text`
+    // template cannot represent JS logic. Set generated:true so consumers query
+    // the server at runtime while still getting name/description hints here.
+    prompts_generated: true,
+    ...(Object.keys(userConfig).length > 0 ? { user_config: userConfig } : {}),
+    _meta: {
+      'dev.frontmcp.generator': cliVersion ? `frontmcp@${cliVersion}` : 'frontmcp',
+      'dev.frontmcp.capabilities': schema.capabilities,
+    },
+  };
+
+  return manifest;
+}

--- a/libs/cli/src/commands/build/mcpb/stage.ts
+++ b/libs/cli/src/commands/build/mcpb/stage.ts
@@ -1,0 +1,144 @@
+/**
+ * Stage the MCPB archive layout on disk before zipping.
+ *
+ * Layout produced:
+ *
+ *   __stage/
+ *     manifest.json
+ *     server/
+ *       index.js          (esbuild bundle, renamed from {name}.bundle.js)
+ *       package.json      (minimal CJS manifest so Node resolves index.js)
+ *       _skills/          (optional — when the server ships skills)
+ *     bin/                (optional — when SEA is enabled)
+ *       {platform}/{name}[.exe]
+ *     icon.png            (optional)
+ *     README.md           (optional)
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+import type { BinaryEntry } from './binary';
+import type { ExtractedSchema } from '../exec/cli-runtime/schema-extractor';
+import { copySkillAssets } from '../exec/skill-assets';
+
+export interface StageInput {
+  stageDir: string;
+  /** Project root (for reading README, icon, etc.). */
+  cwd: string;
+  /** Absolute path to the esbuild server bundle. */
+  serverBundlePath: string;
+  /** App name — written into server/package.json. */
+  name: string;
+  /** App version — written into server/package.json. */
+  version: string;
+  /** Schema extracted from the bundle (drives skill asset copy). */
+  schema: ExtractedSchema;
+  /** Absolute path of a resolved icon file (optional). */
+  iconPath?: string;
+  /** Binaries to stage under bin/{platform}/. */
+  binaries?: BinaryEntry[];
+  /** When true, copy README.md from cwd if present. @default true */
+  includeReadme?: boolean;
+}
+
+export interface StageResult {
+  stageDir: string;
+  /** Relative paths written into the stage (for logging). */
+  written: string[];
+  /** Whether an icon was actually staged (drives manifest.icon field). */
+  hasIcon: boolean;
+  /** Number of skill asset files copied (zero when no skills). */
+  skillAssetCount: number;
+}
+
+/** Build the staged `__stage/` tree on disk. */
+export function stageMcpbDirectory(input: StageInput): StageResult {
+  const {
+    stageDir,
+    cwd,
+    serverBundlePath,
+    name,
+    version,
+    schema,
+    iconPath,
+    binaries = [],
+    includeReadme = true,
+  } = input;
+
+  const written: string[] = [];
+  fs.mkdirSync(stageDir, { recursive: true });
+
+  // 1. server/
+  const serverDir = path.join(stageDir, 'server');
+  fs.mkdirSync(serverDir, { recursive: true });
+
+  const serverIndex = path.join(serverDir, 'index.js');
+  fs.copyFileSync(serverBundlePath, serverIndex);
+  written.push('server/index.js');
+
+  // Minimal server/package.json so Node resolves index.js as CJS.
+  const serverPkg = {
+    name,
+    version,
+    main: 'index.js',
+    type: 'commonjs',
+    private: true,
+  };
+  fs.writeFileSync(
+    path.join(serverDir, 'package.json'),
+    `${JSON.stringify(serverPkg, null, 2)}\n`,
+  );
+  written.push('server/package.json');
+
+  // 2. server/_skills/ (if the bundle exposes skills)
+  const skillsResult = copySkillAssets(serverDir, schema.skillAssets);
+  if (skillsResult.copiedCount > 0) {
+    written.push('server/_skills/');
+  }
+
+  // 3. bin/{platform}/{file}
+  for (const bin of binaries) {
+    const destDir = path.join(stageDir, 'bin', bin.platform);
+    fs.mkdirSync(destDir, { recursive: true });
+    const destFile = path.join(destDir, bin.fileName);
+    fs.copyFileSync(bin.srcPath, destFile);
+    try {
+      fs.chmodSync(destFile, 0o755);
+    } catch {
+      // Windows or a filesystem that rejects chmod — safe to ignore.
+    }
+    written.push(`bin/${bin.platform}/${bin.fileName}`);
+  }
+
+  // 4. icon.png
+  let hasIcon = false;
+  if (iconPath && fs.existsSync(iconPath)) {
+    const destIcon = path.join(stageDir, 'icon.png');
+    fs.copyFileSync(iconPath, destIcon);
+    written.push('icon.png');
+    hasIcon = true;
+  }
+
+  // 5. README.md
+  if (includeReadme) {
+    const readmePath = path.join(cwd, 'README.md');
+    if (fs.existsSync(readmePath)) {
+      fs.copyFileSync(readmePath, path.join(stageDir, 'README.md'));
+      written.push('README.md');
+    }
+  }
+
+  return {
+    stageDir,
+    written,
+    hasIcon,
+    skillAssetCount: skillsResult.copiedCount,
+  };
+}
+
+/** Write the final manifest.json to the stage root. */
+export function writeManifest(stageDir: string, manifest: unknown): string {
+  const manifestPath = path.join(stageDir, 'manifest.json');
+  fs.writeFileSync(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`);
+  return manifestPath;
+}

--- a/libs/cli/src/commands/build/mcpb/user-config.ts
+++ b/libs/cli/src/commands/build/mcpb/user-config.ts
@@ -1,0 +1,178 @@
+/**
+ * Translate FrontMCP `setup.steps` into MCPB `user_config` + `mcp_config.env`.
+ *
+ * MCPB's user_config is a flat key/value form. FrontMCP's setup graph supports
+ * branching (`step.next`) and conditional visibility (`step.showWhen`). Those
+ * features have no MCPB equivalent — we emit a warning and render every step
+ * unconditionally.
+ */
+
+import { idToEnvName, type SetupStep, zodSchemaToJsonSchema } from '../exec/setup';
+import type {
+  McpbDeployment,
+  McpbUserConfigEntry,
+  McpbUserConfigType,
+} from '../../../config/frontmcp-config.types';
+import { USER_CONFIG_PREFIX } from './constants';
+
+export interface UserConfigTranslationResult {
+  /** MCPB user_config block. */
+  userConfig: Record<string, McpbUserConfigEntry>;
+  /** mcp_config.env map: ENV_NAME → ${user_config.key}. */
+  env: Record<string, string>;
+  /** Warnings to surface to the CLI log. */
+  warnings: string[];
+}
+
+/** Convert kebab/snake/SCREAMING_SNAKE id to camelCase for the MCPB key. */
+export function idToCamelKey(id: string): string {
+  const normalized = id.replace(/[^a-zA-Z0-9]+/g, ' ').trim().toLowerCase();
+  const parts = normalized.split(/\s+/).filter(Boolean);
+  if (parts.length === 0) return 'value';
+  return parts
+    .map((part, idx) => (idx === 0 ? part : part[0].toUpperCase() + part.slice(1)))
+    .join('');
+}
+
+/** Resolve the user_config.type for a setup step. */
+function resolveType(
+  jsonSchema: Record<string, unknown>,
+  override?: McpbUserConfigType,
+): { type: McpbUserConfigType; multiple: boolean } {
+  if (override) {
+    return { type: override, multiple: false };
+  }
+  const schemaType = jsonSchema['type'];
+  if (schemaType === 'boolean') return { type: 'boolean', multiple: false };
+  if (schemaType === 'number' || schemaType === 'integer') {
+    return { type: 'number', multiple: false };
+  }
+  if (schemaType === 'array') {
+    const items = jsonSchema['items'];
+    const itemType =
+      items && typeof items === 'object' && 'type' in items
+        ? (items as { type: unknown }).type
+        : 'string';
+    if (itemType === 'number' || itemType === 'integer') {
+      return { type: 'number', multiple: true };
+    }
+    if (itemType === 'boolean') {
+      return { type: 'boolean', multiple: true };
+    }
+    return { type: 'string', multiple: true };
+  }
+  return { type: 'string', multiple: false };
+}
+
+/**
+ * Produce MCPB user_config + env mapping from FrontMCP setup steps.
+ * Also applies any per-key `deployment.userConfig` overrides (e.g., to change
+ * type to `file` or `directory`).
+ */
+export function setupStepsToUserConfig(
+  steps: SetupStep[] | undefined,
+  deployment?: McpbDeployment,
+): UserConfigTranslationResult {
+  const userConfig: Record<string, McpbUserConfigEntry> = {};
+  const env: Record<string, string> = {};
+  const warnings: string[] = [];
+
+  if (!steps || steps.length === 0) {
+    // Allow deployment.userConfig to stand alone (no setup graph).
+    if (deployment?.userConfig) {
+      for (const [key, entry] of Object.entries(deployment.userConfig)) {
+        userConfig[key] = entry;
+      }
+    }
+    return { userConfig, env, warnings };
+  }
+
+  for (const step of steps) {
+    if (step.showWhen || step.next) {
+      warnings.push(
+        `Step "${step.id}" uses showWhen/next — MCPB has no equivalent; rendered unconditionally`,
+      );
+    }
+
+    const jsonSchema =
+      step.jsonSchema ?? (step.schema ? zodSchemaToJsonSchema(step.schema) : { type: 'string' });
+    const key = idToCamelKey(step.id);
+    const override = deployment?.userConfig?.[key];
+
+    const { type, multiple } = resolveType(jsonSchema, override?.type);
+
+    const entry: McpbUserConfigEntry = {
+      type,
+      title: override?.title ?? step.prompt,
+      ...(step.description || override?.description
+        ? { description: override?.description ?? step.description }
+        : {}),
+      ...(step.sensitive || override?.sensitive ? { sensitive: true } : {}),
+      ...(multiple || override?.multiple ? { multiple: true } : {}),
+    };
+
+    const required = inferRequired(jsonSchema, override?.required);
+    if (required) entry.required = true;
+
+    const defaultVal = jsonSchema['default'] ?? override?.default;
+    if (defaultVal !== undefined && !entry.sensitive) {
+      if (
+        (entry.type === 'string' || entry.type === 'directory' || entry.type === 'file') &&
+        typeof defaultVal === 'string'
+      ) {
+        entry.default = defaultVal;
+      } else if (entry.type === 'number' && typeof defaultVal === 'number') {
+        entry.default = defaultVal;
+      } else if (entry.type === 'boolean' && typeof defaultVal === 'boolean') {
+        entry.default = defaultVal;
+      }
+    }
+
+    const min = pickNumber(jsonSchema['minimum'] ?? jsonSchema['minLength']) ?? override?.min;
+    const max = pickNumber(jsonSchema['maximum'] ?? jsonSchema['maxLength']) ?? override?.max;
+    if (min !== undefined) entry.min = min;
+    if (max !== undefined) entry.max = max;
+
+    // Merge explicit deployment.userConfig fields that weren't captured above.
+    if (override) {
+      for (const prop of ['title', 'description', 'required', 'multiple', 'sensitive', 'min', 'max', 'default'] as const) {
+        if (override[prop] !== undefined && entry[prop] === undefined) {
+          (entry as unknown as Record<string, unknown>)[prop] = override[prop];
+        }
+      }
+    }
+
+    userConfig[key] = entry;
+
+    const envName = step.env ?? idToEnvName(step.id);
+    env[envName] = `\${${USER_CONFIG_PREFIX}${key}}`;
+  }
+
+  // Any deployment.userConfig entries not derived from a setup step are merged verbatim.
+  if (deployment?.userConfig) {
+    for (const [key, entry] of Object.entries(deployment.userConfig)) {
+      if (!userConfig[key]) {
+        userConfig[key] = entry;
+      }
+    }
+  }
+
+  return { userConfig, env, warnings };
+}
+
+function inferRequired(jsonSchema: Record<string, unknown>, override?: boolean): boolean {
+  if (override !== undefined) return override;
+  // JSON Schema 'required' arrays apply at the parent level; for a single-value
+  // schema, treat missing default + no `.optional()` marker as required.
+  if (jsonSchema['default'] !== undefined) return false;
+  // Best-effort: Zod/v4 encodes optional as a union with undefined or nullable.
+  const anyOf = jsonSchema['anyOf'];
+  if (Array.isArray(anyOf) && anyOf.some((s) => s && typeof s === 'object' && (s as { type?: string }).type === 'null')) {
+    return false;
+  }
+  return true;
+}
+
+function pickNumber(value: unknown): number | undefined {
+  return typeof value === 'number' && Number.isFinite(value) ? value : undefined;
+}

--- a/libs/cli/src/commands/build/mcpb/validate.ts
+++ b/libs/cli/src/commands/build/mcpb/validate.ts
@@ -1,0 +1,217 @@
+/**
+ * Validate a `.mcpb` archive against the subset of MCPB v0.3 that FrontMCP
+ * emits. Surfaces problems clients would hit when loading the bundle.
+ *
+ * Checks performed:
+ *   1. Archive opens as a zip
+ *   2. `manifest.json` exists and parses as JSON
+ *   3. Manifest matches `mcpbManifestSchema`
+ *   4. `server.entry_point` resolves to an entry inside the archive
+ *   5. Every `${user_config.KEY}` reference declares matching user_config[KEY]
+ *   6. Only allow-listed variables appear in substitutions
+ *   7. `icon` / `icons[*].src` files exist when referenced
+ *   8. No zip-slip (entry names with `..` segments or absolute paths)
+ *   9. Warnings on large archives, absolute-path args, node_modules presence
+ */
+
+import type { Entry, ZipFile } from 'yauzl';
+import { mcpbManifestSchema, type McpbManifest, type McpbMcpConfig } from './manifest';
+import { ALLOWED_SUBSTITUTION_VARS, ARCHIVE_SIZE_ERROR, ARCHIVE_SIZE_WARN, USER_CONFIG_PREFIX } from './constants';
+
+export interface ValidateResult {
+  ok: boolean;
+  errors: string[];
+  warnings: string[];
+  manifest?: McpbManifest;
+  entries?: string[];
+  /** Archive size in bytes. */
+  size?: number;
+}
+
+/** Validate a `.mcpb` archive at the given path. */
+export async function validateMcpb(archivePath: string): Promise<ValidateResult> {
+  const result: ValidateResult = { ok: false, errors: [], warnings: [] };
+
+  let archive: { entries: string[]; manifestRaw?: string; size: number };
+  try {
+    archive = await readArchive(archivePath);
+  } catch (err) {
+    result.errors.push(`Cannot open archive: ${(err as Error).message}`);
+    return result;
+  }
+
+  result.entries = archive.entries;
+  result.size = archive.size;
+
+  if (archive.size > ARCHIVE_SIZE_ERROR) {
+    result.warnings.push(
+      `Archive is ${(archive.size / 1024 / 1024).toFixed(1)} MB — consider tuning esbuild externals or disabling node_modules inclusion`,
+    );
+  } else if (archive.size > ARCHIVE_SIZE_WARN) {
+    result.warnings.push(`Archive is ${(archive.size / 1024 / 1024).toFixed(1)} MB`);
+  }
+
+  // Zip-slip: flag any suspicious entry names
+  for (const entry of archive.entries) {
+    if (entry.startsWith('/') || entry.includes('..')) {
+      result.errors.push(`Zip-slip risk: entry "${entry}"`);
+    }
+  }
+
+  if (archive.entries.some((e) => e.startsWith('server/node_modules/'))) {
+    result.warnings.push('Archive contains server/node_modules/ — opt-in only; verify this was intentional');
+  }
+
+  if (!archive.manifestRaw) {
+    result.errors.push('manifest.json is missing from the archive root');
+    return result;
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(archive.manifestRaw);
+  } catch (err) {
+    result.errors.push(`manifest.json is not valid JSON: ${(err as Error).message}`);
+    return result;
+  }
+
+  const schemaResult = mcpbManifestSchema.safeParse(parsed);
+  if (!schemaResult.success) {
+    const issues = schemaResult.error.issues
+      .map((i) => `${i.path.join('.')}: ${i.message}`)
+      .join('; ');
+    result.errors.push(`manifest.json fails schema: ${issues}`);
+    return result;
+  }
+
+  const manifest = schemaResult.data as McpbManifest;
+  result.manifest = manifest;
+
+  // entry_point must live in the archive
+  if (!archive.entries.includes(manifest.server.entry_point)) {
+    result.errors.push(
+      `server.entry_point "${manifest.server.entry_point}" is not present in the archive`,
+    );
+  }
+
+  // Variable substitution + user_config cross-check
+  checkMcpConfig(manifest.server.mcp_config, manifest.user_config, result);
+
+  // Icon existence
+  if (manifest.icon && !archive.entries.includes(manifest.icon)) {
+    result.errors.push(`icon "${manifest.icon}" is not present in the archive`);
+  }
+
+  // Binary references declared via platform_overrides must exist
+  const overrides = manifest.server.mcp_config.platform_overrides || {};
+  for (const [platform, cfg] of Object.entries(overrides)) {
+    const cmd = cfg.command;
+    const entryName = stripDirname(cmd);
+    if (entryName && !archive.entries.includes(entryName)) {
+      result.errors.push(
+        `platform_overrides["${platform}"].command points to "${entryName}" which is not in the archive`,
+      );
+    }
+  }
+
+  result.ok = result.errors.length === 0;
+  return result;
+}
+
+function checkMcpConfig(
+  cfg: McpbMcpConfig,
+  userConfig: Record<string, unknown> | undefined,
+  result: ValidateResult,
+): void {
+  const declared = new Set(Object.keys(userConfig ?? {}));
+  const valuesToScan: string[] = [cfg.command, ...(cfg.args ?? [])];
+  if (cfg.env) valuesToScan.push(...Object.values(cfg.env));
+  for (const value of valuesToScan) {
+    verifySubstitutions(value, declared, result);
+    if (isAbsolutePath(value) && !value.startsWith('${__dirname}')) {
+      result.warnings.push(`Absolute path in mcp_config: "${value}" — consider using \${__dirname}`);
+    }
+  }
+  if (cfg.platform_overrides) {
+    for (const [platform, nested] of Object.entries(cfg.platform_overrides)) {
+      checkMcpConfig(nested, userConfig, result);
+      void platform;
+    }
+  }
+}
+
+function verifySubstitutions(value: string, declared: Set<string>, result: ValidateResult): void {
+  const re = /\$\{([^}]+)\}/g;
+  let match: RegExpExecArray | null;
+  while ((match = re.exec(value)) !== null) {
+    const variable = match[1];
+    if (variable.startsWith(USER_CONFIG_PREFIX)) {
+      const key = variable.slice(USER_CONFIG_PREFIX.length);
+      if (!declared.has(key)) {
+        result.errors.push(`Unknown user_config reference: "${variable}"`);
+      }
+      continue;
+    }
+    if (!ALLOWED_SUBSTITUTION_VARS.has(variable)) {
+      result.errors.push(`Unknown substitution variable: "\${${variable}}"`);
+    }
+  }
+}
+
+function isAbsolutePath(value: string): boolean {
+  if (!value) return false;
+  if (value.startsWith('/')) return true;
+  return /^[a-zA-Z]:[\\/]/.test(value); // C:\ or C:/
+}
+
+/** Strip a leading ${__dirname}/ from a command path, returning the in-archive entry. */
+function stripDirname(command: string): string | undefined {
+  const prefix = '${__dirname}/';
+  return command.startsWith(prefix) ? command.slice(prefix.length) : undefined;
+}
+
+interface RawArchive {
+  entries: string[];
+  manifestRaw?: string;
+  size: number;
+}
+
+function readArchive(archivePath: string): Promise<RawArchive> {
+  const yauzl = require('yauzl') as typeof import('yauzl');
+  return new Promise<RawArchive>((resolve, reject) => {
+    yauzl.open(archivePath, { lazyEntries: true }, (err: Error | null, zip: ZipFile | undefined) => {
+      if (err || !zip) {
+        reject(err || new Error('yauzl returned no handle'));
+        return;
+      }
+      const entries: string[] = [];
+      let manifestRaw: string | undefined;
+
+      zip.readEntry();
+      zip.on('entry', (entry: Entry) => {
+        entries.push(entry.fileName);
+        if (entry.fileName === 'manifest.json') {
+          zip.openReadStream(entry, (streamErr: Error | null, stream: NodeJS.ReadableStream | undefined) => {
+            if (streamErr || !stream) {
+              reject(streamErr || new Error('Failed to open manifest stream'));
+              return;
+            }
+            const chunks: Buffer[] = [];
+            stream.on('data', (chunk: Buffer) => chunks.push(chunk));
+            stream.on('end', () => {
+              manifestRaw = Buffer.concat(chunks).toString('utf-8');
+              zip.readEntry();
+            });
+            stream.on('error', reject);
+          });
+        } else {
+          zip.readEntry();
+        }
+      });
+      zip.on('end', () => {
+        resolve({ entries, manifestRaw, size: zip.fileSize ?? 0 });
+      });
+      zip.on('error', reject);
+    });
+  });
+}

--- a/libs/cli/src/commands/build/mcpb/validate.ts
+++ b/libs/cli/src/commands/build/mcpb/validate.ts
@@ -9,11 +9,13 @@
  *   4. `server.entry_point` resolves to an entry inside the archive
  *   5. Every `${user_config.KEY}` reference declares matching user_config[KEY]
  *   6. Only allow-listed variables appear in substitutions
- *   7. `icon` / `icons[*].src` files exist when referenced
- *   8. No zip-slip (entry names with `..` segments or absolute paths)
+ *   7. `manifest.icon` file exists when referenced
+ *   8. No zip-slip (normalized entry names escaping the archive root)
  *   9. Warnings on large archives, absolute-path args, node_modules presence
  */
 
+import * as fs from 'fs';
+import * as path from 'path';
 import type { Entry, ZipFile } from 'yauzl';
 import { mcpbManifestSchema, type McpbManifest, type McpbMcpConfig } from './manifest';
 import { ALLOWED_SUBSTITUTION_VARS, ARCHIVE_SIZE_ERROR, ARCHIVE_SIZE_WARN, USER_CONFIG_PREFIX } from './constants';
@@ -51,9 +53,11 @@ export async function validateMcpb(archivePath: string): Promise<ValidateResult>
     result.warnings.push(`Archive is ${(archive.size / 1024 / 1024).toFixed(1)} MB`);
   }
 
-  // Zip-slip: flag any suspicious entry names
+  // Zip-slip: flag entries that escape the archive root.
+  // Substring-matching `..` would false-positive on legit names like `foo..bar`,
+  // so we normalize and check for literal `..` segments plus absolute paths.
   for (const entry of archive.entries) {
-    if (entry.startsWith('/') || entry.includes('..')) {
+    if (isUnsafeArchivePath(entry)) {
       result.errors.push(`Zip-slip risk: entry "${entry}"`);
     }
   }
@@ -178,6 +182,10 @@ interface RawArchive {
 
 function readArchive(archivePath: string): Promise<RawArchive> {
   const yauzl = require('yauzl') as typeof import('yauzl');
+  // yauzl's ZipFile doesn't expose the archive byte size, so measure it
+  // directly from disk. stat before open mirrors the error path for missing
+  // files.
+  const size = fs.statSync(archivePath).size;
   return new Promise<RawArchive>((resolve, reject) => {
     yauzl.open(archivePath, { lazyEntries: true }, (err: Error | null, zip: ZipFile | undefined) => {
       if (err || !zip) {
@@ -186,6 +194,17 @@ function readArchive(archivePath: string): Promise<RawArchive> {
       }
       const entries: string[] = [];
       let manifestRaw: string | undefined;
+      let settled = false;
+      const settle = (fn: () => void): void => {
+        if (settled) return;
+        settled = true;
+        try {
+          zip.close();
+        } catch {
+          // best-effort close — don't mask the original error
+        }
+        fn();
+      };
 
       zip.readEntry();
       zip.on('entry', (entry: Entry) => {
@@ -193,7 +212,7 @@ function readArchive(archivePath: string): Promise<RawArchive> {
         if (entry.fileName === 'manifest.json') {
           zip.openReadStream(entry, (streamErr: Error | null, stream: NodeJS.ReadableStream | undefined) => {
             if (streamErr || !stream) {
-              reject(streamErr || new Error('Failed to open manifest stream'));
+              settle(() => reject(streamErr || new Error('Failed to open manifest stream')));
               return;
             }
             const chunks: Buffer[] = [];
@@ -202,16 +221,30 @@ function readArchive(archivePath: string): Promise<RawArchive> {
               manifestRaw = Buffer.concat(chunks).toString('utf-8');
               zip.readEntry();
             });
-            stream.on('error', reject);
+            stream.on('error', (e: Error) => settle(() => reject(e)));
           });
         } else {
           zip.readEntry();
         }
       });
       zip.on('end', () => {
-        resolve({ entries, manifestRaw, size: zip.fileSize ?? 0 });
+        settle(() => resolve({ entries, manifestRaw, size }));
       });
-      zip.on('error', reject);
+      zip.on('error', (e: Error) => settle(() => reject(e)));
     });
   });
+}
+
+/**
+ * A zip entry is unsafe if it uses an absolute path or any normalized segment
+ * would let it escape the archive root (`..`). Backslashes are also rejected
+ * so Windows-style paths can't bypass the POSIX check.
+ */
+function isUnsafeArchivePath(entry: string): boolean {
+  if (!entry) return false;
+  if (entry.startsWith('/') || entry.includes('\\')) return true;
+  if (/^[a-zA-Z]:/.test(entry)) return true; // drive-letter absolute
+  const normalized = path.posix.normalize(entry);
+  if (normalized.startsWith('../') || normalized === '..') return true;
+  return normalized.split('/').some((segment) => segment === '..');
 }

--- a/libs/cli/src/commands/build/mcpb/zip.ts
+++ b/libs/cli/src/commands/build/mcpb/zip.ts
@@ -29,8 +29,8 @@ export interface ZipResult {
 export interface ZipOptions {
   /** Apply DETERMINISTIC_MTIME to every entry. @default true */
   deterministic?: boolean;
-  /** Compression level passed to yazl (0 = store, 1-9 = deflate). @default 6 */
-  compressionLevel?: number;
+  /** When true, deflate entries; when false, store uncompressed. @default true */
+  compress?: boolean;
 }
 
 /**
@@ -59,7 +59,11 @@ export function listFilesForArchive(
       // expected to be portable across Windows/macOS/Linux consumers.
     }
   }
-  return out.sort((a, b) => (a.archivePath < b.archivePath ? -1 : 1));
+  return out.sort((a, b) => {
+    if (a.archivePath < b.archivePath) return -1;
+    if (a.archivePath > b.archivePath) return 1;
+    return 0;
+  });
 }
 
 /** Create a deterministic `.mcpb` archive from a staged directory. */
@@ -69,7 +73,7 @@ export async function createDeterministicZip(
   options: ZipOptions = {},
 ): Promise<ZipResult> {
   const yazl = require('yazl') as typeof import('yazl');
-  const { deterministic = true, compressionLevel = 6 } = options;
+  const { deterministic = true, compress = true } = options;
 
   const files = listFilesForArchive(stageDir);
   const zip = new yazl.ZipFile();
@@ -77,7 +81,7 @@ export async function createDeterministicZip(
   for (const { archivePath: rel, absPath } of files) {
     zip.addFile(absPath, rel, {
       mtime: deterministic ? DETERMINISTIC_MTIME : undefined,
-      compress: compressionLevel > 0,
+      compress,
     });
   }
   zip.end({ forceZip64Format: false });

--- a/libs/cli/src/commands/build/mcpb/zip.ts
+++ b/libs/cli/src/commands/build/mcpb/zip.ts
@@ -1,0 +1,103 @@
+/**
+ * Deterministic ZIP creation for MCPB archives.
+ *
+ * Determinism is achieved by:
+ *   - walking the stage directory in sorted order
+ *   - uniform mtime (`DETERMINISTIC_MTIME`) on every entry
+ *   - forceZip64Format: false (yazl default — keeps the archive small & portable)
+ *
+ * Two back-to-back builds of the same staged directory produce byte-identical
+ * `.mcpb` archives with matching SHA-256 hashes.
+ */
+
+import * as crypto from 'crypto';
+import * as fs from 'fs';
+import * as path from 'path';
+import { DETERMINISTIC_MTIME } from './constants';
+
+export interface ZipResult {
+  /** Absolute path to the produced archive. */
+  archivePath: string;
+  /** Final archive size in bytes. */
+  size: number;
+  /** SHA-256 of the archive contents (lowercase hex). */
+  sha256: string;
+  /** Entry names in archive order (useful for tests/logging). */
+  entries: string[];
+}
+
+export interface ZipOptions {
+  /** Apply DETERMINISTIC_MTIME to every entry. @default true */
+  deterministic?: boolean;
+  /** Compression level passed to yazl (0 = store, 1-9 = deflate). @default 6 */
+  compressionLevel?: number;
+}
+
+/**
+ * Recursively walk a directory and return every file's {archivePath, absPath}
+ * pair. Archive paths use forward slashes regardless of host OS.
+ */
+export function listFilesForArchive(
+  stageDir: string,
+): Array<{ archivePath: string; absPath: string }> {
+  const out: Array<{ archivePath: string; absPath: string }> = [];
+  const stack: Array<{ dir: string; rel: string }> = [{ dir: stageDir, rel: '' }];
+  while (stack.length > 0) {
+    const next = stack.pop();
+    if (!next) break;
+    const { dir, rel } = next;
+    const entries = fs.readdirSync(dir, { withFileTypes: true });
+    for (const entry of entries) {
+      const abs = path.join(dir, entry.name);
+      const relPath = rel ? `${rel}/${entry.name}` : entry.name;
+      if (entry.isDirectory()) {
+        stack.push({ dir: abs, rel: relPath });
+      } else if (entry.isFile()) {
+        out.push({ archivePath: relPath, absPath: abs });
+      }
+      // Symlinks and other types are deliberately skipped: MCPB archives are
+      // expected to be portable across Windows/macOS/Linux consumers.
+    }
+  }
+  return out.sort((a, b) => (a.archivePath < b.archivePath ? -1 : 1));
+}
+
+/** Create a deterministic `.mcpb` archive from a staged directory. */
+export async function createDeterministicZip(
+  stageDir: string,
+  archivePath: string,
+  options: ZipOptions = {},
+): Promise<ZipResult> {
+  const yazl = require('yazl') as typeof import('yazl');
+  const { deterministic = true, compressionLevel = 6 } = options;
+
+  const files = listFilesForArchive(stageDir);
+  const zip = new yazl.ZipFile();
+
+  for (const { archivePath: rel, absPath } of files) {
+    zip.addFile(absPath, rel, {
+      mtime: deterministic ? DETERMINISTIC_MTIME : undefined,
+      compress: compressionLevel > 0,
+    });
+  }
+  zip.end({ forceZip64Format: false });
+
+  fs.mkdirSync(path.dirname(archivePath), { recursive: true });
+  await new Promise<void>((resolve, reject) => {
+    const out = fs.createWriteStream(archivePath);
+    out.on('error', reject);
+    out.on('close', () => resolve());
+    zip.outputStream.on('error', reject);
+    zip.outputStream.pipe(out);
+  });
+
+  const buf = fs.readFileSync(archivePath);
+  const sha256 = crypto.createHash('sha256').update(buf).digest('hex');
+
+  return {
+    archivePath,
+    size: buf.byteLength,
+    sha256,
+    entries: files.map((f) => f.archivePath),
+  };
+}

--- a/libs/cli/src/commands/build/register.ts
+++ b/libs/cli/src/commands/build/register.ts
@@ -1,7 +1,7 @@
 import type { Command } from 'commander';
 import { toParsedArgs } from '../../core/bridge';
 
-const BUILD_TARGETS = ['cli', 'node', 'sdk', 'browser', 'cloudflare', 'vercel', 'lambda', 'distributed'];
+const BUILD_TARGETS = ['cli', 'node', 'sdk', 'browser', 'cloudflare', 'vercel', 'lambda', 'distributed', 'mcpb'];
 
 export function registerBuildCommands(program: Command): void {
   program
@@ -11,6 +11,12 @@ export function registerBuildCommands(program: Command): void {
     .option('--js', 'Output JS bundle instead of native binary (cli target only)')
     .option('-o, --out-dir <dir>', 'Output directory')
     .option('-e, --entry <path>', 'Manually specify entry file path')
+    // MCPB-specific flags
+    .option('--sea', 'Build an SEA binary for the host platform and embed it in the bundle (mcpb target)')
+    .option('--merge-from <dir>', 'Directory of pre-built cross-platform SEA binaries to merge (mcpb target)')
+    .option('--icon <path>', 'Override icon path (mcpb target)')
+    .option('--no-deterministic', 'Disable deterministic archive output (mcpb target)')
+    .option('--stage-only', 'Leave the MCPB staging directory intact and skip zipping (mcpb target)')
     .action(async (options) => {
       options.outDir = options.outDir || 'dist';
       const { runBuild } = await import('./index.js');

--- a/libs/cli/src/commands/mcpb/register.ts
+++ b/libs/cli/src/commands/mcpb/register.ts
@@ -1,0 +1,13 @@
+import type { Command } from 'commander';
+
+export function registerMcpbCommands(program: Command): void {
+  const mcpb = program.command('mcpb').description('Manage MCPB (MCP Bundle) archives');
+
+  mcpb
+    .command('validate <path>')
+    .description('Validate a .mcpb archive against the MCPB v0.3 specification')
+    .action(async (archivePath: string) => {
+      const { runValidate } = await import('./validate.js');
+      await runValidate(archivePath);
+    });
+}

--- a/libs/cli/src/commands/mcpb/validate.ts
+++ b/libs/cli/src/commands/mcpb/validate.ts
@@ -1,0 +1,32 @@
+import * as path from 'path';
+
+import { c } from '../../core/colors';
+import { validateMcpb } from '../build/mcpb/validate';
+
+export async function runValidate(archivePath: string): Promise<void> {
+  const abs = path.resolve(process.cwd(), archivePath);
+  console.log(`${c('cyan', '[mcpb:validate]')} ${path.relative(process.cwd(), abs)}`);
+
+  const result = await validateMcpb(abs);
+
+  if (result.manifest) {
+    console.log(`${c('gray', '[mcpb:validate]')} name=${result.manifest.name} version=${result.manifest.version}`);
+    console.log(
+      `${c('gray', '[mcpb:validate]')} tools=${result.manifest.tools?.length ?? 0} prompts=${result.manifest.prompts?.length ?? 0} user_config=${Object.keys(result.manifest.user_config ?? {}).length}`,
+    );
+  }
+
+  for (const w of result.warnings) {
+    console.log(`${c('yellow', '[mcpb:validate]')} warning: ${w}`);
+  }
+
+  if (result.ok) {
+    console.log(`${c('green', '[mcpb:validate]')} archive is valid`);
+    return;
+  }
+
+  for (const e of result.errors) {
+    console.error(`${c('red', '[mcpb:validate]')} ${e}`);
+  }
+  throw new Error(`MCPB validation failed (${result.errors.length} error${result.errors.length === 1 ? '' : 's'})`);
+}

--- a/libs/cli/src/config/__tests__/frontmcp-config.schema.spec.ts
+++ b/libs/cli/src/config/__tests__/frontmcp-config.schema.spec.ts
@@ -106,6 +106,75 @@ describe('frontmcpConfigSchema', () => {
       expect(result.success).toBe(true);
     });
 
+    it('should accept minimal mcpb target', () => {
+      const result = frontmcpConfigSchema.safeParse({
+        name: 'my-server',
+        deployments: [{ target: 'mcpb' }],
+      });
+      expect(result.success).toBe(true);
+    });
+
+    it('should accept fully populated mcpb target', () => {
+      const result = frontmcpConfigSchema.safeParse({
+        name: 'my-server',
+        version: '1.2.3',
+        deployments: [
+          {
+            target: 'mcpb',
+            displayName: 'My Server',
+            longDescription: '# My Server\n\nA sample MCP bundle.',
+            author: { name: 'Acme', email: 'hello@acme.dev', url: 'https://acme.dev' },
+            license: 'Apache-2.0',
+            homepage: 'https://acme.dev/my-server',
+            repository: { type: 'git', url: 'https://github.com/acme/my-server' },
+            documentation: 'https://docs.acme.dev',
+            support: 'https://github.com/acme/my-server/issues',
+            icon: 'assets/icon.png',
+            keywords: ['mcp', 'demo'],
+            privacyPolicies: ['https://acme.dev/privacy'],
+            compatibility: {
+              claude_desktop: '>=1.0.0',
+              platforms: ['darwin', 'linux', 'win32'],
+              runtimes: { node: '>=22.0.0' },
+            },
+            userConfig: {
+              apiKey: {
+                type: 'string',
+                title: 'API Key',
+                description: 'API token for the external service',
+                required: true,
+                sensitive: true,
+              },
+              maxItems: {
+                type: 'number',
+                title: 'Max Items',
+                default: 50,
+                min: 1,
+                max: 1000,
+              },
+            },
+            sea: { enabled: true, mergeFrom: './dist/ci-binaries' },
+            includeNodeModules: false,
+            deterministic: true,
+          },
+        ],
+      });
+      expect(result.success).toBe(true);
+    });
+
+    it('should accept mcpb target with string repository', () => {
+      const result = frontmcpConfigSchema.safeParse({
+        name: 'my-server',
+        deployments: [
+          {
+            target: 'mcpb',
+            repository: 'https://github.com/acme/my-server',
+          },
+        ],
+      });
+      expect(result.success).toBe(true);
+    });
+
     it('should accept CSP with array directives inside deployment', () => {
       const result = frontmcpConfigSchema.safeParse({
         name: 'csp-server',
@@ -204,6 +273,44 @@ describe('frontmcpConfigSchema', () => {
       const result = frontmcpConfigSchema.safeParse({
         name: 'my-server',
         deployments: [{ target: 'browser', server: { http: { port: 3000 } } }],
+      });
+      expect(result.success).toBe(false);
+    });
+
+    it('should reject mcpb userConfig entry with unknown type', () => {
+      const result = frontmcpConfigSchema.safeParse({
+        name: 'my-server',
+        deployments: [
+          {
+            target: 'mcpb',
+            userConfig: {
+              // biome-ignore lint/suspicious/noExplicitAny: intentional invalid type
+              foo: { type: 'bogus' as any, title: 'Foo' },
+            },
+          },
+        ],
+      });
+      expect(result.success).toBe(false);
+    });
+
+    it('should reject mcpb with invalid email in author', () => {
+      const result = frontmcpConfigSchema.safeParse({
+        name: 'my-server',
+        deployments: [{ target: 'mcpb', author: { name: 'Acme', email: 'not-an-email' } }],
+      });
+      expect(result.success).toBe(false);
+    });
+
+    it('should reject mcpb with invalid platforms', () => {
+      const result = frontmcpConfigSchema.safeParse({
+        name: 'my-server',
+        deployments: [
+          {
+            target: 'mcpb',
+            // biome-ignore lint/suspicious/noExplicitAny: intentional invalid platform
+            compatibility: { platforms: ['bsd' as any] },
+          },
+        ],
       });
       expect(result.success).toBe(false);
     });

--- a/libs/cli/src/config/frontmcp-config.schema.ts
+++ b/libs/cli/src/config/frontmcp-config.schema.ts
@@ -213,6 +213,103 @@ export const sdkDeploymentSchema = deploymentBaseSchema
   })
   .strict();
 
+// ============================================
+// MCPB (MCP Bundles) target — produces a .mcpb ZIP archive
+// per https://github.com/modelcontextprotocol/mcpb (manifest_version 0.3)
+// ============================================
+
+export const mcpbAuthorSchema = z
+  .object({
+    name: z.string(),
+    email: z.string().email().optional(),
+    url: z.string().url().optional(),
+  })
+  .strict();
+
+export const mcpbUserConfigEntrySchema = z
+  .object({
+    type: z.enum(['string', 'number', 'boolean', 'directory', 'file']),
+    title: z.string(),
+    description: z.string().optional(),
+    required: z.boolean().optional(),
+    default: z.union([z.string(), z.number(), z.boolean()]).optional(),
+    multiple: z.boolean().optional(),
+    sensitive: z.boolean().optional(),
+    min: z.number().optional(),
+    max: z.number().optional(),
+  })
+  .strict();
+
+export const mcpbCompatibilitySchema = z
+  .object({
+    claude_desktop: z.string().optional(),
+    platforms: z.array(z.enum(['darwin', 'win32', 'linux'])).optional(),
+    runtimes: z
+      .object({
+        node: z.string().optional(),
+        python: z.string().optional(),
+      })
+      .strict()
+      .optional(),
+  })
+  .strict();
+
+export const mcpbRepositorySchema = z.union([
+  z.string(),
+  z
+    .object({
+      type: z.string(),
+      url: z.string(),
+    })
+    .strict(),
+]);
+
+export const mcpbDeploymentSchema = deploymentBaseSchema
+  .extend({
+    target: z.literal('mcpb'),
+    /** Human-friendly display name shown in installer dialog. */
+    displayName: z.string().optional(),
+    /** Long markdown description shown in extension details. */
+    longDescription: z.string().optional(),
+    /** Author object (name/email/url). Overrides parsed package.json.author. */
+    author: mcpbAuthorSchema.optional(),
+    /** SPDX license identifier. Overrides package.json.license. */
+    license: z.string().optional(),
+    /** Project homepage URL. */
+    homepage: z.string().url().optional(),
+    /** Source repository (string URL or {type, url}). */
+    repository: mcpbRepositorySchema.optional(),
+    /** Documentation URL. */
+    documentation: z.string().url().optional(),
+    /** Support URL (issues/contact). */
+    support: z.string().optional(),
+    /** Path to icon (PNG) relative to project root. */
+    icon: z.string().optional(),
+    /** Keywords for search. */
+    keywords: z.array(z.string()).optional(),
+    /** Privacy policy URLs for external services this bundle talks to. */
+    privacyPolicies: z.array(z.string()).optional(),
+    /** Runtime/platform/client compatibility constraints. */
+    compatibility: mcpbCompatibilitySchema.optional(),
+    /** User-configurable inputs (injected as env vars at runtime). */
+    userConfig: z.record(z.string(), mcpbUserConfigEntrySchema).optional(),
+    /** Single-executable-application binary integration. */
+    sea: z
+      .object({
+        /** Build SEA binary for host platform and include via platform_overrides. */
+        enabled: z.boolean().optional(),
+        /** Directory of pre-built SEA binaries to merge (e.g., CI artifacts). */
+        mergeFrom: z.string().optional(),
+      })
+      .strict()
+      .optional(),
+    /** Include node_modules/ in archive (opt-in, defaults off). */
+    includeNodeModules: z.boolean().optional(),
+    /** Produce byte-identical archives across builds. @default true */
+    deterministic: z.boolean().optional(),
+  })
+  .strict();
+
 export const deploymentTargetSchema = z.discriminatedUnion('target', [
   nodeDeploymentSchema,
   distributedDeploymentSchema,
@@ -222,6 +319,7 @@ export const deploymentTargetSchema = z.discriminatedUnion('target', [
   cloudflareDeploymentSchema,
   browserDeploymentSchema,
   sdkDeploymentSchema,
+  mcpbDeploymentSchema,
 ]);
 
 // ============================================

--- a/libs/cli/src/config/frontmcp-config.types.ts
+++ b/libs/cli/src/config/frontmcp-config.types.ts
@@ -184,7 +184,8 @@ export type DeploymentTargetType =
   | 'lambda'
   | 'cloudflare'
   | 'browser'
-  | 'sdk';
+  | 'sdk'
+  | 'mcpb';
 
 interface DeploymentBase {
   /** Deployment target type. */
@@ -249,6 +250,85 @@ export interface SdkDeployment extends DeploymentBase {
   /** No server — SDK is a library. */
 }
 
+// ============================================
+// MCPB Deployment (MCP Bundle)
+// ============================================
+
+export interface McpbAuthor {
+  name: string;
+  email?: string;
+  url?: string;
+}
+
+export type McpbUserConfigType = 'string' | 'number' | 'boolean' | 'directory' | 'file';
+
+export interface McpbUserConfigEntry {
+  type: McpbUserConfigType;
+  title: string;
+  description?: string;
+  required?: boolean;
+  default?: string | number | boolean;
+  multiple?: boolean;
+  sensitive?: boolean;
+  min?: number;
+  max?: number;
+}
+
+export interface McpbCompatibility {
+  /** Semver range for Claude Desktop (e.g., ">=1.0.0"). */
+  claude_desktop?: string;
+  /** Supported platforms. */
+  platforms?: Array<'darwin' | 'win32' | 'linux'>;
+  /** Runtime version constraints. */
+  runtimes?: {
+    node?: string;
+    python?: string;
+  };
+}
+
+export type McpbRepository = string | { type: string; url: string };
+
+export interface McpbDeployment extends DeploymentBase {
+  target: 'mcpb';
+  /** Human-friendly display name. */
+  displayName?: string;
+  /** Long markdown description. */
+  longDescription?: string;
+  /** Author object — overrides parsed package.json.author. */
+  author?: McpbAuthor;
+  /** SPDX license identifier — overrides package.json.license. */
+  license?: string;
+  /** Project homepage URL. */
+  homepage?: string;
+  /** Source repository. */
+  repository?: McpbRepository;
+  /** Documentation URL. */
+  documentation?: string;
+  /** Support URL (issues/contact). */
+  support?: string;
+  /** Path to icon (PNG) relative to project root. */
+  icon?: string;
+  /** Keywords for search. */
+  keywords?: string[];
+  /** Privacy policy URLs. */
+  privacyPolicies?: string[];
+  /** Runtime/platform compatibility constraints. */
+  compatibility?: McpbCompatibility;
+  /** User-configurable inputs (injected as env vars). */
+  userConfig?: Record<string, McpbUserConfigEntry>;
+  /** Single-executable binary integration. */
+  sea?: {
+    /** Build SEA binary for host platform. */
+    enabled?: boolean;
+    /** Directory of pre-built cross-platform SEA binaries to merge. */
+    mergeFrom?: string;
+  };
+  /** Include node_modules/ in archive (opt-in). */
+  includeNodeModules?: boolean;
+  /** Deterministic archive output. @default true */
+  deterministic?: boolean;
+}
+
 export type DeploymentTarget =
   | NodeDeployment
   | DistributedDeployment
@@ -257,7 +337,8 @@ export type DeploymentTarget =
   | LambdaDeployment
   | CloudflareDeployment
   | BrowserDeployment
-  | SdkDeployment;
+  | SdkDeployment
+  | McpbDeployment;
 
 // ============================================
 // Top-Level Config

--- a/libs/cli/src/core/__tests__/program.spec.ts
+++ b/libs/cli/src/core/__tests__/program.spec.ts
@@ -11,7 +11,7 @@ describe('createProgram', () => {
     expect(program.version()).toMatch(/^\d+\.\d+\.\d+/);
   });
 
-  it('should register all 19 commands', () => {
+  it('should register all top-level commands', () => {
     const program = createProgram();
     const names = program.commands.map((c) => c.name()).sort();
     expect(names).toEqual([
@@ -25,6 +25,7 @@ describe('createProgram', () => {
       'install',
       'list',
       'logs',
+      'mcpb',
       'restart',
       'service',
       'skills',

--- a/libs/cli/src/core/args.ts
+++ b/libs/cli/src/core/args.ts
@@ -23,7 +23,16 @@ export type Command =
   | 'configure';
 
 export type DeploymentAdapter = 'node' | 'vercel' | 'lambda' | 'cloudflare' | 'distributed';
-export type BuildTarget = 'cli' | 'node' | 'sdk' | 'browser' | 'cloudflare' | 'vercel' | 'lambda' | 'distributed';
+export type BuildTarget =
+  | 'cli'
+  | 'node'
+  | 'sdk'
+  | 'browser'
+  | 'cloudflare'
+  | 'vercel'
+  | 'lambda'
+  | 'distributed'
+  | 'mcpb';
 
 const DEPLOYMENT_ADAPTERS: readonly DeploymentAdapter[] = ['node', 'vercel', 'lambda', 'cloudflare', 'distributed'];
 const BUILD_TARGETS: readonly BuildTarget[] = [
@@ -35,6 +44,7 @@ const BUILD_TARGETS: readonly BuildTarget[] = [
   'vercel',
   'lambda',
   'distributed',
+  'mcpb',
 ];
 
 export function isDeploymentAdapter(val: string): val is DeploymentAdapter {
@@ -62,6 +72,12 @@ export interface ParsedArgs {
   buildTarget?: BuildTarget;
   // Build --js flag (cli target: produce JS bundle instead of SEA binary)
   js?: boolean;
+  // MCPB flags
+  sea?: boolean;
+  mergeFrom?: string;
+  icon?: string;
+  noDeterministic?: boolean;
+  stageOnly?: boolean;
   // Create command flags
   yes?: boolean;
   target?: DeploymentAdapter;

--- a/libs/cli/src/core/bridge.ts
+++ b/libs/cli/src/core/bridge.ts
@@ -1,4 +1,10 @@
-import { BuildTarget, DeploymentAdapter, PackageManagerOption, ParsedArgs, RedisSetupOption } from './args';
+import {
+  type BuildTarget,
+  type DeploymentAdapter,
+  type PackageManagerOption,
+  type ParsedArgs,
+  type RedisSetupOption,
+} from './args';
 
 /**
  * Convert commander's parsed command name, positional arguments, and options
@@ -19,6 +25,11 @@ export function toParsedArgs(
   if (commandName === 'build') {
     if (options['target'] !== undefined) out.buildTarget = options['target'] as BuildTarget;
     if (options['js'] !== undefined) out.js = options['js'] as boolean;
+    if (options['sea'] !== undefined) out.sea = options['sea'] as boolean;
+    if (options['mergeFrom'] !== undefined) out.mergeFrom = options['mergeFrom'] as string;
+    if (options['icon'] !== undefined) out.icon = options['icon'] as string;
+    if (options['deterministic'] === false) out.noDeterministic = true;
+    if (options['stageOnly'] !== undefined) out.stageOnly = options['stageOnly'] as boolean;
   }
 
   // Create

--- a/libs/cli/src/core/program.ts
+++ b/libs/cli/src/core/program.ts
@@ -1,12 +1,14 @@
 import { Command } from 'commander';
-import { getSelfVersion } from './version';
-import { registerDevCommands } from '../commands/dev/register';
+
 import { registerBuildCommands } from '../commands/build/register';
-import { registerScaffoldCommands } from '../commands/scaffold/register';
-import { registerPmCommands } from '../commands/pm/register';
+import { registerDevCommands } from '../commands/dev/register';
+import { registerMcpbCommands } from '../commands/mcpb/register';
 import { registerPackageCommands } from '../commands/package/register';
+import { registerPmCommands } from '../commands/pm/register';
+import { registerScaffoldCommands } from '../commands/scaffold/register';
 import { registerSkillsCommands } from '../commands/skills/register';
 import { customizeHelp } from './help';
+import { getSelfVersion } from './version';
 
 export function createProgram(): Command {
   const program = new Command();
@@ -22,6 +24,7 @@ export function createProgram(): Command {
   registerPmCommands(program);
   registerPackageCommands(program);
   registerSkillsCommands(program);
+  registerMcpbCommands(program);
   customizeHelp(program);
 
   return program;

--- a/libs/skills/catalog/frontmcp-deployment/examples/build-for-mcpb/mcpb-bundle-build.md
+++ b/libs/skills/catalog/frontmcp-deployment/examples/build-for-mcpb/mcpb-bundle-build.md
@@ -1,0 +1,117 @@
+---
+name: mcpb-bundle-build
+reference: build-for-mcpb
+level: basic
+description: 'Produce a .mcpb archive for Claude Desktop with metadata, tools, and install-time user_config.'
+tags: [deployment, mcpb, bundle, claude-desktop, user-config]
+features:
+  - 'Using `frontmcp build --target mcpb` to produce a single `.mcpb` archive'
+  - 'Translating `setup.steps` into MCPB `user_config` + `${user_config.KEY}` env bindings'
+  - 'Validating the archive round-trip with `frontmcp mcpb validate`'
+---
+
+# MCPB Bundle Build
+
+Produce a .mcpb archive for Claude Desktop with metadata, tools, and install-time user_config.
+
+## Code
+
+```typescript
+// src/main.ts
+import { App, FrontMcp, Tool, ToolContext, z } from '@frontmcp/sdk';
+
+@Tool({
+  name: 'greet',
+  description: 'Greet a user by name',
+  inputSchema: { name: z.string() },
+})
+class GreetTool extends ToolContext<{ name: string }> {
+  async execute(input: { name: string }) {
+    const apiBase = process.env.API_BASE ?? 'https://api.example.com';
+    return {
+      content: [{ type: 'text' as const, text: `Hello, ${input.name}! (via ${apiBase})` }],
+    };
+  }
+}
+
+@App({ name: 'GreeterApp', tools: [GreetTool] })
+class GreeterApp {}
+
+@FrontMcp({
+  info: { name: 'greeter-mcpb', version: '1.0.0' },
+  apps: [GreeterApp],
+})
+export default class GreeterServer {}
+```
+
+```js
+// frontmcp.config.js
+const { z } = require('zod');
+
+module.exports = {
+  name: 'greeter-mcpb',
+  version: '1.0.0',
+  entry: './src/main.ts',
+  nodeVersion: '>=22.0.0',
+  deployments: [
+    {
+      target: 'mcpb',
+      displayName: 'Greeter',
+      longDescription: '# Greeter\n\nSays hi to the configured API.',
+      author: { name: 'Acme', email: 'hello@acme.dev' },
+      license: 'Apache-2.0',
+      homepage: 'https://acme.dev/greeter',
+      repository: 'https://github.com/acme/greeter',
+      icon: 'assets/icon.png',
+      keywords: ['greeting', 'demo'],
+      compatibility: {
+        claude_desktop: '>=1.0.0',
+        platforms: ['darwin', 'linux', 'win32'],
+        runtimes: { node: '>=22.0.0' },
+      },
+      sea: { enabled: true },
+    },
+  ],
+  // Install-time questions — each step becomes a user_config entry + env var.
+  setup: {
+    steps: [
+      {
+        id: 'api-base',
+        prompt: 'API Base URL',
+        description: 'Endpoint the greeter should call',
+        env: 'API_BASE',
+        schema: z.string().url().default('https://api.example.com'),
+      },
+      {
+        id: 'api-token',
+        prompt: 'API Token',
+        description: 'Personal access token for the API',
+        env: 'API_TOKEN',
+        sensitive: true,
+        schema: z.string().min(1),
+      },
+    ],
+  },
+};
+```
+
+```bash
+# Build — produces dist/mcpb/greeter-mcpb-1.0.0.mcpb
+frontmcp build --target mcpb
+
+# Validate the archive
+frontmcp mcpb validate dist/mcpb/greeter-mcpb-1.0.0.mcpb
+
+# Open in Claude Desktop to install
+open dist/mcpb/greeter-mcpb-1.0.0.mcpb
+```
+
+## What This Demonstrates
+
+- Using `frontmcp build --target mcpb` to produce a single `.mcpb` archive
+- Translating `setup.steps` into MCPB `user_config` + `${user_config.KEY}` env bindings
+- Validating the archive round-trip with `frontmcp mcpb validate`
+
+## Related
+
+- See `build-for-mcpb` for the full manifest reference, user_config type resolution, SEA binary packaging, and cross-platform `--merge-from` workflow.

--- a/libs/skills/catalog/frontmcp-deployment/references/build-for-mcpb.md
+++ b/libs/skills/catalog/frontmcp-deployment/references/build-for-mcpb.md
@@ -1,0 +1,198 @@
+---
+name: build-for-mcpb
+description: Package a FrontMCP server as a .mcpb archive that Claude Desktop and other MCPB-aware clients install with one click
+---
+
+# Building an MCP Bundle (MCPB)
+
+Package your FrontMCP server as a `.mcpb` archive conforming to the
+[MCPB v0.3 spec](https://github.com/modelcontextprotocol/mcpb). Consumers
+double-click the file — the host client extracts it and runs the server over
+stdio. Metadata, tools, prompts, user-configurable inputs, and per-platform
+runtime overrides are all declared statically in `manifest.json`.
+
+## When to Use This Skill
+
+### Must Use
+
+- Distributing an MCP server to end users who install via Claude Desktop,
+  Cursor, or another MCPB-aware client — no CLI, no `npx`, no registry.
+- Attaching a single signed artifact with a stable hash to a GitHub release.
+- Exposing install-time configuration (tokens, paths, toggles) through the
+  client's native install dialog via `user_config`.
+
+### Recommended
+
+- Shipping optional platform-specific binaries so users without Node installed
+  can still run the server.
+- Producing reproducible builds — MCPB archives are deterministic by default
+  (same inputs → byte-identical output → matching SHA-256).
+
+### Skip When
+
+- You need an interactive CLI with subcommands per tool — use `build-for-cli`.
+- You're hosting the server yourself over HTTP — use `deploy-to-node` or a
+  serverless target (`deploy-to-vercel`, `deploy-to-lambda`, `deploy-to-cloudflare`).
+- You're embedding tools in an existing Node.js application — use `build-for-sdk`.
+
+> **Decision:** Choose `build-for-mcpb` when users install your server through
+> an MCPB-aware client; choose `build-for-cli` for terminal-first distribution.
+
+## Build Commands
+
+```bash
+# Basic bundle — dist/mcpb/{name}-{version}.mcpb
+frontmcp build --target mcpb
+
+# Include a SEA binary for the host platform
+frontmcp build --target mcpb --sea
+
+# Merge pre-built cross-platform binaries from CI
+frontmcp build --target mcpb --merge-from ./ci-bins
+
+# Skip zipping and inspect the staging directory
+frontmcp build --target mcpb --stage-only
+
+# Validate a produced archive
+frontmcp mcpb validate dist/mcpb/my-server-1.0.0.mcpb
+```
+
+## Requirements
+
+- **Node.js ≥ 22** at build time.
+- The entry file must export or instantiate a `@FrontMcp`-decorated class
+  (the build-time schema extractor boots it in introspection mode).
+- `@frontmcp/sdk` must be installed and reachable at the path used by the
+  build (never exclude it from bundling).
+- For `--sea` builds, Node.js ≥ 24 is required (SEA spec prerequisite).
+
+## What the Archive Contains
+
+```
+dist/mcpb/
+  my-server-1.0.0.mcpb              # the distributable artifact
+  __stage/                          # removed after successful zip
+    manifest.json                   # MCPB v0.3 manifest (generated)
+    server/
+      index.js                      # esbuild single-file CJS bundle
+      package.json                  # minimal { type: "commonjs" } marker
+      _skills/                      # when capabilities.skills
+    bin/                            # when --sea or --merge-from
+      darwin-arm64/my-server
+      win32-x64/my-server.exe
+    icon.png                        # when resolved
+    README.md                       # when present in project root
+```
+
+## Manifest Sources
+
+| MCPB field                                      | Source (priority order)                                                             |
+| ----------------------------------------------- | ----------------------------------------------------------------------------------- |
+| `name`, `version`                               | frontmcp.config → package.json                                                      |
+| `description`                                   | deployment.longDescription first line → package.json.description                    |
+| `author`                                        | deployment.author → parsed `package.json.author` string (`"Name <email> (url)"`)    |
+| `license`, `homepage`, `repository`, `keywords` | deployment override → package.json fallback                                         |
+| `icon`                                          | deployment.icon → package.json.icon → `icon.png` / `assets/icon.png` in cwd         |
+| `tools`                                         | Schema extraction (system tools like `execute-job` filtered out)                    |
+| `prompts`                                       | Schema extraction; emitted with `prompts_generated: true`                           |
+| `user_config`                                   | Translated from `setup.steps` + deployment.userConfig overrides                     |
+| `compatibility.runtimes.node`                   | deployment.compatibility.runtimes.node → frontmcp.config.nodeVersion → `">=22.0.0"` |
+| `compatibility.platforms`                       | deployment.compatibility.platforms → `["darwin","linux","win32"]`                   |
+
+## Setup Steps → user_config + env
+
+If your exec config declares a `setup.steps` questionnaire, each step becomes
+an MCPB `user_config` entry and a matching `mcp_config.env` variable wired via
+`${user_config.KEY}` substitution.
+
+Type resolution:
+
+| FrontMCP schema                                      | MCPB `type`           |
+| ---------------------------------------------------- | --------------------- |
+| `z.string()`                                         | `string`              |
+| `z.number()` / `z.number().int()`                    | `number`              |
+| `z.boolean()`                                        | `boolean`             |
+| `z.array(z.string())`                                | `string` + `multiple` |
+| `deployment.userConfig.X.type: 'directory'` override | `directory`           |
+| `deployment.userConfig.X.type: 'file'` override      | `file`                |
+
+Secrets: defaults are stripped when `sensitive: true` so tokens never appear
+in the manifest.
+
+Unsupported: `showWhen` / `next` branching — MCPB forms are flat; the
+generator logs a warning and renders every step unconditionally.
+
+## Cross-Platform Binaries
+
+Node SEA builds for the host OS/arch only. To ship a `.mcpb` that runs
+binary-only on every platform, run the build in a CI matrix and assemble with
+`--merge-from`:
+
+```
+ci-bins/
+  darwin-arm64/my-server
+  darwin-x64/my-server
+  linux-x64/my-server
+  win32-x64/my-server.exe
+```
+
+Platforms without a binary automatically fall through to the Node command +
+bundled JS, so a partial matrix is fine.
+
+## Common Patterns
+
+| Pattern                 | Correct                                    | Incorrect                    | Why                                                             |
+| ----------------------- | ------------------------------------------ | ---------------------------- | --------------------------------------------------------------- |
+| Entry path              | `${__dirname}/server/index.js`             | Absolute host path           | Host app extracts to a fresh tmp dir each install               |
+| User config reference   | `${user_config.apiToken}`                  | `$API_TOKEN`                 | MCPB substitution happens at install time, not shell expansion  |
+| Sensitive defaults      | Omit `default`                             | Emit the real token          | Manifests ship in plaintext; anything in `default` is committed |
+| External services       | Declare in `privacy_policies`              | Omit                         | Stores/clients surface these during install review              |
+| Multi-platform binaries | CI matrix + `--merge-from`                 | Build on one OS and ship     | SEA binaries are OS/arch-specific                               |
+| Prompt `text`           | Leave empty, set `prompts_generated: true` | Try to serialize `execute()` | JS logic doesn't fit MCPB's static `${arguments.KEY}` template  |
+
+## Verification Checklist
+
+**Build**
+
+- [ ] `frontmcp build --target mcpb` exits 0
+- [ ] `dist/mcpb/{name}-{version}.mcpb` exists and is a valid ZIP
+- [ ] Archive size is reasonable (< 50 MB typical; warn-threshold fires at 50 MB)
+- [ ] Two back-to-back builds produce identical SHA-256 (deterministic mode on)
+
+**Manifest**
+
+- [ ] `manifest_version: "0.3"`
+- [ ] `server.entry_point` matches the file present in the archive
+- [ ] Every `${user_config.KEY}` reference has a matching `user_config[KEY]`
+- [ ] No `${…}` substitutions outside the allow-list
+
+**Install**
+
+- [ ] Opening the `.mcpb` in Claude Desktop shows the expected name, description, author, tools
+- [ ] `user_config` form renders with correct titles / descriptions / default values
+- [ ] Server starts over stdio and answers `initialize` / `tools/list`
+
+## Troubleshooting
+
+| Problem                                                | Cause                                                          | Solution                                                                                                                    |
+| ------------------------------------------------------ | -------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------- | ---------- | ----------- | --------- | ------------------------ |
+| `@frontmcp/sdk is required for schema extraction`      | SDK missing or externalized from bundle                        | Ensure `@frontmcp/sdk` is installed                                                                                         |
+| Archive > 100 MB                                       | node_modules bundled or node runtime bloated                   | Tune `build.esbuild.external`, drop `--sea`, or disable `includeNodeModules`                                                |
+| `Unknown substitution variable` on validate            | Typo in `mcp_config.args` / `env`                              | Only `__dirname`, `HOME`, `DESKTOP`, `DOCUMENTS`, `DOWNLOADS`, `pathSeparator`, and declared `user_config` keys are allowed |
+| `entry_point is not present in archive`                | Custom `--entry` flag or bundler moved the file                | Re-run without the override, or update the config's `entry`                                                                 |
+| Two builds produce different SHA-256                   | `--no-deterministic` set, or inputs embed a changing timestamp | Restore deterministic mode; scan your sources for live date/time values                                                     |
+| `platform_overrides.{platform}.command` missing binary | `--merge-from` folders don't match MCPB platform keys          | Expected layout: `{dir}/{darwin-arm64                                                                                       | darwin-x64 | linux-arm64 | linux-x64 | win32-x64}/{name}[.exe]` |
+
+## Examples
+
+| Example                                                                | Level | Description                                                                                    |
+| ---------------------------------------------------------------------- | ----- | ---------------------------------------------------------------------------------------------- |
+| [`mcpb-bundle-build`](../examples/build-for-mcpb/mcpb-bundle-build.md) | Basic | Produce a .mcpb archive for Claude Desktop with metadata, tools, and install-time user_config. |
+
+> See all examples in [`examples/build-for-mcpb/`](../examples/build-for-mcpb/)
+
+## Reference
+
+- **MCPB spec:** <https://github.com/modelcontextprotocol/mcpb>
+- **Docs:** <https://docs.agentfront.dev/frontmcp/deployment/mcpb>
+- **Related skills:** `build-for-cli`, `build-for-sdk`, `mcp-client-integration`

--- a/libs/skills/catalog/frontmcp-deployment/references/build-for-mcpb.md
+++ b/libs/skills/catalog/frontmcp-deployment/references/build-for-mcpb.md
@@ -64,11 +64,11 @@ frontmcp mcpb validate dist/mcpb/my-server-1.0.0.mcpb
   (the build-time schema extractor boots it in introspection mode).
 - `@frontmcp/sdk` must be installed and reachable at the path used by the
   build (never exclude it from bundling).
-- For `--sea` builds, Node.js ≥ 24 is required (SEA spec prerequisite).
+- For `--sea` builds, Node.js ≥ 24 is required (FrontMCP targets the current SEA API).
 
 ## What the Archive Contains
 
-```
+```text
 dist/mcpb/
   my-server-1.0.0.mcpb              # the distributable artifact
   __stage/                          # removed after successful zip
@@ -128,7 +128,7 @@ Node SEA builds for the host OS/arch only. To ship a `.mcpb` that runs
 binary-only on every platform, run the build in a CI matrix and assemble with
 `--merge-from`:
 
-```
+```text
 ci-bins/
   darwin-arm64/my-server
   darwin-x64/my-server
@@ -175,13 +175,24 @@ bundled JS, so a partial matrix is fine.
 ## Troubleshooting
 
 | Problem                                                | Cause                                                          | Solution                                                                                                                    |
-| ------------------------------------------------------ | -------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------- | ---------- | ----------- | --------- | ------------------------ |
+| ------------------------------------------------------ | -------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------- |
 | `@frontmcp/sdk is required for schema extraction`      | SDK missing or externalized from bundle                        | Ensure `@frontmcp/sdk` is installed                                                                                         |
 | Archive > 100 MB                                       | node_modules bundled or node runtime bloated                   | Tune `build.esbuild.external`, drop `--sea`, or disable `includeNodeModules`                                                |
 | `Unknown substitution variable` on validate            | Typo in `mcp_config.args` / `env`                              | Only `__dirname`, `HOME`, `DESKTOP`, `DOCUMENTS`, `DOWNLOADS`, `pathSeparator`, and declared `user_config` keys are allowed |
 | `entry_point is not present in archive`                | Custom `--entry` flag or bundler moved the file                | Re-run without the override, or update the config's `entry`                                                                 |
 | Two builds produce different SHA-256                   | `--no-deterministic` set, or inputs embed a changing timestamp | Restore deterministic mode; scan your sources for live date/time values                                                     |
-| `platform_overrides.{platform}.command` missing binary | `--merge-from` folders don't match MCPB platform keys          | Expected layout: `{dir}/{darwin-arm64                                                                                       | darwin-x64 | linux-arm64 | linux-x64 | win32-x64}/{name}[.exe]` |
+| `platform_overrides.{platform}.command` missing binary | `--merge-from` folders don't match MCPB platform keys          | See the expected layout below                                                                                               |
+
+Expected `--merge-from` layout (platform dirs must match MCPB platform keys):
+
+```text
+{dir}/
+  darwin-arm64/{name}
+  darwin-x64/{name}
+  linux-arm64/{name}
+  linux-x64/{name}
+  win32-x64/{name}.exe
+```
 
 ## Examples
 

--- a/libs/skills/catalog/skills-manifest.json
+++ b/libs/skills/catalog/skills-manifest.json
@@ -513,6 +513,23 @@
           ]
         },
         {
+          "name": "build-for-mcpb",
+          "description": "Package a FrontMCP server as a .mcpb archive that Claude Desktop and other MCPB-aware clients install with one click",
+          "examples": [
+            {
+              "name": "mcpb-bundle-build",
+              "description": "Produce a .mcpb archive for Claude Desktop with metadata, tools, and install-time user_config.",
+              "level": "basic",
+              "tags": ["deployment", "mcpb", "bundle", "claude-desktop", "user-config"],
+              "features": [
+                "Using `frontmcp build --target mcpb` to produce a single `.mcpb` archive",
+                "Translating `setup.steps` into MCPB `user_config` + `${user_config.KEY}` env bindings",
+                "Validating the archive round-trip with `frontmcp mcpb validate`"
+              ]
+            }
+          ]
+        },
+        {
           "name": "build-for-sdk",
           "description": "Build a FrontMCP server as an embeddable library with create() and connect() APIs",
           "examples": [

--- a/yarn.lock
+++ b/yarn.lock
@@ -4350,6 +4350,20 @@
   dependencies:
     "@types/yargs-parser" "*"
 
+"@types/yauzl@^2.10.3":
+  version "2.10.3"
+  resolved "https://registry.yarnpkg.com/@types/yauzl/-/yauzl-2.10.3.tgz#e9b2808b4f109504a03cda958259876f61017999"
+  integrity sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q==
+  dependencies:
+    "@types/node" "*"
+
+"@types/yazl@^2.4.5":
+  version "2.4.6"
+  resolved "https://registry.yarnpkg.com/@types/yazl/-/yazl-2.4.6.tgz#482af719b6feb709ee8cb64fd9cec2628f55a180"
+  integrity sha512-/ifFjQtcKaoZOjl5NNCQRR0fAKafB3Foxd7J/WvFPTMea46zekapcR30uzkwIkKAAuq5T6d0dkwz754RFH27hg==
+  dependencies:
+    "@types/node" "*"
+
 "@typescript-eslint/eslint-plugin@8.55.0":
   version "8.55.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.55.0.tgz#086d2ef661507b561f7b17f62d3179d692a0765f"
@@ -5649,6 +5663,11 @@ buffer-crc32@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/buffer-crc32/-/buffer-crc32-1.0.0.tgz#a10993b9055081d55304bd9feb4a072de179f405"
   integrity sha512-Db1SbgBS/fg/392AblrMJk97KggmvYhr4pB5ZIMTWtaivCPMWLkmb7m21cJvpvgK+J3nsU2CmmixNBZx4vFj/w==
+
+buffer-crc32@~0.2.3:
+  version "0.2.13"
+  resolved "https://registry.yarnpkg.com/buffer-crc32/-/buffer-crc32-0.2.13.tgz#0d333e3f00eac50aa1454abd30ef8c2a5d9a7242"
+  integrity sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==
 
 buffer-equal-constant-time@^1.0.1:
   version "1.0.1"
@@ -11640,6 +11659,11 @@ peek-stream@^1.1.0:
     duplexify "^3.5.0"
     through2 "^2.0.3"
 
+pend@~1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/pend/-/pend-1.2.0.tgz#7a57eb550a6783f9115331fcf4663d5c8e007a50"
+  integrity sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==
+
 performance-now@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/performance-now/-/performance-now-2.1.0.tgz#6309f4e0e5fa913ec1c69307ae364b4b377c9e7b"
@@ -15191,6 +15215,21 @@ yargs@^17.6.2, yargs@^17.7.2:
     string-width "^4.2.3"
     y18n "^5.0.5"
     yargs-parser "^21.1.1"
+
+yauzl@^3.2.0:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/yauzl/-/yauzl-3.3.0.tgz#5be5e287b9a8112941c177734a34bf61a3e11bb4"
+  integrity sha512-PtGEvEP30p7sbIBJKUBjUnqgTVOyMURc4dLo9iNyAJnNIEz9pm88cCXF21w94Kg3k6RXkeZh5DHOGS0qEONvNQ==
+  dependencies:
+    buffer-crc32 "~0.2.3"
+    pend "~1.2.0"
+
+yazl@^3.3.1:
+  version "3.3.1"
+  resolved "https://registry.yarnpkg.com/yazl/-/yazl-3.3.1.tgz#a69abad02d80739d3b1a7ffcca8434422477432c"
+  integrity sha512-BbETDVWG+VcMUle37k5Fqp//7SDOK2/1+T7X8TD96M3D9G8jK5VLUdQVdVjGi8im7FGkazX7kk5hkU8X4L5Bng==
+  dependencies:
+    buffer-crc32 "^1.0.0"
 
 yn@3.1.1:
   version "3.1.1"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added MCP Bundle (MCPB) deployment target and `frontmcp build --target mcpb`
  * Added `frontmcp mcpb validate <path>`
  * Build flags: `--sea`, `--merge-from <dir>`, `--icon <path>`, `--no-deterministic`, `--stage-only`

* **Documentation**
  * New MCPB guide, CLI reference, examples, and troubleshooting (build/validate/workflow)

* **Tests**
  * End-to-end validation and determinism tests for MCPB archives
<!-- end of auto-generated comment: release notes by coderabbit.ai -->