### PR TITLE
fix: derive execute() input/output types from schemas in tool template

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -87,3 +87,4 @@ perf-results/
 /.claude/planning/
 ROADMAP.md
 planning/
+/.claude/*.lock

--- a/libs/nx-plugin/src/generators/tool/files/__fileName__.tool.ts__tmpl__
+++ b/libs/nx-plugin/src/generators/tool/files/__fileName__.tool.ts__tmpl__
@@ -1,18 +1,27 @@
-import { Tool, ToolContext } from '@frontmcp/sdk';
-import { z } from '@frontmcp/sdk';
+import { Tool, ToolContext, ToolInputOf, ToolOutputOf, z } from '@frontmcp/sdk';
+
+// Hoist only the schemas — the rest of the @Tool config (name, description,
+// annotations, throttling, …) stays inside @Tool({…}) where it naturally
+// lives. Changing a schema field automatically updates the derived TS types.
+const inputSchema = {
+  value: z.string().describe('TODO: replace with actual input'),
+};
+
+const outputSchema = {
+  result: z.string().describe('TODO: replace with actual output'),
+};
+
+export type <%= className %>Input = ToolInputOf<{ inputSchema: typeof inputSchema }>;
+export type <%= className %>Output = ToolOutputOf<{ outputSchema: typeof outputSchema }>;
 
 @Tool({
   name: '<%= name %>',
   description: 'TODO: describe what this tool does',
-  inputSchema: {
-    value: z.string().describe('TODO: replace with actual input'),
-  },
-  outputSchema: {
-    result: z.string().describe('TODO: replace with actual output'),
-  },
+  inputSchema,
+  outputSchema,
 })
 export default class <%= className %>Tool extends ToolContext {
-  async execute(input: { value: string }) {
+  async execute(input: <%= className %>Input): Promise<<%= className %>Output> {
     // TODO: implement
     return { result: input.value };
   }

--- a/libs/nx-plugin/src/generators/tool/tool.spec.ts
+++ b/libs/nx-plugin/src/generators/tool/tool.spec.ts
@@ -1,5 +1,6 @@
+import { addProjectConfiguration, type Tree } from '@nx/devkit';
 import { createTreeWithEmptyWorkspace } from '@nx/devkit/testing';
-import { type Tree, addProjectConfiguration } from '@nx/devkit';
+
 import { toolGenerator } from './tool';
 
 describe('tool generator', () => {
@@ -26,6 +27,25 @@ describe('tool generator', () => {
     const content = tree.read('apps/my-app/src/tools/calculate.tool.ts', 'utf-8');
     expect(content).toContain('class CalculateTool extends ToolContext');
     expect(content).toContain("name: 'calculate'");
+  });
+
+  it('should derive execute() types from schemas (issue #405)', async () => {
+    await toolGenerator(tree, { name: 'calculate', project: 'my-app', skipFormat: true });
+
+    const content = tree.read('apps/my-app/src/tools/calculate.tool.ts', 'utf-8');
+    // The template MUST emit derived types via ToolInputOf / ToolOutputOf
+    // so the schema stays the single source of truth (issue #405).
+    expect(content).toContain('ToolInputOf');
+    expect(content).toContain('ToolOutputOf');
+    expect(content).toContain('type CalculateInput = ToolInputOf<{ inputSchema: typeof inputSchema }>');
+    expect(content).toContain('type CalculateOutput = ToolOutputOf<{ outputSchema: typeof outputSchema }>');
+    expect(content).toContain('execute(input: CalculateInput): Promise<CalculateOutput>');
+    // The decorator config (name, description) MUST stay inline so the @Tool
+    // block remains self-contained — only the schemas are hoisted.
+    expect(content).toContain("name: 'calculate'");
+    // And MUST NOT emit the legacy inline-shape annotation that hand-typed
+    // the input next to the schema — the pattern #405 specifically removes.
+    expect(content).not.toContain('async execute(input: { value: string }');
   });
 
   it('should generate in subdirectory when specified', async () => {

--- a/libs/skills/catalog/frontmcp-development/examples/create-tool/basic-class-tool.md
+++ b/libs/skills/catalog/frontmcp-development/examples/create-tool/basic-class-tool.md
@@ -2,37 +2,54 @@
 name: basic-class-tool
 reference: create-tool
 level: basic
-description: 'A minimal tool using the class-based pattern with Zod input validation and output schema.'
+description: 'A minimal tool using the class-based pattern with Zod input validation, output schema, and types derived from the schemas.'
 tags: [development, tool, class]
 features:
   - 'Extending `ToolContext` and implementing the `execute()` method'
   - 'Using a Zod raw shape for `inputSchema` (not wrapped in `z.object()`)'
   - 'Defining `outputSchema` to validate and restrict output fields'
+  - 'Deriving `execute()` input/output types from the schemas via `ToolInputOf<>` / `ToolOutputOf<>` (no duplicated annotation)'
+  - 'Co-locating schema and tool in sibling files (`<name>.schema.ts` / `<name>.tool.ts`)'
   - 'Registering the tool in an `@App` via the `tools` array'
 ---
 
 # Basic Class-Based Tool
 
-A minimal tool using the class-based pattern with Zod input validation and output schema.
+A minimal tool using the class-based pattern with Zod input validation, output schema, and types derived from the schemas.
 
 ## Code
 
 ```typescript
+// src/apps/main/tools/greet-user.schema.ts
+import { ToolInputOf, ToolOutputOf, z } from '@frontmcp/sdk';
+
+// Hoist only the schemas — keep `@Tool({…})` self-contained in the tool file.
+export const inputSchema = {
+  name: z.string().describe('The name of the user to greet'),
+};
+
+export const outputSchema = {
+  greeting: z.string(),
+};
+
+export type GreetUserInput = ToolInputOf<{ inputSchema: typeof inputSchema }>;
+export type GreetUserOutput = ToolOutputOf<{ outputSchema: typeof outputSchema }>;
+```
+
+```typescript
 // src/apps/main/tools/greet-user.tool.ts
-import { Tool, ToolContext, z } from '@frontmcp/sdk';
+import { Tool, ToolContext } from '@frontmcp/sdk';
+
+import { inputSchema, outputSchema, type GreetUserInput, type GreetUserOutput } from './greet-user.schema';
 
 @Tool({
   name: 'greet_user',
   description: 'Greet a user by name',
-  inputSchema: {
-    name: z.string().describe('The name of the user to greet'),
-  },
-  outputSchema: {
-    greeting: z.string(),
-  },
+  inputSchema,
+  outputSchema,
 })
 class GreetUserTool extends ToolContext {
-  async execute(input: { name: string }): Promise<{ greeting: string }> {
+  async execute(input: GreetUserInput): Promise<GreetUserOutput> {
     return { greeting: `Hello, ${input.name}!` };
   }
 }
@@ -54,8 +71,10 @@ class MainApp {}
 - Extending `ToolContext` and implementing the `execute()` method
 - Using a Zod raw shape for `inputSchema` (not wrapped in `z.object()`)
 - Defining `outputSchema` to validate and restrict output fields
+- Deriving `execute()` input/output types from the schemas via `ToolInputOf<>` / `ToolOutputOf<>` (no duplicated annotation)
+- Co-locating schema and tool in sibling files (`<name>.schema.ts` / `<name>.tool.ts`)
 - Registering the tool in an `@App` via the `tools` array
 
 ## Related
 
-- See `create-tool` for the full API reference including annotations, rate limiting, and elicitation
+- See `create-tool` for the full API reference including the derive-types pattern, file layouts, annotations, rate limiting, and elicitation

--- a/libs/skills/catalog/frontmcp-development/examples/create-tool/tool-with-di-and-errors.md
+++ b/libs/skills/catalog/frontmcp-development/examples/create-tool/tool-with-di-and-errors.md
@@ -2,18 +2,32 @@
 name: tool-with-di-and-errors
 reference: create-tool
 level: intermediate
-description: 'A tool that resolves a database service via DI and uses `this.fail()` for business-logic errors.'
+description: 'A tool that resolves a database service via DI and uses `this.fail()` for business-logic errors, with `execute()` types derived from the schemas.'
 tags: [development, database, tool, di, errors]
 features:
   - 'Defining a typed DI token with `Token<T>` and resolving it via `this.get()`'
   - 'Using `this.fail()` with `ResourceNotFoundError` for MCP-compliant error responses'
   - 'Letting infrastructure errors (database failures) propagate naturally to the framework'
+  - 'Deriving `execute()` types from `inputSchema` / `outputSchema` via `ToolInputOf<>` / `ToolOutputOf<>`'
+  - 'Folder-per-tool layout (`tools/delete-record/{schema,tool,index}.ts`) for tools with local helpers or error types'
   - 'Registering both the provider and tool in the same `@App`'
 ---
 
 # Tool with Dependency Injection and Error Handling
 
-A tool that resolves a database service via DI and uses `this.fail()` for business-logic errors.
+A tool that resolves a database service via DI and uses `this.fail()` for business-logic errors, with `execute()` types derived from the schemas.
+
+## File layout
+
+```
+src/apps/main/
+├── tokens.ts                              # shared DI tokens
+└── tools/
+    └── delete-record/
+        ├── delete-record.schema.ts        # input/output schemas + derived types
+        ├── delete-record.tool.ts          # @Tool class, execute()
+        └── index.ts                       # barrel re-export
+```
 
 ## Code
 
@@ -29,23 +43,38 @@ export const DATABASE: Token<DatabaseService> = Symbol('database');
 ```
 
 ```typescript
-// src/apps/main/tools/delete-record.tool.ts
-import { ResourceNotFoundError, Tool, ToolContext, z } from '@frontmcp/sdk';
+// src/apps/main/tools/delete-record/delete-record.schema.ts
+import { ToolInputOf, ToolOutputOf, z } from '@frontmcp/sdk';
 
-import { DATABASE } from '../tokens';
+// Only the schemas live here — decorator config (`name`, `description`, …)
+// stays inside @Tool({…}) in the tool file.
+export const inputSchema = {
+  id: z.string().uuid().describe('Record UUID'),
+};
+
+export const outputSchema = {
+  message: z.string(),
+};
+
+export type DeleteRecordInput = ToolInputOf<{ inputSchema: typeof inputSchema }>;
+export type DeleteRecordOutput = ToolOutputOf<{ outputSchema: typeof outputSchema }>;
+```
+
+```typescript
+// src/apps/main/tools/delete-record/delete-record.tool.ts
+import { ResourceNotFoundError, Tool, ToolContext } from '@frontmcp/sdk';
+
+import { DATABASE } from '../../tokens';
+import { inputSchema, outputSchema, type DeleteRecordInput, type DeleteRecordOutput } from './delete-record.schema';
 
 @Tool({
   name: 'delete_record',
   description: 'Delete a record by ID',
-  inputSchema: {
-    id: z.string().uuid().describe('Record UUID'),
-  },
-  outputSchema: {
-    message: z.string(),
-  },
+  inputSchema,
+  outputSchema,
 })
-class DeleteRecordTool extends ToolContext {
-  async execute(input: { id: string }): Promise<{ message: string }> {
+export class DeleteRecordTool extends ToolContext {
+  async execute(input: DeleteRecordInput): Promise<DeleteRecordOutput> {
     const db = this.get(DATABASE);
     const rows = await db.query('SELECT * FROM records WHERE id = $1', [input.id]);
 
@@ -60,8 +89,21 @@ class DeleteRecordTool extends ToolContext {
 ```
 
 ```typescript
+// src/apps/main/tools/delete-record/index.ts
+export { DeleteRecordTool } from './delete-record.tool';
+export {
+  inputSchema as deleteRecordInputSchema,
+  outputSchema as deleteRecordOutputSchema,
+  type DeleteRecordInput,
+  type DeleteRecordOutput,
+} from './delete-record.schema';
+```
+
+```typescript
 // src/apps/main/index.ts
 import { App } from '@frontmcp/sdk';
+
+import { DeleteRecordTool } from './tools/delete-record';
 
 @App({
   name: 'main',
@@ -76,9 +118,11 @@ class MainApp {}
 - Defining a typed DI token with `Token<T>` and resolving it via `this.get()`
 - Using `this.fail()` with `ResourceNotFoundError` for MCP-compliant error responses
 - Letting infrastructure errors (database failures) propagate naturally to the framework
+- Deriving `execute()` types from `inputSchema` / `outputSchema` via `ToolInputOf<>` / `ToolOutputOf<>`
+- Folder-per-tool layout (`tools/delete-record/{schema,tool,index}.ts`) for tools with local helpers or error types
 - Registering both the provider and tool in the same `@App`
 
 ## Related
 
-- See `create-tool` for all context methods and error handling patterns
+- See `create-tool` for all context methods, the derive-types pattern, and error handling
 - See `create-provider` for how to implement the `DatabaseProvider` class

--- a/libs/skills/catalog/frontmcp-development/examples/create-tool/tool-with-di-and-errors.md
+++ b/libs/skills/catalog/frontmcp-development/examples/create-tool/tool-with-di-and-errors.md
@@ -19,7 +19,7 @@ A tool that resolves a database service via DI and uses `this.fail()` for busine
 
 ## File layout
 
-```
+```text
 src/apps/main/
 ├── tokens.ts                              # shared DI tokens
 └── tools/

--- a/libs/skills/catalog/frontmcp-development/examples/create-tool/tool-with-di-and-errors.md
+++ b/libs/skills/catalog/frontmcp-development/examples/create-tool/tool-with-di-and-errors.md
@@ -103,6 +103,10 @@ export {
 // src/apps/main/index.ts
 import { App } from '@frontmcp/sdk';
 
+// `DatabaseProvider` is the singleton that backs `DATABASE` — see the
+// `create-provider` skill for an `AsyncProvider({ useFactory })` reference
+// implementation that opens a connection pool at startup.
+import { DatabaseProvider } from './providers/database';
 import { DeleteRecordTool } from './tools/delete-record';
 
 @App({

--- a/libs/skills/catalog/frontmcp-development/examples/create-tool/tool-with-rate-limiting-and-progress.md
+++ b/libs/skills/catalog/frontmcp-development/examples/create-tool/tool-with-rate-limiting-and-progress.md
@@ -2,7 +2,7 @@
 name: tool-with-rate-limiting-and-progress
 reference: create-tool
 level: advanced
-description: 'A batch processing tool that uses rate limiting, concurrency control, progress notifications, and annotations.'
+description: 'A batch processing tool that uses rate limiting, concurrency control, progress notifications, and annotations, with `execute()` types derived from the schemas.'
 tags: [development, throttle, tool, rate, limiting, progress]
 features:
   - 'Configuring `rateLimit`, `concurrency`, and `timeout` for throttling protection'
@@ -10,28 +10,45 @@ features:
   - 'Using `this.mark(stage)` for execution stage tracking and debugging'
   - 'Sending log-level notifications with `this.notify(message, level)`'
   - 'Setting tool `annotations` to communicate behavioral hints to clients'
+  - 'Deriving `execute()` types from the schemas via `ToolInputOf<>` / `ToolOutputOf<>`'
 ---
 
 # Tool with Rate Limiting, Progress, and Annotations
 
-A batch processing tool that uses rate limiting, concurrency control, progress notifications, and annotations.
+A batch processing tool that uses rate limiting, concurrency control, progress notifications, and annotations, with `execute()` types derived from the schemas.
 
 ## Code
 
 ```typescript
+// src/apps/main/tools/batch-process.schema.ts
+import { ToolInputOf, ToolOutputOf, z } from '@frontmcp/sdk';
+
+// Schemas only — `annotations`, `rateLimit`, `concurrency`, `timeout` etc.
+// stay inside @Tool({…}) in the tool file.
+export const inputSchema = {
+  items: z.array(z.string()).min(1).describe('Items to process'),
+};
+
+export const outputSchema = {
+  processed: z.number(),
+  results: z.array(z.string()),
+};
+
+export type BatchProcessInput = ToolInputOf<{ inputSchema: typeof inputSchema }>;
+export type BatchProcessOutput = ToolOutputOf<{ outputSchema: typeof outputSchema }>;
+```
+
+```typescript
 // src/apps/main/tools/batch-process.tool.ts
-import { Tool, ToolContext, z } from '@frontmcp/sdk';
+import { Tool, ToolContext } from '@frontmcp/sdk';
+
+import { inputSchema, outputSchema, type BatchProcessInput, type BatchProcessOutput } from './batch-process.schema';
 
 @Tool({
   name: 'batch_process',
   description: 'Process a batch of items with progress tracking',
-  inputSchema: {
-    items: z.array(z.string()).min(1).describe('Items to process'),
-  },
-  outputSchema: {
-    processed: z.number(),
-    results: z.array(z.string()),
-  },
+  inputSchema,
+  outputSchema,
   annotations: {
     title: 'Batch Processor',
     readOnlyHint: false,
@@ -43,7 +60,7 @@ import { Tool, ToolContext, z } from '@frontmcp/sdk';
   timeout: { executeMs: 30_000 },
 })
 class BatchProcessTool extends ToolContext {
-  async execute(input: { items: string[] }): Promise<{ processed: number; results: string[] }> {
+  async execute(input: BatchProcessInput): Promise<BatchProcessOutput> {
     this.mark('validation');
     if (input.items.some((item) => item.trim() === '')) {
       this.fail(new Error('Items must not be empty strings'));
@@ -86,7 +103,8 @@ class MainApp {}
 - Using `this.mark(stage)` for execution stage tracking and debugging
 - Sending log-level notifications with `this.notify(message, level)`
 - Setting tool `annotations` to communicate behavioral hints to clients
+- Deriving `execute()` types from the schemas via `ToolInputOf<>` / `ToolOutputOf<>`
 
 ## Related
 
-- See `create-tool` for all annotation fields, elicitation, and auth provider patterns
+- See `create-tool` for the full derive-types pattern, annotation fields, elicitation, and auth provider patterns

--- a/libs/skills/catalog/frontmcp-development/references/create-tool.md
+++ b/libs/skills/catalog/frontmcp-development/references/create-tool.md
@@ -103,7 +103,7 @@ Two layouts are endorsed. Pick based on tool count and whether the tool has loca
 
 **Flat sibling files** — works well for projects with ≤3 tools per app, or when each tool is small enough to fit in one screen:
 
-```
+```text
 src/apps/<app>/tools/
 ├── get-weather.tool.ts        # @Tool class, execute()
 ├── get-weather.schema.ts      # input/output schemas + derived types
@@ -112,7 +112,7 @@ src/apps/<app>/tools/
 
 **Folder-per-tool** — recommended for >3 tools per app, or any tool with local helpers, fixtures, or error types:
 
-```
+```text
 src/apps/<app>/tools/
 └── get-weather/
     ├── get-weather.tool.ts        # @Tool class, execute()

--- a/libs/skills/catalog/frontmcp-development/references/create-tool.md
+++ b/libs/skills/catalog/frontmcp-development/references/create-tool.md
@@ -31,24 +31,36 @@ Tools are the primary way to expose executable actions to AI clients in the MCP 
 
 ## Class-Based Pattern
 
-Create a class extending `ToolContext` and implement the `execute(input)` method. The `@Tool` decorator requires at minimum a `name` and an `inputSchema`. Do **not** parameterize `ToolContext` with explicit generics — the input/output types are inferred automatically from the `@Tool` decorator.
+Create a class extending `ToolContext` and implement the `execute(input)` method. The `@Tool` decorator requires at minimum a `name` and an `inputSchema`. Do **not** parameterize `ToolContext` with explicit generics — the input/output types are inferred automatically from the `@Tool` decorator. Hoist the **schemas only** to module scope and derive the `execute()` parameter and return types with `ToolInputOf<>` / `ToolOutputOf<>`, so the schema stays the single source of truth (issue #405). Keep `name`, `description`, `annotations`, `rateLimit`, etc. inside the decorator where they belong.
 
 ```typescript
-import { Tool, ToolContext, z } from '@frontmcp/sdk';
+import { Tool, ToolContext, ToolInputOf, ToolOutputOf, z } from '@frontmcp/sdk';
+
+const inputSchema = {
+  name: z.string().describe('The name of the user to greet'),
+};
+
+const outputSchema = {
+  greeting: z.string(),
+};
+
+type GreetUserInput = ToolInputOf<{ inputSchema: typeof inputSchema }>;
+type GreetUserOutput = ToolOutputOf<{ outputSchema: typeof outputSchema }>;
 
 @Tool({
   name: 'greet_user',
   description: 'Greet a user by name',
-  inputSchema: {
-    name: z.string().describe('The name of the user to greet'),
-  },
+  inputSchema,
+  outputSchema,
 })
 class GreetUserTool extends ToolContext {
-  async execute(input: { name: string }) {
-    return `Hello, ${input.name}!`;
+  async execute(input: GreetUserInput): Promise<GreetUserOutput> {
+    return { greeting: `Hello, ${input.name}!` };
   }
 }
 ```
+
+> **Why derive the types?** Hand-typing `execute(input: { name: string })` next to the schema is a second declaration of the same shape. Change the schema without touching the annotation and TypeScript happily compiles — validation moves to runtime and the IDE never warns. Derived types make the schema the single source of truth: change a Zod field and the `execute()` signature follows automatically. Only the **schemas** are hoisted so they can be re-imported by specs, sibling tools, and generated clients; everything else (`name`, `description`, `annotations`, `rateLimit`, `authProviders`, …) stays inside `@Tool({…})` where the decorator config naturally lives. See [File layout](#file-layout) for sibling-file and folder-per-tool variants.
 
 ### Available Context Methods and Properties
 
@@ -85,6 +97,43 @@ class GreetUserTool extends ToolContext {
 | `timestamp`    | `number`            | Request timestamp                   |
 | `metadata`     | `RequestMetadata`   | Request headers, client IP, etc.    |
 
+## File layout
+
+Two layouts are endorsed. Pick based on tool count and whether the tool has local helpers, fixtures, or error types.
+
+**Flat sibling files** — works well for projects with ≤3 tools per app, or when each tool is small enough to fit in one screen:
+
+```
+src/apps/<app>/tools/
+├── get-weather.tool.ts        # @Tool class, execute()
+├── get-weather.schema.ts      # input/output schemas + derived types
+└── get-weather.tool.spec.ts   # unit tests
+```
+
+**Folder-per-tool** — recommended for >3 tools per app, or any tool with local helpers, fixtures, or error types:
+
+```
+src/apps/<app>/tools/
+└── get-weather/
+    ├── get-weather.tool.ts        # @Tool class, execute()
+    ├── get-weather.schema.ts      # input/output schemas + derived types
+    ├── get-weather.tool.spec.ts   # unit tests
+    ├── index.ts                   # barrel re-export
+    └── …                          # tool-local helpers, fixtures, error types
+```
+
+Either way the schemas live in their own file so they can be imported from the tool class, the spec, sibling tools, or generated clients without dragging the `@Tool`-decorated class along. Sample `index.ts` for the folder layout:
+
+```typescript
+export { GetWeatherTool } from './get-weather.tool';
+export {
+  inputSchema as getWeatherInputSchema,
+  outputSchema as getWeatherOutputSchema,
+  type GetWeatherInput,
+  type GetWeatherOutput,
+} from './get-weather.schema';
+```
+
 ## Input Schema: Zod Raw Shapes
 
 The `inputSchema` accepts a **Zod raw shape** -- a plain object mapping field names to Zod types. Do NOT wrap it in `z.object()`. The framework wraps it internally.
@@ -119,25 +168,28 @@ The `execute()` parameter type must match the inferred output of `z.object(input
 3. **Type safety** -- `ToolContext` infers the output type from `outputSchema` automatically (no explicit generics needed), giving you compile-time guarantees that `execute()` returns the correct shape.
 
 ```typescript
+const inputSchema = {
+  city: z.string().describe('City name'),
+};
+
+// Always define outputSchema to validate output and prevent data leaks
+const outputSchema = {
+  temperature: z.number(),
+  unit: z.enum(['celsius', 'fahrenheit']),
+  description: z.string(),
+};
+
+type GetWeatherInput = ToolInputOf<{ inputSchema: typeof inputSchema }>;
+type GetWeatherOutput = ToolOutputOf<{ outputSchema: typeof outputSchema }>;
+
 @Tool({
   name: 'get_weather',
   description: 'Get current weather for a location',
-  inputSchema: {
-    city: z.string().describe('City name'),
-  },
-  // Always define outputSchema to validate output and prevent data leaks
-  outputSchema: {
-    temperature: z.number(),
-    unit: z.enum(['celsius', 'fahrenheit']),
-    description: z.string(),
-  },
+  inputSchema,
+  outputSchema,
 })
 class GetWeatherTool extends ToolContext {
-  async execute(input: { city: string }): Promise<{
-    temperature: number;
-    unit: 'celsius' | 'fahrenheit';
-    description: string;
-  }> {
+  async execute(input: GetWeatherInput): Promise<GetWeatherOutput> {
     const response = await this.fetch(`https://api.weather.example.com/v1/current?city=${input.city}`);
     const weather = await response.json();
     // Only temperature, unit, and description are returned.
@@ -157,13 +209,15 @@ class GetWeatherTool extends ToolContext {
 - CodeCall cannot infer return types for chaining tool calls in VM scripts
 - No compile-time type checking on the return value
 
-### Typed Output Patterns
+### Derive `execute()` types from the schemas (recommended)
 
-`ToolContext` infers both input and output types from the `@Tool` decorator's `inputSchema` / `outputSchema`. Do not pass explicit generics — the inference is automatic and gives you full type safety with no `as any` casts:
+`ToolContext` already infers the input/output types from the `@Tool` decorator at the **class** level (no generics needed). To make the same types reachable from your `execute()` signature — and from sibling files like specs, helpers, or generated clients — hoist the **schemas only** to module scope and derive types from them with `ToolInputOf<>` / `ToolOutputOf<>` exported from `@frontmcp/sdk`. The decorator config (`name`, `description`, `annotations`, `rateLimit`, …) stays inline:
 
 ```typescript
+import { Tool, ToolContext, ToolInputOf, ToolOutputOf, z } from '@frontmcp/sdk';
+
 const inputSchema = {
-  city: z.string(),
+  city: z.string().describe('City name'),
 };
 
 const outputSchema = {
@@ -171,20 +225,35 @@ const outputSchema = {
   unit: z.enum(['celsius', 'fahrenheit']),
 };
 
+type GetWeatherInput = ToolInputOf<{ inputSchema: typeof inputSchema }>;
+type GetWeatherOutput = ToolOutputOf<{ outputSchema: typeof outputSchema }>;
+
 @Tool({
   name: 'get_weather',
+  description: 'Get current weather for a location',
   inputSchema,
   outputSchema,
 })
-// No generics needed — ToolContext infers types from the @Tool decorator
 class GetWeatherTool extends ToolContext {
-  async execute(input: { city: string }) {
-    // Return type is inferred as { temperature: number; unit: 'celsius' | 'fahrenheit' }
-    // TypeScript will error if you return the wrong shape
-    return { temperature: 22, unit: 'celsius' as const };
+  async execute(input: GetWeatherInput): Promise<GetWeatherOutput> {
+    return { temperature: 22, unit: 'celsius' };
   }
 }
 ```
+
+**Two equivalent forms** — pick whichever fits the surrounding code; they produce identical types:
+
+```typescript
+// Form 1 — SDK helpers (preferred — works with the type returned by ToolContext)
+type GetWeatherInput = ToolInputOf<{ inputSchema: typeof inputSchema }>;
+type GetWeatherOutput = ToolOutputOf<{ outputSchema: typeof outputSchema }>;
+
+// Form 2 — raw zod (terser if you don't mind a direct z dependency)
+type GetWeatherInput = z.infer<z.ZodObject<typeof inputSchema>>;
+type GetWeatherOutput = z.infer<z.ZodObject<typeof outputSchema>>;
+```
+
+> **Never duplicate the shape inline on `execute()` — derive it.** If the schema changes, the type changes automatically. If it doesn't, the compiler tells you exactly which call sites broke. And only hoist the **schemas** — leaving `name`/`description`/`annotations`/throttling inside `@Tool({…})` keeps the decorator declaration self-contained and easy to scan.
 
 **`return` vs `this.respond()`** — Both work and both are validated against `outputSchema` in the finalize stage:
 
@@ -675,14 +744,16 @@ class ConvertCurrencyTool extends ToolContext {
 
 ## Common Patterns
 
-| Pattern              | Correct                                         | Incorrect                                              | Why                                                                              |
-| -------------------- | ----------------------------------------------- | ------------------------------------------------------ | -------------------------------------------------------------------------------- |
-| Input schema         | `inputSchema: { name: z.string() }` (raw shape) | `inputSchema: z.object({ name: z.string() })`          | Framework wraps in `z.object()` internally                                       |
-| Output schema        | Always define `outputSchema`                    | Omit `outputSchema`                                    | Prevents data leaks and enables CodeCall chaining                                |
-| DI resolution        | `this.get(TOKEN)` with proper error handling    | `this.tryGet(TOKEN)!` with non-null assertion          | `get` throws a clear error; non-null assertions mask failures                    |
-| Error handling       | `this.fail(new ResourceNotFoundError(...))`     | `throw new Error(...)`                                 | `this.fail` triggers the error flow with MCP error codes                         |
-| Tool naming          | `snake_case` names: `get_weather`               | `camelCase` or `PascalCase`: `getWeather`              | MCP protocol convention for tool names                                           |
-| ToolContext generics | `class MyTool extends ToolContext`              | `class MyTool extends ToolContext<typeof inputSchema>` | Types are auto-inferred from `@Tool` decorator — explicit generics are redundant |
+| Pattern              | Correct                                                                                                               | Incorrect                                                        | Why                                                                                                |
+| -------------------- | --------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------- | -------------------------------------------------------------------------------------------------- |
+| Input schema         | `inputSchema: { name: z.string() }` (raw shape)                                                                       | `inputSchema: z.object({ name: z.string() })`                    | Framework wraps in `z.object()` internally                                                         |
+| Output schema        | Always define `outputSchema`                                                                                          | Omit `outputSchema`                                              | Prevents data leaks and enables CodeCall chaining                                                  |
+| `execute()` types    | Derive via `ToolInputOf<{ inputSchema: typeof inputSchema }>` / `ToolOutputOf<{ outputSchema: typeof outputSchema }>` | Inline `execute(input: { city: string })` annotation             | Schema is the single source of truth — derive once, use everywhere; no silent drift                |
+| File layout          | Schema in `<name>.schema.ts`, class in `<name>.tool.ts` (sibling files or folder-per-tool)                            | One large `<name>.tool.ts` that bundles schema + class + helpers | Schema can be imported by specs, sibling tools, generated clients without dragging the class along |
+| DI resolution        | `this.get(TOKEN)` with proper error handling                                                                          | `this.tryGet(TOKEN)!` with non-null assertion                    | `get` throws a clear error; non-null assertions mask failures                                      |
+| Error handling       | `this.fail(new ResourceNotFoundError(...))`                                                                           | `throw new Error(...)`                                           | `this.fail` triggers the error flow with MCP error codes                                           |
+| Tool naming          | `snake_case` names: `get_weather`                                                                                     | `camelCase` or `PascalCase`: `getWeather`                        | MCP protocol convention for tool names                                                             |
+| ToolContext generics | `class MyTool extends ToolContext`                                                                                    | `class MyTool extends ToolContext<typeof inputSchema>`           | Types are auto-inferred from `@Tool` decorator — explicit generics are redundant                   |
 
 ## Verification Checklist
 
@@ -714,11 +785,11 @@ class ConvertCurrencyTool extends ToolContext {
 
 ## Examples
 
-| Example                                                                                                   | Level        | Description                                                                                                    |
-| --------------------------------------------------------------------------------------------------------- | ------------ | -------------------------------------------------------------------------------------------------------------- |
-| [`basic-class-tool`](../examples/create-tool/basic-class-tool.md)                                         | Basic        | A minimal tool using the class-based pattern with Zod input validation and output schema.                      |
-| [`tool-with-di-and-errors`](../examples/create-tool/tool-with-di-and-errors.md)                           | Intermediate | A tool that resolves a database service via DI and uses `this.fail()` for business-logic errors.               |
-| [`tool-with-rate-limiting-and-progress`](../examples/create-tool/tool-with-rate-limiting-and-progress.md) | Advanced     | A batch processing tool that uses rate limiting, concurrency control, progress notifications, and annotations. |
+| Example                                                                                                   | Level        | Description                                                                                                                                                     |
+| --------------------------------------------------------------------------------------------------------- | ------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| [`basic-class-tool`](../examples/create-tool/basic-class-tool.md)                                         | Basic        | A minimal tool using the class-based pattern with Zod input validation, output schema, and types derived from the schemas.                                      |
+| [`tool-with-di-and-errors`](../examples/create-tool/tool-with-di-and-errors.md)                           | Intermediate | A tool that resolves a database service via DI and uses `this.fail()` for business-logic errors, with `execute()` types derived from the schemas.               |
+| [`tool-with-rate-limiting-and-progress`](../examples/create-tool/tool-with-rate-limiting-and-progress.md) | Advanced     | A batch processing tool that uses rate limiting, concurrency control, progress notifications, and annotations, with `execute()` types derived from the schemas. |
 
 > See all examples in [`examples/create-tool/`](../examples/create-tool/)
 

--- a/libs/skills/catalog/skills-manifest.json
+++ b/libs/skills/catalog/skills-manifest.json
@@ -1393,31 +1393,35 @@
           "examples": [
             {
               "name": "basic-class-tool",
-              "description": "A minimal tool using the class-based pattern with Zod input validation and output schema.",
+              "description": "A minimal tool using the class-based pattern with Zod input validation, output schema, and types derived from the schemas.",
               "level": "basic",
               "tags": ["development", "tool", "class"],
               "features": [
                 "Extending `ToolContext` and implementing the `execute()` method",
                 "Using a Zod raw shape for `inputSchema` (not wrapped in `z.object()`)",
                 "Defining `outputSchema` to validate and restrict output fields",
+                "Deriving `execute()` input/output types from the schemas via `ToolInputOf<>` / `ToolOutputOf<>` (no duplicated annotation)",
+                "Co-locating schema and tool in sibling files (`<name>.schema.ts` / `<name>.tool.ts`)",
                 "Registering the tool in an `@App` via the `tools` array"
               ]
             },
             {
               "name": "tool-with-di-and-errors",
-              "description": "A tool that resolves a database service via DI and uses `this.fail()` for business-logic errors.",
+              "description": "A tool that resolves a database service via DI and uses `this.fail()` for business-logic errors, with `execute()` types derived from the schemas.",
               "level": "intermediate",
               "tags": ["development", "database", "tool", "di", "errors"],
               "features": [
                 "Defining a typed DI token with `Token<T>` and resolving it via `this.get()`",
                 "Using `this.fail()` with `ResourceNotFoundError` for MCP-compliant error responses",
                 "Letting infrastructure errors (database failures) propagate naturally to the framework",
+                "Deriving `execute()` types from `inputSchema` / `outputSchema` via `ToolInputOf<>` / `ToolOutputOf<>`",
+                "Folder-per-tool layout (`tools/delete-record/{schema,tool,index}.ts`) for tools with local helpers or error types",
                 "Registering both the provider and tool in the same `@App`"
               ]
             },
             {
               "name": "tool-with-rate-limiting-and-progress",
-              "description": "A batch processing tool that uses rate limiting, concurrency control, progress notifications, and annotations.",
+              "description": "A batch processing tool that uses rate limiting, concurrency control, progress notifications, and annotations, with `execute()` types derived from the schemas.",
               "level": "advanced",
               "tags": ["development", "throttle", "tool", "rate", "limiting", "progress"],
               "features": [
@@ -1425,7 +1429,8 @@
                 "Sending progress updates to the client with `this.progress(progress, total, message?)`",
                 "Using `this.mark(stage)` for execution stage tracking and debugging",
                 "Sending log-level notifications with `this.notify(message, level)`",
-                "Setting tool `annotations` to communicate behavioral hints to clients"
+                "Setting tool `annotations` to communicate behavioral hints to clients",
+                "Deriving `execute()` types from the schemas via `ToolInputOf<>` / `ToolOutputOf<>`"
               ]
             }
           ]


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * execute() input/output types are now derived from declared schemas, standardizing typing and promoting schema-first patterns.
  * Encourages folder-per-tool or sibling-file layouts for clearer schema/tool separation and re-export patterns.

* **Documentation**
  * Updated guides, examples, and reference docs to demonstrate schema-driven type derivation, file layout options, and related patterns.

* **Tests**
  * Added/updated tests to assert generated tools emit schema-derived execute() types.

* **Chores**
  * .gitignore updated to ignore new lock files.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/agentfront/frontmcp/pull/428?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->