### PR TITLE
feat: normalize internal @frontmcp/* dependency versions to exact rel…

### DIFF
--- a/apps/e2e/demo-e2e-cli-tasks/e2e/cli-tasks.e2e.spec.ts
+++ b/apps/e2e/demo-e2e-cli-tasks/e2e/cli-tasks.e2e.spec.ts
@@ -157,11 +157,12 @@ test.describe('CLI Task Runner E2E', () => {
 
   test('SIGKILL of worker triggers orphan detection (record → failed)', async ({ mcp }) => {
     const { taskId } = await createTask(mcp, 'crash', { delayMs: 100 });
-    // Wait long enough for the crash tool to SIGKILL itself.
-    await new Promise((r) => setTimeout(r, 1500));
-    const snap = await getTask(mcp, taskId);
-    expect(snap.result?.status).toBe('failed');
-    expect(snap.result?.statusMessage).toMatch(/runner exited/i);
+    // Worker SIGKILLs itself after delayMs; orphan detection fires on the next
+    // tasks/get. Process spawn + kill timing varies across CI runners, so poll
+    // instead of a single static wait.
+    const snap = await pollUntil(mcp, taskId, (s) => s === 'failed' || s === 'completed');
+    expect(snap.status).toBe('failed');
+    expect(snap.statusMessage).toMatch(/runner exited/i);
   });
 
   test('tasks/list surfaces records created across different client sessions', async ({ mcp, server }) => {


### PR DESCRIPTION
…ease-line

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved E2E test reliability by replacing hard-coded wait times with polling-based verification for task completion states, ensuring more accurate validation of task status transitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->