### PR TITLE
feat: capture caller directory for skill instructions and resources resolution

### DIFF
--- a/docs/frontmcp/sdk-reference/decorators/skill.mdx
+++ b/docs/frontmcp/sdk-reference/decorators/skill.mdx
@@ -106,6 +106,16 @@ These properties align with the [Anthropic Agent Skills specification](https://a
 })
 ```
 
+<Info>
+**File path resolution.** Relative paths in `instructions: { file: '…' }`,
+`resources.references`, and `resources.examples` resolve against the
+directory of the source file that declared the `@Skill` class — **not**
+`process.cwd()`. The directory is captured at decoration time by walking
+the call stack, and the same rule applies to the inline `skill()` helper.
+For bundled CLIs the framework additionally falls back to the build-time
+`_skills/manifest.json` so paths keep resolving after `frontmcp build`.
+</Info>
+
 ### URL Reference
 
 ```typescript

--- a/docs/frontmcp/sdk-reference/decorators/skill.mdx
+++ b/docs/frontmcp/sdk-reference/decorators/skill.mdx
@@ -80,7 +80,7 @@ These properties align with the [Anthropic Agent Skills specification](https://a
 | `compatibility` | `string`                 | Environment requirements (max 500 chars)                          |
 | `specMetadata`  | `Record<string, string>` | Arbitrary key-value metadata (maps to spec `metadata`)            |
 | `allowedTools`  | `string`                 | Space-delimited pre-approved tools (maps to spec `allowed-tools`) |
-| `resources`     | `SkillResources`         | Bundled resource directories (`scripts`, `references`, `assets`)  |
+| `resources`     | `SkillResources`         | Bundled resource directories (`scripts`, `references`, `examples`, `assets`)  |
 
 ## Instruction Sources
 
@@ -249,6 +249,7 @@ interface SkillContent {
 interface SkillResources {
   scripts?: string;
   references?: string;
+  examples?: string;
   assets?: string;
 }
 ```

--- a/libs/sdk/src/common/decorators/skill.decorator.ts
+++ b/libs/sdk/src/common/decorators/skill.decorator.ts
@@ -1,6 +1,6 @@
 import 'reflect-metadata';
 
-import { dirname } from '@frontmcp/utils';
+import { basename, dirname } from '@frontmcp/utils';
 
 import { parsePackageSpecifier } from '../../esm-loader/package-specifier';
 import { skillMetadataSchema, type EsmOptions, type RemoteOptions, type SkillMetadata } from '../metadata';
@@ -214,6 +214,11 @@ export function parseCallerDir(stack: string | undefined): string | undefined {
   // Start from index 1 (skip the "Error" header line); cap at 30 frames.
   for (let i = 1; i < lines.length && i < 30; i++) {
     const line = lines[i];
+    // Cap per-line length so the greedy regexes below can never backtrack
+    // pathologically on a hostile / malformed stack (CodeQL ReDoS warning
+    // PR #419: GHAS finding 146/147). A real stack-trace frame is well
+    // under this — anything longer is almost certainly not a real frame.
+    if (line.length > 2048) continue;
     // Match "at func (...:line:col)" and "at ...:line:col"; capture group
     // tolerates `file:///` because it greedily includes the scheme.
     const match = line.match(/\(([^)]+):\d+:\d+\)/) || line.match(/at\s+([^\s]+):\d+:\d+/);
@@ -240,13 +245,16 @@ export function parseCallerDir(stack: string | undefined): string | undefined {
     //   - third-party packages (`node_modules`)
     //   - this decorator file itself (match by basename only — `skill.decorator.ts`
     //     or `.js` — so we don't accidentally reject files like `skill.decorator.spec.ts`)
-    const basenameMatch = file.match(/[^/\\]+$/);
-    const basename = basenameMatch ? basenameMatch[0] : file;
+    //
+    // `basename` from `@frontmcp/utils` handles both POSIX and Windows
+    // separators and is not a regex — sidesteps the CodeQL ReDoS warning
+    // GHAS #147 that the previous `[^/\\]+$` regex tripped.
+    const base = basename(file);
     if (
       file.startsWith('node:') ||
       file.includes('node_modules') ||
-      basename === 'skill.decorator.ts' ||
-      basename === 'skill.decorator.js'
+      base === 'skill.decorator.ts' ||
+      base === 'skill.decorator.js'
     ) {
       continue;
     }

--- a/libs/sdk/src/common/decorators/skill.decorator.ts
+++ b/libs/sdk/src/common/decorators/skill.decorator.ts
@@ -10,7 +10,7 @@ import { SkillKind, type SkillValueRecord } from '../records';
 // ═══════════════════════════════════════════════════════════════════
 
 import { type SkillEsmTargetRecord, type SkillRemoteRecord } from '../records/skill.record';
-import { extendedSkillMetadata, FrontMcpSkillTokens } from '../tokens';
+import { extendedSkillMetadata, FrontMcpSkillTokens, skillCallerDir } from '../tokens';
 import { validateRemoteUrl } from '../utils/validate-remote-url';
 
 /**
@@ -24,6 +24,18 @@ import { validateRemoteUrl } from '../utils/validate-remote-url';
  * - `name`: kebab-case, max 64 chars, no consecutive hyphens
  * - `description`: max 1024 chars, no XML/HTML tags
  * - Supports `license`, `compatibility`, `specMetadata`, `allowedTools`, `resources`
+ *
+ * ## File path resolution
+ *
+ * When `instructions: { file: './…' }`, `resources.references: './…'`, or
+ * `resources.examples: './…'` are relative, they are resolved relative to
+ * the directory of the source file that declared the `@Skill` class —
+ * **not** the process `cwd`. The directory is captured at decoration time
+ * by walking the call stack. This matches the behaviour of the inline
+ * `skill()` helper, and works under both CJS and ESM. If the caller
+ * cannot be determined (e.g. an exotic loader strips stack frames), the
+ * framework falls back to the build-time `_skills/manifest.json` for
+ * bundled CLIs and otherwise to the legacy `cwd`-relative behaviour.
  *
  * @param providedMetadata - Skill metadata including name, description, and instructions
  * @returns Class decorator
@@ -69,6 +81,12 @@ import { validateRemoteUrl } from '../utils/validate-remote-url';
  * ```
  */
 function FrontMcpSkill(providedMetadata: SkillMetadata): ClassDecorator {
+  // Capture the caller directory at decorator-evaluation time (i.e. when the
+  // user's source file is being loaded), before returning the inner function.
+  // This is the moment the user's file is on the stack; deferring until the
+  // class body executes would still work but is less robust under bundling.
+  const callerDir = resolveCallerDir();
+
   return (target: object) => {
     const metadata = skillMetadataSchema.parse(providedMetadata);
     Reflect.defineMetadata(FrontMcpSkillTokens.type, true, target);
@@ -83,6 +101,10 @@ function FrontMcpSkill(providedMetadata: SkillMetadata): ClassDecorator {
       }
     }
     Reflect.defineMetadata(extendedSkillMetadata, extended, target);
+
+    if (callerDir) {
+      Reflect.defineMetadata(skillCallerDir, callerDir, target);
+    }
   };
 }
 
@@ -94,6 +116,14 @@ function FrontMcpSkill(providedMetadata: SkillMetadata): ClassDecorator {
  *
  * Name must be kebab-case (max 64 chars, no consecutive hyphens).
  * Description max 1024 chars, no XML/HTML tags.
+ *
+ * ## File path resolution
+ *
+ * When `instructions: { file: './…' }`, `resources.references: './…'`, or
+ * `resources.examples: './…'` are relative, they are resolved relative to
+ * the directory of the source file that called `skill()` — **not** the
+ * process `cwd`. The directory is captured at call time by walking the
+ * stack. Works under both CJS and ESM.
  *
  * @param providedMetadata - Skill metadata including name, description, and instructions
  * @returns A skill value record that can be passed to app/plugin skills array
@@ -155,27 +185,73 @@ function frontMcpSkill(providedMetadata: SkillMetadata): SkillValueRecord {
 /**
  * Walk the call stack to find the first file outside this module.
  * Returns the directory of that file, or undefined if it cannot be determined.
+ *
+ * Supports both CJS frames (`at fn (/abs/path/foo.ts:1:1)`) and ESM frames
+ * (`at fn (file:///abs/path/foo.ts:1:1)`). For ESM frames, the `file://`
+ * scheme is converted via `node:url`'s `fileURLToPath` so the result is a
+ * usable filesystem path on both POSIX and Windows.
  */
 function resolveCallerDir(): string | undefined {
-  const err = new Error();
-  const stack = err.stack;
+  return parseCallerDir(new Error().stack);
+}
+
+/**
+ * Pure helper that parses a V8-format stack string and returns the directory
+ * of the first user-code frame. Exported for unit testing only — the
+ * production entry point is `resolveCallerDir()`.
+ *
+ * Filters out:
+ *   - Node internals (`node:internal/...`, `node:fs`, etc.)
+ *   - `node_modules` packages
+ *   - this decorator file itself (basename match — `skill.decorator.ts`/`.js`)
+ *
+ * @internal
+ */
+export function parseCallerDir(stack: string | undefined): string | undefined {
   if (!stack) return undefined;
 
   const lines = stack.split('\n');
-  // Start from index 1 (skip the "Error" header line).
-  // The existing filter for 'skill.decorator' handles skipping internal frames.
-  for (let i = 1; i < lines.length; i++) {
+  // Start from index 1 (skip the "Error" header line); cap at 30 frames.
+  for (let i = 1; i < lines.length && i < 30; i++) {
     const line = lines[i];
-    // Match both "at func (file:line:col)" and "at file:line:col" formats
-    const match = line.match(/\(([^)]+):\d+:\d+\)/) || line.match(/at\s+([^\s:]+):\d+:\d+/);
-    if (match) {
-      const file = match[1];
-      // Skip node_modules and this decorator file
-      if (file.includes('node_modules') || file.includes('skill.decorator')) {
-        continue;
+    // Match "at func (...:line:col)" and "at ...:line:col"; capture group
+    // tolerates `file:///` because it greedily includes the scheme.
+    const match = line.match(/\(([^)]+):\d+:\d+\)/) || line.match(/at\s+([^\s]+):\d+:\d+/);
+    if (!match) continue;
+
+    let file = match[1];
+
+    // ESM frames surface URLs; convert to a filesystem path before dirname().
+    if (file.startsWith('file://')) {
+      try {
+        // Lazy-require so browser/Edge builds that never import `node:url` stay clean.
+
+        const { fileURLToPath } = require('node:url');
+        file = fileURLToPath(file);
+      } catch {
+        // If node:url is unavailable (browser-ish runtimes), fall back to a
+        // best-effort strip. dirname() works on most POSIX cases this way.
+        file = file.replace(/^file:\/\//, '');
       }
-      return dirname(file);
     }
+
+    // Skip frames that don't represent user code:
+    //   - Node internals (`node:internal/...`, `node:fs`, etc.)
+    //   - third-party packages (`node_modules`)
+    //   - this decorator file itself (match by basename only — `skill.decorator.ts`
+    //     or `.js` — so we don't accidentally reject files like `skill.decorator.spec.ts`)
+    const basenameMatch = file.match(/[^/\\]+$/);
+    const basename = basenameMatch ? basenameMatch[0] : file;
+    if (
+      file.startsWith('node:') ||
+      file.includes('node_modules') ||
+      basename === 'skill.decorator.ts' ||
+      basename === 'skill.decorator.js'
+    ) {
+      continue;
+    }
+
+    return dirname(file);
   }
   return undefined;
 }

--- a/libs/sdk/src/common/records/skill.record.ts
+++ b/libs/sdk/src/common/records/skill.record.ts
@@ -41,6 +41,8 @@ export type SkillClassTokenRecord = {
   kind: SkillKind.CLASS_TOKEN;
   provide: Type<SkillContext>;
   metadata: SkillMetadata;
+  /** Directory of the file that declared the @Skill class. Used to resolve relative instruction file paths. */
+  callerDir?: string;
 };
 
 /**

--- a/libs/sdk/src/common/tokens/skill.tokens.ts
+++ b/libs/sdk/src/common/tokens/skill.tokens.ts
@@ -29,3 +29,12 @@ export const FrontMcpSkillTokens = {
 } as const satisfies RawMetadataShape<SkillMetadata, ExtendFrontMcpSkillMetadata>;
 
 export const extendedSkillMetadata = tokenFactory.meta('extendedSkillMetadata');
+
+/**
+ * Internal metadata token used to stash the directory of the source file
+ * that contains the `@Skill`-decorated class. Consumed by `normalizeSkill`
+ * so `SkillInstance` can resolve `instructions: { file: './…' }` and
+ * `resources.{references,examples}` relative to the skill source file
+ * instead of `process.cwd()`. Not part of `SkillMetadata`.
+ */
+export const skillCallerDir = tokenFactory.meta('skill:__callerDir');

--- a/libs/sdk/src/skill/__tests__/skill.decorator.spec.ts
+++ b/libs/sdk/src/skill/__tests__/skill.decorator.spec.ts
@@ -5,15 +5,21 @@
  */
 
 import 'reflect-metadata';
+
+import { dirname } from '@frontmcp/utils';
+
+import { skillCallerDir, SkillContext, SkillKind, type SkillContent, type SkillMetadata } from '../../common';
 import {
   FrontMcpSkill,
-  Skill,
   frontMcpSkill,
-  skill,
-  isSkillDecorated,
   getSkillMetadata,
+  isSkillDecorated,
+  parseCallerDir,
+  Skill,
+  skill,
 } from '../../common/decorators/skill.decorator';
-import { SkillMetadata, SkillKind, SkillContext, SkillContent } from '../../common';
+
+const THIS_DIR = __dirname;
 
 // Mock SkillContext for testing
 class MockSkillContext extends SkillContext {
@@ -253,6 +259,141 @@ describe('skill.decorator', () => {
 
       const metadata = getSkillMetadata(PlainClass);
       expect(metadata).toBeUndefined();
+    });
+  });
+
+  describe('callerDir capture (issue #413)', () => {
+    it('should record the caller directory on a decorated class', () => {
+      @Skill({
+        name: 'caller-dir-skill',
+        description: 'A skill that should capture its caller directory',
+        instructions: 'Inline instructions',
+      })
+      class CallerDirSkill extends MockSkillContext {}
+
+      const dir = Reflect.getMetadata(skillCallerDir, CallerDirSkill) as string | undefined;
+      // The decorator captured the source file's directory, which is this test file's directory.
+      expect(dir).toBe(THIS_DIR);
+    });
+
+    it('should record the caller directory on a skill() helper record', () => {
+      const record = skill({
+        name: 'caller-dir-value',
+        description: 'A value skill that should capture its caller directory',
+        instructions: 'Inline instructions',
+      });
+
+      expect(record.callerDir).toBe(THIS_DIR);
+    });
+
+    describe('parseCallerDir (pure)', () => {
+      it('returns the dirname of the first user CJS frame', () => {
+        const stack = [
+          'Error',
+          '    at resolveCallerDir (/abs/path/sdk/src/common/decorators/skill.decorator.ts:175:15)',
+          '    at FrontMcpSkill (/abs/path/sdk/src/common/decorators/skill.decorator.ts:76:21)',
+          '    at Object.<anonymous> (/abs/path/user/src/my-skill.ts:12:1)',
+          '    at Module._compile (node:internal/modules/cjs/loader:1356:14)',
+        ].join('\n');
+
+        expect(parseCallerDir(stack)).toBe('/abs/path/user/src');
+      });
+
+      it('returns the dirname of the first user ESM frame (file:// URL)', () => {
+        const stack = [
+          'Error',
+          '    at FrontMcpSkill (/abs/path/sdk/src/common/decorators/skill.decorator.ts:76:21)',
+          '    at file:///abs/path/user/src/my-skill.ts:12:1',
+          '    at ModuleJob.run (node:internal/modules/esm/module_job:218:25)',
+        ].join('\n');
+
+        const result = parseCallerDir(stack);
+        // POSIX result; on Windows the value would be C:-style. Compare via dirname()
+        // so the assertion stays platform-tolerant.
+        expect(result).toBe(dirname('/abs/path/user/src/my-skill.ts'));
+      });
+
+      it('skips node_modules frames', () => {
+        const stack = [
+          'Error',
+          '    at FrontMcpSkill (/abs/path/sdk/src/common/decorators/skill.decorator.ts:76:21)',
+          '    at someHelper (/abs/path/node_modules/some-lib/index.js:42:7)',
+          '    at Object.<anonymous> (/abs/path/user/src/my-skill.ts:12:1)',
+        ].join('\n');
+
+        expect(parseCallerDir(stack)).toBe('/abs/path/user/src');
+      });
+
+      it('skips node: internal frames', () => {
+        const stack = [
+          'Error',
+          '    at FrontMcpSkill (/abs/path/sdk/src/common/decorators/skill.decorator.ts:76:21)',
+          '    at processTicksAndRejections (node:internal/process/task_queues:104:5)',
+          '    at Object.<anonymous> (/abs/path/user/src/my-skill.ts:12:1)',
+        ].join('\n');
+
+        expect(parseCallerDir(stack)).toBe('/abs/path/user/src');
+      });
+
+      it('skips the decorator file itself but accepts skill.decorator.spec.ts', () => {
+        const stack = [
+          'Error',
+          '    at FrontMcpSkill (/abs/path/sdk/src/common/decorators/skill.decorator.ts:76:21)',
+          '    at Object.<anonymous> (/abs/path/sdk/src/skill/__tests__/skill.decorator.spec.ts:50:1)',
+        ].join('\n');
+
+        // Spec file must NOT be filtered even though it shares the `skill.decorator` substring.
+        expect(parseCallerDir(stack)).toBe('/abs/path/sdk/src/skill/__tests__');
+      });
+
+      it('returns undefined when the stack is undefined', () => {
+        expect(parseCallerDir(undefined)).toBeUndefined();
+      });
+
+      it('returns undefined when no user frames are present', () => {
+        const stack = [
+          'Error',
+          '    at FrontMcpSkill (/abs/path/sdk/src/common/decorators/skill.decorator.ts:76:21)',
+          '    at processTicksAndRejections (node:internal/process/task_queues:104:5)',
+        ].join('\n');
+
+        expect(parseCallerDir(stack)).toBeUndefined();
+      });
+
+      it('caps iteration at 30 frames', () => {
+        // Build a 50-frame stack where the only user frame is at frame 35 — past the cap.
+        const lines = ['Error'];
+        for (let i = 0; i < 50; i++) {
+          if (i === 34) {
+            lines.push('    at Object.<anonymous> (/abs/path/user/src/late.ts:1:1)');
+          } else {
+            lines.push('    at internal (/abs/path/node_modules/x/index.js:1:1)');
+          }
+        }
+        expect(parseCallerDir(lines.join('\n'))).toBeUndefined();
+      });
+    });
+
+    it('should never write a node: internal frame as the caller directory', () => {
+      // Regression: the helper used to match frames like
+      // `at evaluate (node:internal/process/...)` and return `node:internal/process`,
+      // which is not a usable filesystem path.
+      @Skill({
+        name: 'no-node-internal-skill',
+        description: 'Skill whose captured callerDir must not be a node: frame',
+        instructions: 'Inline',
+      })
+      class NoNodeInternalSkill extends MockSkillContext {}
+
+      const dir = Reflect.getMetadata(skillCallerDir, NoNodeInternalSkill) as string | undefined;
+      // Either we found a real user-code frame, or we found none. We must never
+      // return a node: internal path.
+      if (dir !== undefined) {
+        expect(dir.startsWith('node:')).toBe(false);
+        expect(dir.includes('node_modules')).toBe(false);
+      }
+      // Either way, decoration always succeeds.
+      expect(isSkillDecorated(NoNodeInternalSkill)).toBe(true);
     });
   });
 });

--- a/libs/sdk/src/skill/__tests__/skill.instance.spec.ts
+++ b/libs/sdk/src/skill/__tests__/skill.instance.spec.ts
@@ -5,19 +5,24 @@
  */
 
 import 'reflect-metadata';
-import { SkillInstance, createSkillInstance } from '../skill.instance';
-import { SkillKind, SkillRecord, SkillMetadata, EntryOwnerRef } from '../../common';
-import ProviderRegistry from '../../provider/provider.registry';
-import { Scope } from '../../scope';
 
-// Mock the loadInstructions utility
+import { SkillKind, type EntryOwnerRef, type SkillMetadata, type SkillRecord } from '../../common';
+import type ProviderRegistry from '../../provider/provider.registry';
+import { type Scope } from '../../scope';
+import { createSkillInstance, SkillInstance } from '../skill.instance';
+import { loadInstructions, resolveExamples, resolveReferences } from '../skill.utils';
+
+// Mock the loadInstructions utility (and the resource resolvers used by load()).
 jest.mock('../skill.utils', () => ({
   ...jest.requireActual('../skill.utils'),
   loadInstructions: jest.fn(),
+  resolveReferences: jest.fn(),
+  resolveExamples: jest.fn(),
 }));
 
-import { loadInstructions } from '../skill.utils';
 const mockLoadInstructions = loadInstructions as jest.MockedFunction<typeof loadInstructions>;
+const mockResolveReferences = resolveReferences as jest.MockedFunction<typeof resolveReferences>;
+const mockResolveExamples = resolveExamples as jest.MockedFunction<typeof resolveExamples>;
 
 // Helper to create mock ProviderRegistry
 const createMockProviderRegistry = (): ProviderRegistry => {
@@ -64,6 +69,8 @@ describe('SkillInstance', () => {
     mockProviders = createMockProviderRegistry();
     mockOwner = createMockOwner();
     mockLoadInstructions.mockResolvedValue('Loaded instructions');
+    mockResolveReferences.mockResolvedValue([]);
+    mockResolveExamples.mockResolvedValue([]);
   });
 
   describe('constructor', () => {
@@ -195,6 +202,168 @@ describe('SkillInstance', () => {
       await instance.loadInstructions();
 
       expect(mockLoadInstructions).toHaveBeenCalledWith('Inline instructions', undefined);
+    });
+
+    it('should pass callerDir as base path for CLASS_TOKEN records (issue #413)', async () => {
+      const metadata: SkillMetadata = {
+        name: 'class-token-skill',
+        description: 'A class-decorated skill with captured callerDir',
+        instructions: { file: './SKILL.md' },
+      };
+      const record = {
+        kind: SkillKind.CLASS_TOKEN,
+        provide: class {} as never,
+        metadata,
+        callerDir: '/abs/path/to/skill-dir',
+      } as unknown as SkillRecord;
+      const instance = new SkillInstance(record, mockProviders, mockOwner);
+      await instance.ready;
+
+      await instance.loadInstructions();
+
+      expect(mockLoadInstructions).toHaveBeenCalledWith({ file: './SKILL.md' }, '/abs/path/to/skill-dir');
+    });
+
+    it('should pass callerDir as base path for VALUE records', async () => {
+      const metadata: SkillMetadata = {
+        name: 'value-skill-with-caller',
+        description: 'A value skill that captured its caller dir',
+        instructions: { file: './SKILL.md' },
+      };
+      const record = {
+        kind: SkillKind.VALUE,
+        provide: Symbol('caller-value-skill'),
+        metadata,
+        callerDir: '/abs/path/to/value-dir',
+      } as SkillRecord;
+      const instance = new SkillInstance(record, mockProviders, mockOwner);
+      await instance.ready;
+
+      await instance.loadInstructions();
+
+      expect(mockLoadInstructions).toHaveBeenCalledWith({ file: './SKILL.md' }, '/abs/path/to/value-dir');
+    });
+  });
+
+  describe('getBaseDir', () => {
+    it('should return callerDir for CLASS_TOKEN records (issue #413)', () => {
+      const metadata: SkillMetadata = {
+        name: 'class-token-base-dir',
+        description: 'A class-decorated skill with captured callerDir',
+        instructions: 'Inline',
+      };
+      const record = {
+        kind: SkillKind.CLASS_TOKEN,
+        provide: class {} as never,
+        metadata,
+        callerDir: '/abs/path/to/class-dir',
+      } as unknown as SkillRecord;
+      const instance = new SkillInstance(record, mockProviders, mockOwner);
+
+      expect(instance.getBaseDir()).toBe('/abs/path/to/class-dir');
+    });
+
+    it('should return callerDir for VALUE records', () => {
+      const metadata: SkillMetadata = {
+        name: 'value-base-dir',
+        description: 'A value skill with captured callerDir',
+        instructions: 'Inline',
+      };
+      const record = {
+        kind: SkillKind.VALUE,
+        provide: Symbol('base-dir-value'),
+        metadata,
+        callerDir: '/abs/path/to/value-dir',
+      } as SkillRecord;
+      const instance = new SkillInstance(record, mockProviders, mockOwner);
+
+      expect(instance.getBaseDir()).toBe('/abs/path/to/value-dir');
+    });
+
+    it('should return undefined when CLASS_TOKEN has no callerDir', () => {
+      const metadata: SkillMetadata = {
+        name: 'class-token-no-caller',
+        description: 'A class skill without callerDir',
+        instructions: 'Inline',
+      };
+      const record = createSkillRecord(metadata, SkillKind.CLASS_TOKEN);
+      const instance = new SkillInstance(record, mockProviders, mockOwner);
+
+      expect(instance.getBaseDir()).toBeUndefined();
+    });
+  });
+
+  describe('load() — callerDir propagation for resources (issue #413)', () => {
+    it('should resolve resources.references relative to callerDir for CLASS_TOKEN records', async () => {
+      const metadata: SkillMetadata = {
+        name: 'class-token-with-refs',
+        description: 'CLASS_TOKEN skill that declares relative references',
+        instructions: 'Inline',
+        resources: { references: './references' },
+      };
+      const record = {
+        kind: SkillKind.CLASS_TOKEN,
+        provide: class {} as never,
+        metadata,
+        callerDir: '/abs/skill-dir',
+      } as unknown as SkillRecord;
+      const instance = new SkillInstance(record, mockProviders, mockOwner);
+      await instance.ready;
+
+      await instance.load();
+
+      // loadResourceWithManifestFallback resolves `./references` against callerDir
+      // before passing the absolute path to the loader.
+      expect(mockResolveReferences).toHaveBeenCalledTimes(1);
+      expect(mockResolveReferences.mock.calls[0][0]).toBe('/abs/skill-dir/references');
+    });
+
+    it('should resolve resources.examples relative to callerDir for CLASS_TOKEN records', async () => {
+      const metadata: SkillMetadata = {
+        name: 'class-token-with-examples',
+        description: 'CLASS_TOKEN skill that declares relative examples',
+        instructions: 'Inline',
+        resources: { examples: './examples' },
+      };
+      const record = {
+        kind: SkillKind.CLASS_TOKEN,
+        provide: class {} as never,
+        metadata,
+        callerDir: '/abs/skill-dir',
+      } as unknown as SkillRecord;
+      const instance = new SkillInstance(record, mockProviders, mockOwner);
+      await instance.ready;
+
+      await instance.load();
+
+      expect(mockResolveExamples).toHaveBeenCalledTimes(1);
+      expect(mockResolveExamples.mock.calls[0][0]).toBe('/abs/skill-dir/examples');
+    });
+  });
+
+  describe('loadInstructions() — ENOENT fallback regression (issue #413)', () => {
+    it('should re-throw ENOENT when no skill manifest is available, even for CLASS_TOKEN records', async () => {
+      const metadata: SkillMetadata = {
+        name: 'class-token-enoent',
+        description: 'CLASS_TOKEN skill whose file does not exist on disk',
+        instructions: { file: './missing.md' },
+      };
+      const record = {
+        kind: SkillKind.CLASS_TOKEN,
+        provide: class {} as never,
+        metadata,
+        callerDir: '/abs/skill-dir',
+      } as unknown as SkillRecord;
+      const instance = new SkillInstance(record, mockProviders, mockOwner);
+      await instance.ready;
+
+      const enoent = Object.assign(new Error('ENOENT: no such file or directory'), { code: 'ENOENT' });
+      mockLoadInstructions.mockRejectedValueOnce(enoent);
+
+      await expect(instance.loadInstructions()).rejects.toThrow(/ENOENT/);
+
+      // First call uses the captured callerDir as base path.
+      expect(mockLoadInstructions).toHaveBeenNthCalledWith(1, { file: './missing.md' }, '/abs/skill-dir');
     });
   });
 

--- a/libs/sdk/src/skill/__tests__/skill.utils.spec.ts
+++ b/libs/sdk/src/skill/__tests__/skill.utils.spec.ts
@@ -62,9 +62,11 @@ describe('skill.utils', () => {
 
       expect(result.kind).toBe(SkillKind.CLASS_TOKEN);
       if (result.kind === SkillKind.CLASS_TOKEN) {
-        expect(typeof result.callerDir).toBe('string');
-        // Decorator was evaluated inside this test file, so the captured dir is this directory.
-        expect(result.callerDir).toContain('/__tests__');
+        // Decorator was evaluated inside this test file, so callerDir should
+        // equal this directory. Comparing against `__dirname` is
+        // cross-platform — the prior substring check assumed POSIX
+        // separators and would fail on Windows runners (CodeRabbit PR #419).
+        expect(result.callerDir).toBe(__dirname);
       }
     });
 

--- a/libs/sdk/src/skill/__tests__/skill.utils.spec.ts
+++ b/libs/sdk/src/skill/__tests__/skill.utils.spec.ts
@@ -5,15 +5,16 @@
  */
 
 import 'reflect-metadata';
+
+import { SkillContext, SkillKind, type SkillContent, type SkillMetadata } from '../../common';
+import { Skill, skill } from '../../common/decorators/skill.decorator';
 import {
-  normalizeSkill,
-  isSkillRecord,
-  skillDiscoveryDeps,
   buildSkillContent,
   formatSkillForLLM,
+  isSkillRecord,
+  normalizeSkill,
+  skillDiscoveryDeps,
 } from '../skill.utils';
-import { SkillKind, SkillMetadata, SkillContext, SkillContent } from '../../common';
-import { Skill, skill } from '../../common/decorators/skill.decorator';
 
 // Mock SkillContext for testing
 class MockSkillContext extends SkillContext {
@@ -47,6 +48,24 @@ describe('skill.utils', () => {
       expect(result.kind).toBe(SkillKind.CLASS_TOKEN);
       expect(result.provide).toBe(ClassSkill);
       expect(result.metadata.name).toBe('class-skill');
+    });
+
+    it('should copy callerDir from class metadata onto the record (issue #413)', () => {
+      @Skill({
+        name: 'class-skill-with-caller',
+        description: 'A class-based skill that captures its source dir',
+        instructions: { file: './SKILL.md' },
+      })
+      class ClassSkillWithCaller extends MockSkillContext {}
+
+      const result = normalizeSkill(ClassSkillWithCaller);
+
+      expect(result.kind).toBe(SkillKind.CLASS_TOKEN);
+      if (result.kind === SkillKind.CLASS_TOKEN) {
+        expect(typeof result.callerDir).toBe('string');
+        // Decorator was evaluated inside this test file, so the captured dir is this directory.
+        expect(result.callerDir).toContain('/__tests__');
+      }
     });
 
     it('should passthrough SkillValueRecord from skill() helper', () => {

--- a/libs/sdk/src/skill/skill.instance.ts
+++ b/libs/sdk/src/skill/skill.instance.ts
@@ -114,9 +114,13 @@ export class SkillInstance extends SkillEntry {
       const filePath = this.record.filePath;
       const lastSlash = filePath.lastIndexOf('/');
       basePath = lastSlash > 0 ? filePath.substring(0, lastSlash) : undefined;
-    } else if (this.record.kind === SkillKind.VALUE && this.record.callerDir) {
-      // For inline skills created via skill(), use the caller's directory
-      // so that relative paths like './docs/my-skill.md' resolve correctly
+    } else if (
+      (this.record.kind === SkillKind.VALUE || this.record.kind === SkillKind.CLASS_TOKEN) &&
+      this.record.callerDir
+    ) {
+      // For inline skills created via skill() and class-decorated skills,
+      // use the caller's directory so that relative paths like
+      // './docs/my-skill.md' resolve relative to the source file rather than cwd.
       basePath = this.record.callerDir;
     }
 
@@ -152,7 +156,7 @@ export class SkillInstance extends SkillEntry {
     if (this.record.kind === SkillKind.FILE) {
       return dirname(this.record.filePath) || undefined;
     }
-    if (this.record.kind === SkillKind.VALUE && this.record.callerDir) {
+    if ((this.record.kind === SkillKind.VALUE || this.record.kind === SkillKind.CLASS_TOKEN) && this.record.callerDir) {
       return this.record.callerDir;
     }
     return undefined;

--- a/libs/sdk/src/skill/skill.utils.ts
+++ b/libs/sdk/src/skill/skill.utils.ts
@@ -10,6 +10,7 @@ import {
   isInlineInstructions,
   isUrlInstructions,
   normalizeToolRef,
+  skillCallerDir,
   SkillKind,
   type SkillContext,
   type SkillInstructionSource,
@@ -65,10 +66,12 @@ export function normalizeSkill(item: unknown): SkillRecord {
       const className = (item as object).constructor?.name ?? String(item);
       throw new InvalidSkillError(className, 'Class must be decorated with @Skill decorator and have a name property.');
     }
+    const callerDir = getMetadata(skillCallerDir, item as SkillType) as string | undefined;
     return {
       kind: SkillKind.CLASS_TOKEN,
       provide: item as Type<SkillContext>,
       metadata,
+      ...(callerDir ? { callerDir } : {}),
     };
   }
 

--- a/libs/sdk/src/skill/skill.utils.ts
+++ b/libs/sdk/src/skill/skill.utils.ts
@@ -1,7 +1,7 @@
 // file: libs/sdk/src/skill/skill.utils.ts
 
 import { depsOfClass, getMetadata, isClass, type Token, type Type } from '@frontmcp/di';
-import { fileExists, readdir, readFile, stat } from '@frontmcp/utils';
+import { fileExists, isAbsolute, pathJoin, readdir, readFile, stat } from '@frontmcp/utils';
 
 import {
   extendedSkillMetadata,
@@ -144,8 +144,13 @@ export async function loadInstructions(source: SkillInstructionSource, basePath?
   }
 
   if (isFileInstructions(source)) {
-    // Resolve file path
-    const filePath = basePath ? `${basePath}/${source.file}` : source.file;
+    // Resolve file path. When `source.file` is already absolute (callers like
+    // `resolveFromSkillManifest` pass absolute paths), prepending `basePath`
+    // produces nonsense like `/abs/bundle/dir//abs/user/file`. Guard with
+    // `isAbsolute` so absolute paths flow through untouched (fix for the
+    // PR #419 CI regression — `demo-e2e-skills` SKILL.md failed with
+    // `libs/sdk/dist//home/runner/.../SKILL.md`).
+    const filePath = isAbsolute(source.file) ? source.file : basePath ? pathJoin(basePath, source.file) : source.file;
     const content = await readFile(filePath, 'utf-8');
     // Strip YAML frontmatter if present (e.g., SKILL.md files)
     return stripFrontmatter(content);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Documented that resource bundles may include an examples directory and added an examples field to the Skill resources docs; clarified how relative instruction/resource paths are resolved (against the skill source file, with a build-time manifest fallback).

* **Improvements**
  * Made path resolution consistent for class- and value-defined skills so instruction/resource links resolve reliably after build.

* **Tests**
  * Added tests covering source-directory resolution and related regressions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/agentfront/frontmcp/pull/419)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->