### PR TITLE
fix: clarify SkillContext method implementations and error handling

### DIFF
--- a/docs/frontmcp/sdk-reference/contexts/skill-context.mdx
+++ b/docs/frontmcp/sdk-reference/contexts/skill-context.mdx
@@ -19,17 +19,33 @@ export abstract class SkillContext extends ExecutionContextBase<SkillContent>
 | `skillName` | `string`        | Skill name     |
 | `skillId`   | `string`        | Skill ID       |
 
-## Abstract Methods
+## Overridable Methods
+
+<Info>
+Both methods below have **default implementations** that throw
+`SkillContextNotImplementedError`. Under the normal `@Skill` pipeline the
+runtime drives loading via `SkillInstance` against the decorator metadata,
+so these methods are **never invoked on your class** — overriding them is
+optional. This is what makes `class MySkill extends SkillContext {}` (no
+body) compile under strict TypeScript.
+
+Override these methods only when you construct a `SkillContext` subclass
+manually outside the `@Skill` decorator pipeline and need bespoke
+loading/assembly logic. The detailed examples below show that advanced
+pattern.
+</Info>
 
 ### loadInstructions()
 
 Load skill instructions from the configured source.
 
 ```typescript
-abstract loadInstructions(): Promise<string>
+loadInstructions(): Promise<string>
 ```
 
-Instructions can come from:
+Default behaviour: throws `SkillContextNotImplementedError`. The runtime
+calls `SkillInstance.loadInstructions()` (not this method) under the
+`@Skill` pipeline, resolving:
 
 - Inline string
 - File reference (`{ file: './path.md' }`)
@@ -40,8 +56,28 @@ Instructions can come from:
 Build the complete skill content.
 
 ```typescript
-abstract build(): Promise<SkillContent>
+build(): Promise<SkillContent>
 ```
+
+Default behaviour: throws `SkillContextNotImplementedError`. The runtime
+calls `SkillInstance.load()` (not this method) under the `@Skill` pipeline.
+
+## Minimal Example
+
+```typescript
+import { Skill, SkillContext } from '@frontmcp/sdk';
+
+@Skill({
+  name: 'data-analysis',
+  description: 'Analyze datasets and generate insights',
+  instructions: 'Load the dataset, analyze patterns, generate insights.',
+  tools: ['query_database', 'create_chart'],
+})
+class DataAnalysisSkill extends SkillContext {}
+```
+
+That's enough. The runtime resolves `instructions`, `resources`, and tool
+references from the decorator metadata for you.
 
 ## SkillContent Interface
 

--- a/docs/frontmcp/sdk-reference/decorators/skill.mdx
+++ b/docs/frontmcp/sdk-reference/decorators/skill.mdx
@@ -23,12 +23,31 @@ import { Skill, SkillContext } from '@frontmcp/sdk';
   `,
   tools: ['github_get_pr', 'github_post_comment'],
 })
+class CodeReviewSkill extends SkillContext {}
+```
+
+<Info>
+The class body is optional. When you use `@Skill`, the runtime loads
+`instructions` (and `resources`) from the decorator metadata via
+`SkillInstance`, so `loadInstructions()` and `build()` on your class are
+never invoked — you only need to override them if you construct a
+`SkillContext` subclass manually outside the decorator pipeline. See
+[Advanced: overriding loadInstructions / build](#advanced-overriding-loadinstructions--build).
+</Info>
+
+### Advanced: overriding loadInstructions / build
+
+You only need to override these methods when you bypass the `@Skill`
+decorator and want to drive loading yourself. Otherwise, leave the body
+empty — the runtime does the work for you.
+
+```typescript
 class CodeReviewSkill extends SkillContext {
-  async loadInstructions() {
+  override async loadInstructions() {
     return this.metadata.instructions as string;
   }
 
-  async build() {
+  override async build() {
     return {
       id: this.skillId,
       name: this.metadata.name,

--- a/libs/nx-plugin/src/generators/skill/files/__fileName__.skill.ts__tmpl__
+++ b/libs/nx-plugin/src/generators/skill/files/__fileName__.skill.ts__tmpl__
@@ -1,16 +1,14 @@
 import { Skill, SkillContext } from '@frontmcp/sdk';
 
+// The class body is intentionally empty. Under `@Skill`, the runtime loads
+// instructions (and resources) from the decorator metadata via `SkillInstance`,
+// so `loadInstructions()` and `build()` on this class are never invoked.
+// Override them only if you construct a SkillContext subclass manually outside
+// the @Skill pipeline.
 @Skill({
   name: '<%= name %>',
-  description: 'TODO: describe what this skill does',<% if (toolRefs.length > 0) { %>
+  description: 'TODO: describe what this skill does',
+  instructions: 'TODO: define skill instructions',<% if (toolRefs.length > 0) { %>
   tools: [<%- toolRefs.map(t => `'${t}'`).join(', ') %>],<% } %>
 })
-export default class <%= className %>Skill extends SkillContext {
-  async loadInstructions(): Promise<string> {
-    return 'TODO: define skill instructions';
-  }
-
-  async build(): Promise<void> {
-    // TODO: implement skill build logic
-  }
-}
+export default class <%= className %>Skill extends SkillContext {}

--- a/libs/sdk/src/common/decorators/skill.decorator.ts
+++ b/libs/sdk/src/common/decorators/skill.decorator.ts
@@ -28,7 +28,7 @@ import { validateRemoteUrl } from '../utils/validate-remote-url';
  * @param providedMetadata - Skill metadata including name, description, and instructions
  * @returns Class decorator
  *
- * @example Basic skill
+ * @example Basic skill (empty body — runtime drives loading)
  * ```typescript
  * @Skill({
  *   name: 'review-pr',
@@ -36,10 +36,7 @@ import { validateRemoteUrl } from '../utils/validate-remote-url';
  *   instructions: 'Step 1: Fetch PR details...',
  *   tools: ['github_get_pr', 'github_add_comment'],
  * })
- * class ReviewPRSkill extends SkillContext {
- *   async loadInstructions() { return this.metadata.instructions as string; }
- *   async build() { ... }
- * }
+ * class ReviewPRSkill extends SkillContext {}
  * ```
  *
  * @example Skill with Agent Skills spec fields
@@ -54,7 +51,7 @@ import { validateRemoteUrl } from '../utils/validate-remote-url';
  *   compatibility: 'Requires Docker 24+ and kubectl',
  *   allowedTools: 'Read Edit Bash(docker build)',
  * })
- * class DeploySkill extends SkillContext { ... }
+ * class DeploySkill extends SkillContext {}
  * ```
  *
  * @example Skill with URL-based instructions
@@ -65,7 +62,7 @@ import { validateRemoteUrl } from '../utils/validate-remote-url';
  *   instructions: { url: 'https://example.com/skills/security-audit.md' },
  *   tools: ['code_search', 'file_read'],
  * })
- * class SecurityAuditSkill extends SkillContext { ... }
+ * class SecurityAuditSkill extends SkillContext {}
  * ```
  */
 function FrontMcpSkill(providedMetadata: SkillMetadata): ClassDecorator {

--- a/libs/sdk/src/common/interfaces/__tests__/skill-context.type.spec.ts
+++ b/libs/sdk/src/common/interfaces/__tests__/skill-context.type.spec.ts
@@ -1,0 +1,184 @@
+/**
+ * SkillContext type + runtime tests for issue #416.
+ *
+ * Proves:
+ *   1. `class Foo extends SkillContext {}` compiles under strict TypeScript.
+ *   2. Default `loadInstructions()` / `build()` throw `SkillContextNotImplementedError`.
+ *   3. User overrides still win.
+ *   4. The `@Skill` runtime path is unaffected — empty-body classes work end-to-end
+ *      when driven via `SkillInstance`.
+ */
+
+import 'reflect-metadata';
+
+import { SkillContextNotImplementedError } from '../../../errors/sdk.errors';
+import { normalizeSkill } from '../../../skill/skill.utils';
+import { isSkillDecorated, Skill } from '../../decorators/skill.decorator';
+import { type SkillMetadata } from '../../metadata';
+import { SkillKind } from '../../records';
+import { type ExecutionContextBaseArgs } from '../execution-context.interface';
+import { SkillContext, type SkillContent } from '../skill.interface';
+
+const mkArgs = (metadata: SkillMetadata): ExecutionContextBaseArgs & { metadata: SkillMetadata } => ({
+  providers: { getActiveScope: () => undefined } as never,
+  logger: {
+    child: () => ({
+      debug: jest.fn(),
+      info: jest.fn(),
+      warn: jest.fn(),
+      error: jest.fn(),
+    }),
+    debug: jest.fn(),
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+  } as never,
+  authInfo: {},
+  metadata,
+});
+
+describe('SkillContext (issue #416)', () => {
+  describe('empty-body extends', () => {
+    it('compiles under strict TypeScript', () => {
+      @Skill({
+        name: 'empty-body',
+        description: 'A skill with no method overrides — the documented form.',
+        instructions: 'inline',
+      })
+      class EmptyBodySkill extends SkillContext {}
+
+      // The decorator metadata is attached.
+      expect(isSkillDecorated(EmptyBodySkill)).toBe(true);
+    });
+
+    it('rejects construction without required ExecutionContextBase args at compile time', () => {
+      @Skill({
+        name: 'empty-body-ctor',
+        description: 'Empty body — used to assert constructor still gates new()',
+        instructions: 'inline',
+      })
+      class EmptyBodyCtorSkill extends SkillContext {}
+
+      // Compile-time check only — wrapping in an unused arrow ensures the line never runs.
+      // If the `@ts-expect-error` directive becomes invalid (because TS stopped flagging
+      // the call as a type error), this test fails — which is exactly the intended signal.
+
+      const _typeCheck = () => {
+        // @ts-expect-error - constructor requires providers/logger/authInfo/metadata
+        new EmptyBodyCtorSkill();
+      };
+      expect(EmptyBodyCtorSkill).toBeDefined();
+    });
+  });
+
+  describe('default method implementations', () => {
+    @Skill({
+      name: 'default-throw',
+      description: 'A skill whose defaults throw SkillContextNotImplementedError',
+      instructions: 'inline',
+    })
+    class DefaultThrowSkill extends SkillContext {}
+
+    const ctx = new DefaultThrowSkill(
+      mkArgs({
+        name: 'default-throw',
+        description: 'A skill whose defaults throw SkillContextNotImplementedError',
+        instructions: 'inline',
+      }),
+    );
+
+    it('loadInstructions() throws SkillContextNotImplementedError with the documented code', async () => {
+      const promise = ctx.loadInstructions();
+      await expect(promise).rejects.toBeInstanceOf(SkillContextNotImplementedError);
+      try {
+        await ctx.loadInstructions();
+      } catch (err) {
+        expect((err as SkillContextNotImplementedError).message).toMatch(/loadInstructions/);
+        expect((err as SkillContextNotImplementedError).message).toContain('"default-throw"');
+        expect((err as SkillContextNotImplementedError).code).toBe('SKILL_CONTEXT_NOT_IMPLEMENTED');
+      }
+    });
+
+    it('build() throws SkillContextNotImplementedError with the documented code', async () => {
+      const promise = ctx.build();
+      await expect(promise).rejects.toBeInstanceOf(SkillContextNotImplementedError);
+      try {
+        await ctx.build();
+      } catch (err) {
+        expect((err as SkillContextNotImplementedError).message).toMatch(/build/);
+        expect((err as SkillContextNotImplementedError).message).toContain('"default-throw"');
+        expect((err as SkillContextNotImplementedError).code).toBe('SKILL_CONTEXT_NOT_IMPLEMENTED');
+      }
+    });
+  });
+
+  describe('regression guard — methods must remain concrete', () => {
+    it('exposes loadInstructions and build as own prototype methods (not abstract)', () => {
+      // If the methods were `abstract` the prototype would not carry implementations
+      // and `typeof` would be 'undefined'. This locks in the issue #416 fix.
+      expect(typeof SkillContext.prototype.loadInstructions).toBe('function');
+      expect(typeof SkillContext.prototype.build).toBe('function');
+    });
+
+    it('exports SkillContextNotImplementedError through the public SDK barrel', async () => {
+      // Resolve via the SDK's root index so consumers' `import { SkillContextNotImplementedError } from '@frontmcp/sdk'` works.
+      const sdkRoot = (await import('../../../index')) as Record<string, unknown>;
+      expect(sdkRoot['SkillContextNotImplementedError']).toBe(SkillContextNotImplementedError);
+    });
+  });
+
+  describe('user overrides', () => {
+    it('overriding loadInstructions and build wins over the defaults', async () => {
+      @Skill({
+        name: 'overriding-skill',
+        description: 'A skill with user-supplied overrides',
+        instructions: 'metadata-instructions',
+      })
+      class OverridingSkill extends SkillContext {
+        override async loadInstructions(): Promise<string> {
+          return 'custom-instructions';
+        }
+
+        override async build(): Promise<SkillContent> {
+          return {
+            id: this.metadata.id ?? this.metadata.name,
+            name: this.metadata.name,
+            description: this.metadata.description,
+            instructions: 'custom-instructions',
+            tools: [],
+          };
+        }
+      }
+
+      const overridden = new OverridingSkill(
+        mkArgs({
+          name: 'overriding-skill',
+          description: 'A skill with user-supplied overrides',
+          instructions: 'metadata-instructions',
+        }),
+      );
+
+      await expect(overridden.loadInstructions()).resolves.toBe('custom-instructions');
+      const built = await overridden.build();
+      expect(built.instructions).toBe('custom-instructions');
+      expect(built.name).toBe('overriding-skill');
+    });
+  });
+
+  describe('@Skill runtime path remains unaffected (regression for issue #416)', () => {
+    it('normalizes an empty-body class to a CLASS_TOKEN record without invoking user methods', () => {
+      @Skill({
+        name: 'empty-body-normalize',
+        description: 'Empty-body skill normalized through the framework',
+        instructions: 'metadata-only',
+      })
+      class EmptyBodyNormalize extends SkillContext {}
+
+      const record = normalizeSkill(EmptyBodyNormalize);
+
+      expect(record.kind).toBe(SkillKind.CLASS_TOKEN);
+      expect(record.metadata.name).toBe('empty-body-normalize');
+      expect(record.metadata.instructions).toBe('metadata-only');
+    });
+  });
+});

--- a/libs/sdk/src/common/interfaces/skill.interface.ts
+++ b/libs/sdk/src/common/interfaces/skill.interface.ts
@@ -2,6 +2,7 @@
 
 import { type Type } from '@frontmcp/di';
 
+import { SkillContextNotImplementedError } from '../../errors/sdk.errors';
 import {
   normalizeToolRef,
   type SkillMetadata,
@@ -250,15 +251,32 @@ export abstract class SkillContext extends ExecutionContextBase<SkillContent> {
 
   /**
    * Load the skill's detailed instructions.
-   * Resolves from inline string, file path, or URL based on metadata.
+   *
+   * The framework provides a default implementation that throws — when a
+   * class is decorated with `@Skill`, the runtime uses `SkillInstance` to
+   * load instructions from the decorator metadata, so this method is never
+   * called on the user class.
+   *
+   * Override this only when you construct a `SkillContext` subclass manually
+   * (outside the `@Skill` decorator pipeline) and need bespoke loading logic.
    */
-  abstract loadInstructions(): Promise<string>;
+  async loadInstructions(): Promise<string> {
+    throw new SkillContextNotImplementedError(this.skillName, 'loadInstructions');
+  }
 
   /**
    * Build the full SkillContent for this skill.
-   * Resolves instructions and normalizes all metadata into a single object.
+   *
+   * The framework provides a default implementation that throws — when a
+   * class is decorated with `@Skill`, the runtime uses `SkillInstance.load()`
+   * to assemble the content, so this method is never called on the user class.
+   *
+   * Override this only when you construct a `SkillContext` subclass manually
+   * (outside the `@Skill` decorator pipeline) and need bespoke assembly logic.
    */
-  abstract build(): Promise<SkillContent>;
+  async build(): Promise<SkillContent> {
+    throw new SkillContextNotImplementedError(this.skillName, 'build');
+  }
 
   /**
    * Get normalized tool references from the skill metadata.

--- a/libs/sdk/src/errors/index.ts
+++ b/libs/sdk/src/errors/index.ts
@@ -234,6 +234,7 @@ export {
   InvalidSkillError,
   SkillInstructionFetchError,
   InvalidInstructionSourceError,
+  SkillContextNotImplementedError,
   ServerlessHandlerNotInitializedError,
   MissingPromptArgumentError,
   DynamicAdapterNameError,

--- a/libs/sdk/src/errors/sdk.errors.ts
+++ b/libs/sdk/src/errors/sdk.errors.ts
@@ -118,6 +118,27 @@ export class InvalidInstructionSourceError extends InternalMcpError {
 }
 
 /**
+ * Thrown when a user calls `SkillContext.loadInstructions()` or
+ * `SkillContext.build()` directly on a skill that does not override them.
+ *
+ * Under the normal `@Skill`-decorator flow these methods are never invoked on
+ * the user's class — the runtime drives loading via `SkillInstance` against
+ * the decorator metadata. This error fires only when user code constructs a
+ * `SkillContext` subclass manually (outside the decorator pipeline) and
+ * forgets to provide an implementation.
+ */
+export class SkillContextNotImplementedError extends InternalMcpError {
+  constructor(skillName: string, method: 'loadInstructions' | 'build') {
+    super(
+      `SkillContext.${method}() was called on skill "${skillName}" but no implementation ` +
+        `was provided. When using @Skill, the runtime loads instructions via SkillInstance; ` +
+        `this method only needs an implementation if you bypass the @Skill decorator pipeline.`,
+      'SKILL_CONTEXT_NOT_IMPLEMENTED',
+    );
+  }
+}
+
+/**
  * Thrown when a serverless handler is not initialized.
  */
 export class ServerlessHandlerNotInitializedError extends InternalMcpError {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified that `SkillContext` supports empty subclass declarations when using `@Skill` decorator.
  * Updated `loadInstructions()` and `build()` documentation to explain default implementations and decorator-driven loading.
  * Revised code examples to reflect modern TypeScript override semantics and simplified pattern.

* **New Features**
  * Added `SkillContextNotImplementedError` for direct method invocation on unimplemented skills.

* **Tests**
  * Added comprehensive test suite for `SkillContext` type safety and runtime behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/agentfront/frontmcp/pull/418)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->