### PR TITLE
feat: add /metrics endpoint with Prometheus support and configuration options

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -87,3 +87,4 @@ perf-results/
 /.claude/planning/
 ROADMAP.md
 planning/
+/.claude/scheduled_tasks.lock

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -167,6 +167,7 @@
                   "frontmcp/deployment/direct-client",
                   "frontmcp/deployment/unix-socket",
                   "frontmcp/deployment/health-checks",
+                  "frontmcp/deployment/metrics",
                   "frontmcp/deployment/high-availability",
                   "frontmcp/deployment/frontmcp-config",
                   "frontmcp/deployment/machine-id",

--- a/docs/frontmcp/deployment/metrics.mdx
+++ b/docs/frontmcp/deployment/metrics.mdx
@@ -1,0 +1,179 @@
+---
+title: Prometheus /metrics Endpoint
+sidebarTitle: Metrics
+description: Configure the /metrics endpoint that exposes process metrics and framework counters in Prometheus text format
+icon: 'chart-line'
+keywords: ['frontmcp', 'mcp', 'model context protocol', 'metrics', 'prometheus', 'observability', 'monitoring', 'grafana', 'typescript']
+---
+
+FrontMCP can expose process metrics (CPU, RSS, heap, event-loop lag) and every framework counter (`frontmcp_skills_*_total`, plus any counter emitted via `createCounter()`) as a Prometheus scrape endpoint on the same HTTP listener as `/healthz`. The endpoint is **off by default** — turn it on with `metrics: { enabled: true }`.
+
+## Quick Start
+
+```typescript
+import { FrontMcp } from '@frontmcp/sdk';
+
+@FrontMcp({
+  info: { name: 'my-server', version: '1.0.0' },
+  apps: [MyApp],
+  metrics: { enabled: true },
+})
+class Server {}
+```
+
+Then scrape it:
+
+```bash
+curl http://localhost:3001/metrics
+```
+
+```
+# HELP frontmcp_process_resident_memory_bytes Resident memory size in bytes
+# TYPE frontmcp_process_resident_memory_bytes gauge
+frontmcp_process_resident_memory_bytes 50331648
+# HELP frontmcp_process_uptime_seconds Time since process start in seconds
+# TYPE frontmcp_process_uptime_seconds gauge
+frontmcp_process_uptime_seconds 42
+# TYPE frontmcp_skills_bundle_pulls_total counter
+frontmcp_skills_bundle_pulls_total{source="npm"} 3
+...
+```
+
+The Content-Type is the canonical Prometheus `text/plain; version=0.0.4; charset=utf-8`.
+
+## What the endpoint exposes
+
+When enabled, every scrape returns:
+
+| Category | Examples | Source |
+| --- | --- | --- |
+| Process gauges | `frontmcp_process_resident_memory_bytes`, `frontmcp_process_heap_bytes`, `frontmcp_process_uptime_seconds`, `frontmcp_process_cpu_seconds_total{mode="user"\|"system"}` | Built-in `ProcessStatsCollector` |
+| Node.js gauges | `frontmcp_nodejs_eventloop_lag_seconds{quantile="mean"\|"p99"}`, `frontmcp_nodejs_active_handles`, `frontmcp_nodejs_active_requests`, `frontmcp_nodejs_open_fds` (Linux only) | `perf_hooks` + `process._getActiveHandles()` |
+| Framework counters | `frontmcp_skills_bundle_pulls_total`, `frontmcp_skills_signature_*_total`, `frontmcp_skills_replay_*_total`, `frontmcp_skills_audit_*_total` | `@frontmcp/observability`'s in-memory counter snapshot store |
+| Custom counters | Anything emitted via `createCounter('my_counter_total').inc()` | Same snapshot store |
+
+`createCounter()` from `@frontmcp/observability` writes into the same store the scrape reads from — no extra wiring needed.
+
+## Configuration
+
+```typescript
+@FrontMcp({
+  metrics: {
+    enabled: true,                       // default: false
+    path: '/metrics',                    // default: '/metrics'
+    format: 'prometheus',                // 'prometheus' | 'json', default: 'prometheus'
+    auth: 'public',                      // 'public' | 'token' | { token: string }, default: 'public'
+    tokenEnv: 'FRONTMCP_METRICS_TOKEN',  // env var to read the bearer from when auth: 'token'
+    include: ['process', 'skills'],      // optional category filter
+    process: {
+      eventLoopLag: true,                // include event-loop lag gauge
+      fdCount: true,                     // include /proc/self/fd count (Linux only)
+      activeHandles: true,               // include active-handles / active-requests counts
+    },
+  },
+})
+```
+
+### `format: 'json'`
+
+Returns a `{ counters, gauges }` envelope at Content-Type `application/json` — useful for tooling that prefers JSON over text parsing:
+
+```json
+{
+  "counters": [
+    { "name": "frontmcp_skills_bundle_pulls_total", "count": 3, "attributes": { "source": "npm" } }
+  ],
+  "gauges": [
+    { "name": "frontmcp_process_uptime_seconds", "value": 42 }
+  ]
+}
+```
+
+### `auth: 'token'`
+
+Sets `Authorization: Bearer <token>` as the gate. The token is read from `process.env[tokenEnv]` (default env var: `FRONTMCP_METRICS_TOKEN`) at startup. If the env var is unset, the service constructor throws `MetricsTokenNotConfiguredError` — failing fast so a token-gated endpoint never silently downgrades to public:
+
+```typescript
+metrics: {
+  enabled: true,
+  auth: 'token',
+  tokenEnv: 'FRONTMCP_METRICS_TOKEN',
+}
+```
+
+Behaviour:
+- Missing `Authorization` header → **401**
+- `Authorization: Bearer <wrong>` → **403**
+- `Authorization: Bearer <correct>` → **200**
+
+For local / non-secret testing, an inline `{ token: '...' }` literal also works but is discouraged in production:
+
+```typescript
+metrics: {
+  enabled: true,
+  auth: { token: 'dev-only' },
+}
+```
+
+### `include[]` filter
+
+Each category maps to a counter-name prefix:
+
+| Category | Prefix matched |
+| --- | --- |
+| `process` | `frontmcp_process_`, `frontmcp_nodejs_` |
+| `skills` | `frontmcp_skills_` |
+| `tools` | `frontmcp_tool_` |
+| `resources` | `frontmcp_resource_` |
+| `http` | `frontmcp_http_` |
+| `storage` | `frontmcp_storage_` |
+| `auth` | `frontmcp_auth_` |
+| `sessions` | `frontmcp_session_` |
+
+Omit `include` to emit every category.
+
+### Path conflicts
+
+`metrics.path` MUST NOT collide with MCP transport paths (`/mcp`, `/sse`, `/messages`). The service constructor throws `MetricsPathConflictError` at startup if it detects an overlap:
+
+```typescript
+metrics: { enabled: true, path: '/mcp' }
+// → throws MetricsPathConflictError at boot
+```
+
+## Off-by-default rationale
+
+The endpoint is opt-in because process metrics, framework counter names, and tool vocabularies can hint at deployment scale and feature usage (e.g. `frontmcp_skills_signature_failures_total` reveals a signing infra exists, `frontmcp_auth_checks_total{result="denied"}` correlates to attack attempts). Recommendations:
+
+- **Internet-exposed deployments**: use `auth: 'token'` or terminate the endpoint at a sidecar/ingress with a network ACL.
+- **Cluster-local deployments**: `auth: 'public'` matches the Prometheus / Kubernetes convention; ensure the Prometheus pod can reach the port and external traffic cannot.
+
+## How it interacts with OpenTelemetry
+
+`createCounter()` from `@frontmcp/observability` writes to two places: the in-memory snapshot store (which this endpoint reads) AND any globally configured OTel `MeterProvider` (which forwards to OTLP / Prometheus exporter / Grafana Cloud). If you've already wired an OTel `MeterProvider` via `metrics.setGlobalMeterProvider()`, the values in the scrape match the values pushed via OTel — both paths share the same counter handles.
+
+## Adding custom counters
+
+Use `createCounter()` from `@frontmcp/observability`. The counter is automatically included in the scrape:
+
+```typescript
+import { createCounter } from '@frontmcp/observability';
+
+const cacheHits = createCounter('my_cache_hits_total', 'Cache hits by tier');
+
+// Later, in a tool / resource / provider:
+cacheHits.inc(1, { tier: 'l1' });
+
+// Next scrape returns:
+// # TYPE my_cache_hits_total counter
+// my_cache_hits_total{tier="l1"} 1
+```
+
+Label values should be bounded (status codes, enum members, tool names) — unbounded values (user IDs, URLs, JWTs) blow up the timeseries count.
+
+## Reference
+
+- `@frontmcp/sdk` exports: `MetricsService`, `registerMetricsRoutes`, `MetricsPathConflictError`, `MetricsTokenNotConfiguredError`
+- `@frontmcp/observability` exports: `renderPrometheusExposition`, `renderJsonExposition`, `ProcessStatsCollector`, `PROMETHEUS_CONTENT_TYPE`, `createCounter`, `getMetricSnapshot`
+- Type definitions: `MetricsOptionsInterface`, `MetricsAuth`, `MetricsCategory`, `MetricsFormat`, `MetricsProcessOptionsInterface`
+- Tracked under [issue #397](https://github.com/agentfront/frontmcp/issues/397)

--- a/libs/observability/src/index.ts
+++ b/libs/observability/src/index.ts
@@ -113,6 +113,13 @@ export {
 } from './telemetry';
 export type { TelemetryCounter, CounterSnapshotEntry, KnownBundleSource, KnownErrorReason } from './telemetry';
 
+// ──── Prometheus serializer (issue #397) ────
+export { PROMETHEUS_CONTENT_TYPE, renderJsonExposition, renderPrometheusExposition } from './prometheus';
+export type { GaugeSnapshotEntry, RenderOptions } from './prometheus';
+
+// ──── Process-stats collector (issue #397) ────
+export { ProcessStatsCollector } from './process-stats';
+
 // ──── Testing Utilities ────
 export {
   createTestTracer,

--- a/libs/observability/src/process-stats/__tests__/process-stats.collector.spec.ts
+++ b/libs/observability/src/process-stats/__tests__/process-stats.collector.spec.ts
@@ -143,6 +143,127 @@ describe('ProcessStatsCollector (issue #397)', () => {
     expect(entries.find((e) => e.name === 'frontmcp_nodejs_open_fds')?.value).toBe(42);
   });
 
+  describe('default probes (no injected overrides)', () => {
+    it('runs end-to-end against real Node APIs and emits CPU + memory + uptime gauges', () => {
+      const collector = new ProcessStatsCollector();
+      const entries = collector.collect();
+      const names = new Set(entries.map((e) => e.name));
+      // CPU is always emitted (process.cpuUsage is everywhere).
+      expect(names.has('frontmcp_process_cpu_seconds_total')).toBe(true);
+      // Memory + uptime come from process.* and never fail.
+      expect(names.has('frontmcp_process_resident_memory_bytes')).toBe(true);
+      expect(names.has('frontmcp_process_heap_bytes')).toBe(true);
+      expect(names.has('frontmcp_process_heap_used_bytes')).toBe(true);
+      expect(names.has('frontmcp_process_external_bytes')).toBe(true);
+      expect(names.has('frontmcp_process_uptime_seconds')).toBe(true);
+      // Every emitted value is a finite non-negative number.
+      for (const entry of entries) {
+        expect(Number.isFinite(entry.value)).toBe(true);
+        expect(entry.value).toBeGreaterThanOrEqual(0);
+      }
+      collector.close();
+    });
+
+    it('honors options.eventLoopLag === false with real defaults', () => {
+      const collector = new ProcessStatsCollector({ options: { eventLoopLag: false } });
+      const entries = collector.collect();
+      expect(entries.find((e) => e.name === 'frontmcp_nodejs_eventloop_lag_seconds')).toBeUndefined();
+      collector.close();
+    });
+
+    it('reads the fd count on Linux and skips it elsewhere via the default probe', () => {
+      const collector = new ProcessStatsCollector();
+      const entries = collector.collect();
+      const fd = entries.find((e) => e.name === 'frontmcp_nodejs_open_fds');
+      if (process.platform === 'linux') {
+        expect(fd?.value).toBeGreaterThan(0);
+      } else {
+        expect(fd).toBeUndefined();
+      }
+      collector.close();
+    });
+
+    it('returns undefined from the default active-handles probe when _getActiveHandles is missing', () => {
+      const original = (process as unknown as { _getActiveHandles?: unknown })._getActiveHandles;
+      try {
+        // Strip the undocumented probe so `defaultGetActiveHandles` hits the
+        // feature-detection bail-out branch.
+        (process as unknown as { _getActiveHandles?: unknown })._getActiveHandles = undefined;
+        const collector = new ProcessStatsCollector();
+        const entries = collector.collect();
+        expect(entries.find((e) => e.name === 'frontmcp_nodejs_active_handles')).toBeUndefined();
+        collector.close();
+      } finally {
+        (process as unknown as { _getActiveHandles?: unknown })._getActiveHandles = original;
+      }
+    });
+
+    it('returns undefined from the default active-requests probe when _getActiveRequests is missing', () => {
+      const original = (process as unknown as { _getActiveRequests?: unknown })._getActiveRequests;
+      try {
+        (process as unknown as { _getActiveRequests?: unknown })._getActiveRequests = undefined;
+        const collector = new ProcessStatsCollector();
+        const entries = collector.collect();
+        expect(entries.find((e) => e.name === 'frontmcp_nodejs_active_requests')).toBeUndefined();
+        collector.close();
+      } finally {
+        (process as unknown as { _getActiveRequests?: unknown })._getActiveRequests = original;
+      }
+    });
+
+    it('returns undefined from the default active-handles probe when the API throws', () => {
+      const original = (process as unknown as { _getActiveHandles?: unknown })._getActiveHandles;
+      try {
+        (process as unknown as { _getActiveHandles?: () => unknown[] })._getActiveHandles = () => {
+          throw new Error('boom');
+        };
+        const collector = new ProcessStatsCollector();
+        const entries = collector.collect();
+        expect(entries.find((e) => e.name === 'frontmcp_nodejs_active_handles')).toBeUndefined();
+        collector.close();
+      } finally {
+        (process as unknown as { _getActiveHandles?: unknown })._getActiveHandles = original;
+      }
+    });
+
+    it('returns undefined from the default active-requests probe when the API throws', () => {
+      const original = (process as unknown as { _getActiveRequests?: unknown })._getActiveRequests;
+      try {
+        (process as unknown as { _getActiveRequests?: () => unknown[] })._getActiveRequests = () => {
+          throw new Error('boom');
+        };
+        const collector = new ProcessStatsCollector();
+        const entries = collector.collect();
+        expect(entries.find((e) => e.name === 'frontmcp_nodejs_active_requests')).toBeUndefined();
+        collector.close();
+      } finally {
+        (process as unknown as { _getActiveRequests?: unknown })._getActiveRequests = original;
+      }
+    });
+  });
+
+  it('drops non-finite event-loop lag samples (NaN/Infinity) so Prometheus never sees them', () => {
+    const histogram = {
+      mean: NaN,
+      percentile: () => Infinity,
+      reset: jest.fn(),
+      disable: jest.fn(),
+    };
+    const collector = new ProcessStatsCollector({
+      cpuUsage: () => ({ user: 0, system: 0 }),
+      memoryUsage: () => ({ rss: 0, heapTotal: 0, heapUsed: 0, external: 0, arrayBuffers: 0 }),
+      uptime: () => 0,
+      monitorEventLoopDelay: () => histogram,
+      getActiveHandles: () => undefined,
+      getActiveRequests: () => undefined,
+      readFdCount: () => undefined,
+    });
+    const entries = collector.collect();
+    expect(entries.filter((e) => e.name === 'frontmcp_nodejs_eventloop_lag_seconds')).toEqual([]);
+    // Histogram is still reset so the next scrape sees a fresh window.
+    expect(histogram.reset).toHaveBeenCalledTimes(1);
+  });
+
   it('close() disables the event-loop lag histogram', () => {
     const histogram = makeHistogram({ mean: 0, p99: 0 });
     const collector = new ProcessStatsCollector({

--- a/libs/observability/src/process-stats/__tests__/process-stats.collector.spec.ts
+++ b/libs/observability/src/process-stats/__tests__/process-stats.collector.spec.ts
@@ -1,0 +1,160 @@
+import { ProcessStatsCollector } from '../process-stats.collector';
+
+function makeHistogram(values: { mean: number; p99: number }) {
+  return {
+    mean: values.mean,
+    percentile: (p: number) => (p === 99 ? values.p99 : 0),
+    reset: jest.fn(),
+    disable: jest.fn(),
+  };
+}
+
+describe('ProcessStatsCollector (issue #397)', () => {
+  it('emits CPU as a cumulative counter-shaped gauge in seconds, split by mode', () => {
+    let cpuCall = 0;
+    const collector = new ProcessStatsCollector({
+      cpuUsage: () => {
+        cpuCall += 1;
+        return cpuCall === 1 ? { user: 0, system: 0 } : { user: 2_000_000, system: 500_000 };
+      },
+      memoryUsage: () => ({ rss: 1, heapTotal: 1, heapUsed: 1, external: 1, arrayBuffers: 0 }),
+      uptime: () => 10,
+      monitorEventLoopDelay: () => undefined,
+      getActiveHandles: () => undefined,
+      getActiveRequests: () => undefined,
+      readFdCount: () => undefined,
+    });
+
+    const entries = collector.collect();
+    const cpuUser = entries.find(
+      (e) => e.name === 'frontmcp_process_cpu_seconds_total' && e.attributes?.mode === 'user',
+    );
+    const cpuSystem = entries.find(
+      (e) => e.name === 'frontmcp_process_cpu_seconds_total' && e.attributes?.mode === 'system',
+    );
+    expect(cpuUser?.value).toBeCloseTo(2.0, 5);
+    expect(cpuSystem?.value).toBeCloseTo(0.5, 5);
+  });
+
+  it('emits non-negative memory gauges and uptime', () => {
+    const collector = new ProcessStatsCollector({
+      cpuUsage: () => ({ user: 0, system: 0 }),
+      memoryUsage: () => ({
+        rss: 100_000,
+        heapTotal: 80_000,
+        heapUsed: 60_000,
+        external: 20_000,
+        arrayBuffers: 0,
+      }),
+      uptime: () => 42,
+      monitorEventLoopDelay: () => undefined,
+      getActiveHandles: () => undefined,
+      getActiveRequests: () => undefined,
+      readFdCount: () => undefined,
+    });
+    const entries = collector.collect();
+    const byName = (n: string) => entries.find((e) => e.name === n)?.value ?? -1;
+    expect(byName('frontmcp_process_resident_memory_bytes')).toBe(100_000);
+    expect(byName('frontmcp_process_heap_bytes')).toBe(80_000);
+    expect(byName('frontmcp_process_heap_used_bytes')).toBe(60_000);
+    expect(byName('frontmcp_process_external_bytes')).toBe(20_000);
+    expect(byName('frontmcp_process_uptime_seconds')).toBe(42);
+  });
+
+  it('emits event-loop lag (mean + p99) when enabled and resets the histogram per scrape', () => {
+    const histogram = makeHistogram({ mean: 1_000_000, p99: 5_000_000 });
+    const collector = new ProcessStatsCollector({
+      cpuUsage: () => ({ user: 0, system: 0 }),
+      memoryUsage: () => ({ rss: 0, heapTotal: 0, heapUsed: 0, external: 0, arrayBuffers: 0 }),
+      uptime: () => 0,
+      monitorEventLoopDelay: () => histogram,
+      getActiveHandles: () => undefined,
+      getActiveRequests: () => undefined,
+      readFdCount: () => undefined,
+    });
+    const entries = collector.collect();
+    const mean = entries.find(
+      (e) => e.name === 'frontmcp_nodejs_eventloop_lag_seconds' && e.attributes?.quantile === 'mean',
+    );
+    const p99 = entries.find(
+      (e) => e.name === 'frontmcp_nodejs_eventloop_lag_seconds' && e.attributes?.quantile === 'p99',
+    );
+    expect(mean?.value).toBeCloseTo(0.001, 6);
+    expect(p99?.value).toBeCloseTo(0.005, 6);
+    expect(histogram.reset).toHaveBeenCalledTimes(1);
+  });
+
+  it('omits event-loop lag entirely when options.eventLoopLag === false', () => {
+    const histogram = makeHistogram({ mean: 1_000_000, p99: 5_000_000 });
+    const collector = new ProcessStatsCollector({
+      options: { eventLoopLag: false },
+      cpuUsage: () => ({ user: 0, system: 0 }),
+      memoryUsage: () => ({ rss: 0, heapTotal: 0, heapUsed: 0, external: 0, arrayBuffers: 0 }),
+      uptime: () => 0,
+      monitorEventLoopDelay: () => histogram,
+      getActiveHandles: () => undefined,
+      getActiveRequests: () => undefined,
+      readFdCount: () => undefined,
+    });
+    const entries = collector.collect();
+    expect(entries.find((e) => e.name === 'frontmcp_nodejs_eventloop_lag_seconds')).toBeUndefined();
+  });
+
+  it('emits active handles / active requests when available', () => {
+    const collector = new ProcessStatsCollector({
+      cpuUsage: () => ({ user: 0, system: 0 }),
+      memoryUsage: () => ({ rss: 0, heapTotal: 0, heapUsed: 0, external: 0, arrayBuffers: 0 }),
+      uptime: () => 0,
+      monitorEventLoopDelay: () => undefined,
+      getActiveHandles: () => [1, 2, 3],
+      getActiveRequests: () => [],
+      readFdCount: () => undefined,
+    });
+    const entries = collector.collect();
+    expect(entries.find((e) => e.name === 'frontmcp_nodejs_active_handles')?.value).toBe(3);
+    expect(entries.find((e) => e.name === 'frontmcp_nodejs_active_requests')?.value).toBe(0);
+  });
+
+  it('silently skips fd count when probe returns undefined (non-Linux or readdir failure)', () => {
+    const collector = new ProcessStatsCollector({
+      cpuUsage: () => ({ user: 0, system: 0 }),
+      memoryUsage: () => ({ rss: 0, heapTotal: 0, heapUsed: 0, external: 0, arrayBuffers: 0 }),
+      uptime: () => 0,
+      monitorEventLoopDelay: () => undefined,
+      getActiveHandles: () => undefined,
+      getActiveRequests: () => undefined,
+      readFdCount: () => undefined,
+    });
+    const entries = collector.collect();
+    expect(entries.find((e) => e.name === 'frontmcp_nodejs_open_fds')).toBeUndefined();
+  });
+
+  it('emits fd count when the readFdCount probe returns a number', () => {
+    const collector = new ProcessStatsCollector({
+      cpuUsage: () => ({ user: 0, system: 0 }),
+      memoryUsage: () => ({ rss: 0, heapTotal: 0, heapUsed: 0, external: 0, arrayBuffers: 0 }),
+      uptime: () => 0,
+      monitorEventLoopDelay: () => undefined,
+      getActiveHandles: () => undefined,
+      getActiveRequests: () => undefined,
+      readFdCount: () => 42,
+    });
+    const entries = collector.collect();
+    expect(entries.find((e) => e.name === 'frontmcp_nodejs_open_fds')?.value).toBe(42);
+  });
+
+  it('close() disables the event-loop lag histogram', () => {
+    const histogram = makeHistogram({ mean: 0, p99: 0 });
+    const collector = new ProcessStatsCollector({
+      cpuUsage: () => ({ user: 0, system: 0 }),
+      memoryUsage: () => ({ rss: 0, heapTotal: 0, heapUsed: 0, external: 0, arrayBuffers: 0 }),
+      uptime: () => 0,
+      monitorEventLoopDelay: () => histogram,
+      getActiveHandles: () => undefined,
+      getActiveRequests: () => undefined,
+      readFdCount: () => undefined,
+    });
+    collector.close();
+    expect(histogram.disable).toHaveBeenCalledTimes(1);
+  });
+});

--- a/libs/observability/src/process-stats/index.ts
+++ b/libs/observability/src/process-stats/index.ts
@@ -1,0 +1,4 @@
+// observability/process-stats/index.ts
+// Per-scrape Node.js process metrics collector (issue #397).
+
+export { ProcessStatsCollector } from './process-stats.collector';

--- a/libs/observability/src/process-stats/process-stats.collector.ts
+++ b/libs/observability/src/process-stats/process-stats.collector.ts
@@ -1,0 +1,226 @@
+/**
+ * Process-stats collector (issue #397).
+ *
+ * Emits per-scrape Node.js process metrics in `GaugeSnapshotEntry` shape so
+ * the Prometheus serializer can pass them straight through. Pure read of
+ * `process.*` and `perf_hooks.monitorEventLoopDelay()` — no I/O beyond the
+ * single Linux-only `/proc/self/fd` directory probe (wrapped in try/catch
+ * so non-Linux platforms silently skip that gauge).
+ *
+ * Design choices:
+ *   - CPU is emitted as a monotonic counter-shaped gauge built from
+ *     `process.cpuUsage()` deltas — operators graph `rate()` of this.
+ *   - Event-loop lag uses `perf_hooks.monitorEventLoopDelay({ resolution: 10 })`
+ *     started at construction; `collect()` reads mean + p99 and calls
+ *     `reset()` so each scrape sees a fresh window.
+ *   - `process._getActiveHandles()` / `_getActiveRequests()` are
+ *     undocumented but stable since Node 14; guarded behind feature
+ *     detection so they no-op on edge runtimes.
+ *   - All probes are individually toggleable via `MetricsProcessOptions`.
+ */
+
+import type { GaugeSnapshotEntry } from '../prometheus/render';
+
+interface MetricsProcessOptions {
+  eventLoopLag?: boolean;
+  fdCount?: boolean;
+  activeHandles?: boolean;
+}
+
+interface ELDHistogram {
+  mean: number;
+  percentile(p: number): number;
+  reset(): void;
+  disable?(): void;
+}
+
+/**
+ * Optional dependency injection points used by tests; production callers
+ * never pass these.
+ */
+interface ProcessStatsCollectorOptions {
+  options?: MetricsProcessOptions;
+  cpuUsage?: (prev?: NodeJS.CpuUsage) => NodeJS.CpuUsage;
+  memoryUsage?: () => NodeJS.MemoryUsage;
+  uptime?: () => number;
+  monitorEventLoopDelay?: () => ELDHistogram | undefined;
+  getActiveHandles?: () => unknown[] | undefined;
+  getActiveRequests?: () => unknown[] | undefined;
+  readFdCount?: () => number | undefined;
+}
+
+const NS_PER_SECOND = 1e9;
+const MICROS_PER_SECOND = 1e6;
+
+function defaultMonitorEventLoopDelay(): ELDHistogram | undefined {
+  try {
+    const { monitorEventLoopDelay } = require('node:perf_hooks') as typeof import('node:perf_hooks');
+    const histogram = monitorEventLoopDelay({ resolution: 10 });
+    histogram.enable();
+    return histogram as unknown as ELDHistogram;
+  } catch {
+    return undefined;
+  }
+}
+
+function defaultGetActiveHandles(): unknown[] | undefined {
+  const proc = process as unknown as { _getActiveHandles?: () => unknown[] };
+  if (typeof proc._getActiveHandles !== 'function') return undefined;
+  try {
+    return proc._getActiveHandles();
+  } catch {
+    return undefined;
+  }
+}
+
+function defaultGetActiveRequests(): unknown[] | undefined {
+  const proc = process as unknown as { _getActiveRequests?: () => unknown[] };
+  if (typeof proc._getActiveRequests !== 'function') return undefined;
+  try {
+    return proc._getActiveRequests();
+  } catch {
+    return undefined;
+  }
+}
+
+function defaultReadFdCount(): number | undefined {
+  if (process.platform !== 'linux') return undefined;
+  try {
+    const fs = require('node:fs') as typeof import('node:fs');
+    return fs.readdirSync('/proc/self/fd').length;
+  } catch {
+    return undefined;
+  }
+}
+
+export class ProcessStatsCollector {
+  private readonly options: MetricsProcessOptions;
+  private readonly cpuUsage: (prev?: NodeJS.CpuUsage) => NodeJS.CpuUsage;
+  private readonly memoryUsage: () => NodeJS.MemoryUsage;
+  private readonly uptime: () => number;
+  private readonly histogram?: ELDHistogram;
+  private readonly getActiveHandles?: () => unknown[] | undefined;
+  private readonly getActiveRequests?: () => unknown[] | undefined;
+  private readonly readFdCount: () => number | undefined;
+  private cpuStart: NodeJS.CpuUsage;
+
+  constructor(init: ProcessStatsCollectorOptions = {}) {
+    this.options = init.options ?? {};
+    this.cpuUsage = init.cpuUsage ?? ((prev?: NodeJS.CpuUsage) => process.cpuUsage(prev));
+    this.memoryUsage = init.memoryUsage ?? (() => process.memoryUsage());
+    this.uptime = init.uptime ?? (() => process.uptime());
+    this.getActiveHandles = init.getActiveHandles ?? defaultGetActiveHandles;
+    this.getActiveRequests = init.getActiveRequests ?? defaultGetActiveRequests;
+    this.readFdCount = init.readFdCount ?? defaultReadFdCount;
+    this.cpuStart = this.cpuUsage();
+    if (this.options.eventLoopLag !== false) {
+      this.histogram = init.monitorEventLoopDelay ? init.monitorEventLoopDelay() : defaultMonitorEventLoopDelay();
+    }
+  }
+
+  collect(): GaugeSnapshotEntry[] {
+    const entries: GaugeSnapshotEntry[] = [];
+
+    const cpu = this.cpuUsage(this.cpuStart);
+    entries.push({
+      name: 'frontmcp_process_cpu_seconds_total',
+      value: cpu.user / MICROS_PER_SECOND,
+      attributes: { mode: 'user' },
+      help: 'CPU time consumed since collector start, by mode (seconds)',
+    });
+    entries.push({
+      name: 'frontmcp_process_cpu_seconds_total',
+      value: cpu.system / MICROS_PER_SECOND,
+      attributes: { mode: 'system' },
+    });
+
+    const mem = this.memoryUsage();
+    entries.push({
+      name: 'frontmcp_process_resident_memory_bytes',
+      value: mem.rss,
+      help: 'Resident memory size in bytes',
+    });
+    entries.push({
+      name: 'frontmcp_process_heap_bytes',
+      value: mem.heapTotal,
+      help: 'Total V8 heap size in bytes',
+    });
+    entries.push({
+      name: 'frontmcp_process_heap_used_bytes',
+      value: mem.heapUsed,
+      help: 'Used V8 heap size in bytes',
+    });
+    entries.push({
+      name: 'frontmcp_process_external_bytes',
+      value: mem.external,
+      help: 'Memory used by C++ objects bound to JS in bytes',
+    });
+
+    entries.push({
+      name: 'frontmcp_process_uptime_seconds',
+      value: this.uptime(),
+      help: 'Time since process start in seconds',
+    });
+
+    if (this.options.eventLoopLag !== false && this.histogram) {
+      const meanSeconds = this.histogram.mean / NS_PER_SECOND;
+      const p99Seconds = this.histogram.percentile(99) / NS_PER_SECOND;
+      if (Number.isFinite(meanSeconds)) {
+        entries.push({
+          name: 'frontmcp_nodejs_eventloop_lag_seconds',
+          value: meanSeconds,
+          attributes: { quantile: 'mean' },
+          help: 'Event-loop lag in seconds, sampled at 10ms resolution since the last scrape',
+        });
+      }
+      if (Number.isFinite(p99Seconds)) {
+        entries.push({
+          name: 'frontmcp_nodejs_eventloop_lag_seconds',
+          value: p99Seconds,
+          attributes: { quantile: 'p99' },
+        });
+      }
+      this.histogram.reset();
+    }
+
+    if (this.options.activeHandles !== false) {
+      const handles = this.getActiveHandles?.();
+      if (handles !== undefined) {
+        entries.push({
+          name: 'frontmcp_nodejs_active_handles',
+          value: handles.length,
+          help: 'Currently active libuv handles (sockets, timers, etc.)',
+        });
+      }
+      const requests = this.getActiveRequests?.();
+      if (requests !== undefined) {
+        entries.push({
+          name: 'frontmcp_nodejs_active_requests',
+          value: requests.length,
+          help: 'Currently active libuv requests (file I/O, DNS, etc.)',
+        });
+      }
+    }
+
+    if (this.options.fdCount !== false) {
+      const fdCount = this.readFdCount();
+      if (typeof fdCount === 'number') {
+        entries.push({
+          name: 'frontmcp_nodejs_open_fds',
+          value: fdCount,
+          help: 'Number of open file descriptors (Linux only)',
+        });
+      }
+    }
+
+    return entries;
+  }
+
+  /**
+   * Release the perf_hooks histogram listener. Call when the collector is
+   * no longer used (e.g., when reconfiguring the server).
+   */
+  close(): void {
+    this.histogram?.disable?.();
+  }
+}

--- a/libs/observability/src/process-stats/process-stats.collector.ts
+++ b/libs/observability/src/process-stats/process-stats.collector.ts
@@ -19,6 +19,8 @@
  *   - All probes are individually toggleable via `MetricsProcessOptions`.
  */
 
+import { readdirSync } from '@frontmcp/utils';
+
 import type { GaugeSnapshotEntry } from '../prometheus/render';
 
 interface MetricsProcessOptions {
@@ -86,8 +88,7 @@ function defaultGetActiveRequests(): unknown[] | undefined {
 function defaultReadFdCount(): number | undefined {
   if (process.platform !== 'linux') return undefined;
   try {
-    const fs = require('node:fs') as typeof import('node:fs');
-    return fs.readdirSync('/proc/self/fd').length;
+    return readdirSync('/proc/self/fd').length;
   } catch {
     return undefined;
   }

--- a/libs/observability/src/prometheus/__tests__/render.spec.ts
+++ b/libs/observability/src/prometheus/__tests__/render.spec.ts
@@ -1,0 +1,109 @@
+import { PROMETHEUS_CONTENT_TYPE, renderJsonExposition, renderPrometheusExposition } from '../render';
+
+describe('renderPrometheusExposition (issue #397)', () => {
+  it('returns empty string for empty input', () => {
+    expect(renderPrometheusExposition([])).toBe('');
+    expect(renderPrometheusExposition([], [])).toBe('');
+  });
+
+  it('emits a single counter with no labels', () => {
+    const out = renderPrometheusExposition([{ name: 'foo_total', count: 5, attributes: {} }]);
+    expect(out).toContain('# TYPE foo_total counter');
+    expect(out).toContain('foo_total 5');
+    expect(out.endsWith('\n')).toBe(true);
+  });
+
+  it('emits one # HELP and one # TYPE per metric name (groups by name)', () => {
+    const out = renderPrometheusExposition(
+      [
+        { name: 'http_requests_total', count: 3, attributes: { status: '200' } },
+        { name: 'http_requests_total', count: 1, attributes: { status: '500' } },
+      ],
+      [],
+      { counterHelp: { http_requests_total: 'HTTP request count' } },
+    );
+    expect((out.match(/# HELP http_requests_total /g) ?? []).length).toBe(1);
+    expect((out.match(/# TYPE http_requests_total counter/g) ?? []).length).toBe(1);
+    expect(out).toContain('http_requests_total{status="200"} 3');
+    expect(out).toContain('http_requests_total{status="500"} 1');
+  });
+
+  it('escapes label values per spec (backslash, double-quote, newline)', () => {
+    const out = renderPrometheusExposition([
+      { name: 'tag_total', count: 1, attributes: { value: 'bad"v\nwith\\slash' } },
+    ]);
+    expect(out).toContain('tag_total{value="bad\\"v\\nwith\\\\slash"} 1');
+  });
+
+  it('drops entries whose metric name fails Prometheus naming validation', () => {
+    const out = renderPrometheusExposition([
+      { name: '123_invalid', count: 1, attributes: {} },
+      { name: 'good_total', count: 2, attributes: {} },
+    ]);
+    expect(out).not.toContain('123_invalid');
+    expect(out).toContain('good_total 2');
+  });
+
+  it('drops entries with non-finite counter values', () => {
+    const out = renderPrometheusExposition([
+      { name: 'good_total', count: 1, attributes: {} },
+      { name: 'bad_total', count: NaN as unknown as number, attributes: {} },
+      { name: 'inf_total', count: Number.POSITIVE_INFINITY, attributes: {} },
+    ]);
+    expect(out).toContain('good_total 1');
+    expect(out).not.toContain('bad_total');
+    expect(out).not.toContain('inf_total');
+  });
+
+  it('is deterministic: two runs of the same input produce byte-identical output', () => {
+    const counters = [
+      { name: 'b_total', count: 2, attributes: { region: 'us', tier: 'pro' } },
+      { name: 'a_total', count: 1, attributes: { region: 'eu' } },
+    ];
+    const a = renderPrometheusExposition(counters);
+    const b = renderPrometheusExposition(counters);
+    expect(a).toBe(b);
+    expect(a.indexOf('a_total')).toBeLessThan(a.indexOf('b_total'));
+  });
+
+  it('renders counter + gauge as distinct # TYPE blocks', () => {
+    const out = renderPrometheusExposition(
+      [{ name: 'requests_total', count: 7, attributes: {} }],
+      [{ name: 'memory_bytes', value: 1024, help: 'Memory in bytes' }],
+    );
+    expect(out).toContain('# TYPE requests_total counter');
+    expect(out).toContain('# TYPE memory_bytes gauge');
+    expect(out).toContain('# HELP memory_bytes Memory in bytes');
+    expect(out).toContain('memory_bytes 1024');
+  });
+
+  it('exposes the canonical Prometheus content type constant', () => {
+    expect(PROMETHEUS_CONTENT_TYPE).toBe('text/plain; version=0.0.4; charset=utf-8');
+  });
+});
+
+describe('renderJsonExposition (issue #397)', () => {
+  it('returns a { counters, gauges } envelope', () => {
+    const out = renderJsonExposition(
+      [{ name: 'tool_calls_total', count: 4, attributes: { tool: 'echo' } }],
+      [{ name: 'memory_bytes', value: 2048 }],
+    );
+    expect(out.counters).toEqual([{ name: 'tool_calls_total', count: 4, attributes: { tool: 'echo' } }]);
+    expect(out.gauges[0]).toMatchObject({ name: 'memory_bytes', value: 2048 });
+  });
+
+  it('drops entries with invalid metric names or non-finite values', () => {
+    const out = renderJsonExposition(
+      [
+        { name: 'good_total', count: 1, attributes: {} },
+        { name: '0bad', count: 1, attributes: {} },
+      ],
+      [
+        { name: 'good_bytes', value: 10 },
+        { name: 'bad_bytes', value: NaN as unknown as number },
+      ],
+    );
+    expect(out.counters.map((c) => c.name)).toEqual(['good_total']);
+    expect(out.gauges.map((g) => g.name)).toEqual(['good_bytes']);
+  });
+});

--- a/libs/observability/src/prometheus/index.ts
+++ b/libs/observability/src/prometheus/index.ts
@@ -1,0 +1,5 @@
+// observability/prometheus/index.ts
+// Zero-dep Prometheus text-exposition serializer (issue #397).
+
+export { PROMETHEUS_CONTENT_TYPE, renderJsonExposition, renderPrometheusExposition } from './render';
+export type { GaugeSnapshotEntry, RenderOptions } from './render';

--- a/libs/observability/src/prometheus/render.ts
+++ b/libs/observability/src/prometheus/render.ts
@@ -1,0 +1,158 @@
+/**
+ * Prometheus text-exposition serializer (zero-dep).
+ *
+ * Implements the Prometheus 0.0.4 text format documented at
+ * https://prometheus.io/docs/instrumenting/exposition_formats/#text-based-format
+ * without pulling in `prom-client` — keeps `@frontmcp/observability`'s
+ * runtime footprint to `@opentelemetry/api` only (issue #397).
+ *
+ * Counter snapshot entries come from
+ * `@frontmcp/observability`'s in-memory store (`getMetricSnapshot()`); gauge
+ * entries come from the `ProcessStatsCollector` introduced alongside this
+ * serializer.
+ */
+
+import type { CounterSnapshotEntry } from '../telemetry/telemetry.counters';
+
+/**
+ * A single gauge sample at a point in time. Values are emitted unchanged
+ * (no resampling, no rate calculation).
+ */
+export interface GaugeSnapshotEntry {
+  /** Metric name (must match `/^[a-zA-Z_:][a-zA-Z0-9_:]*$/`). */
+  name: string;
+  /** Sample value. NaN / non-finite values are dropped. */
+  value: number;
+  /** Optional bounded-cardinality labels. */
+  attributes?: Record<string, string>;
+  /** Optional `# HELP` line. */
+  help?: string;
+}
+
+/**
+ * Optional rendering knobs.
+ */
+export interface RenderOptions {
+  /** Map of counter-name → `# HELP` text. Counter names not in the map omit the HELP line. */
+  counterHelp?: Record<string, string>;
+}
+
+const METRIC_NAME_REGEX = /^[a-zA-Z_:][a-zA-Z0-9_:]*$/;
+const LABEL_NAME_REGEX = /^[a-zA-Z_][a-zA-Z0-9_]*$/;
+
+/**
+ * Content-Type emitted alongside the text format (canonical Prometheus
+ * 0.0.4 value — pinned so consumers can match exactly).
+ */
+export const PROMETHEUS_CONTENT_TYPE = 'text/plain; version=0.0.4; charset=utf-8';
+
+function escapeLabelValue(value: string): string {
+  return value.replace(/\\/g, '\\\\').replace(/"/g, '\\"').replace(/\n/g, '\\n');
+}
+
+function sortedLabelString(attributes: Record<string, string>): string {
+  const keys = Object.keys(attributes)
+    .filter((k) => LABEL_NAME_REGEX.test(k))
+    .sort();
+  if (keys.length === 0) return '';
+  const pairs = keys.map((k) => `${k}="${escapeLabelValue(attributes[k] ?? '')}"`);
+  return `{${pairs.join(',')}}`;
+}
+
+function formatFloat(value: number): string {
+  if (!Number.isFinite(value)) return '';
+  if (Number.isInteger(value)) return String(value);
+  return String(value);
+}
+
+/**
+ * Render counter + gauge snapshots as Prometheus 0.0.4 text exposition.
+ *
+ * - Groups entries by metric name so `# HELP` / `# TYPE` lines emit once
+ *   per metric.
+ * - Drops entries whose metric name fails Prometheus naming validation.
+ * - Sorts metric names alphabetically so output is byte-deterministic.
+ * - Empty input → empty string.
+ */
+export function renderPrometheusExposition(
+  counters: readonly CounterSnapshotEntry[],
+  gauges: readonly GaugeSnapshotEntry[] = [],
+  options: RenderOptions = {},
+): string {
+  type Grouped = { type: 'counter' | 'gauge'; help?: string; lines: string[] };
+  const byName = new Map<string, Grouped>();
+
+  for (const entry of counters) {
+    if (!METRIC_NAME_REGEX.test(entry.name)) continue;
+    const valueStr = formatFloat(entry.count);
+    if (valueStr === '') continue;
+    const labels = sortedLabelString(entry.attributes ?? {});
+    const line = `${entry.name}${labels} ${valueStr}`;
+    let group = byName.get(entry.name);
+    if (!group) {
+      group = {
+        type: 'counter',
+        help: options.counterHelp?.[entry.name],
+        lines: [],
+      };
+      byName.set(entry.name, group);
+    }
+    group.lines.push(line);
+  }
+
+  for (const entry of gauges) {
+    if (!METRIC_NAME_REGEX.test(entry.name)) continue;
+    const valueStr = formatFloat(entry.value);
+    if (valueStr === '') continue;
+    const labels = sortedLabelString(entry.attributes ?? {});
+    const line = `${entry.name}${labels} ${valueStr}`;
+    let group = byName.get(entry.name);
+    if (!group) {
+      group = { type: 'gauge', help: entry.help, lines: [] };
+      byName.set(entry.name, group);
+    } else if (entry.help && !group.help) {
+      group.help = entry.help;
+    }
+    group.lines.push(line);
+  }
+
+  if (byName.size === 0) return '';
+
+  const sortedNames = Array.from(byName.keys()).sort();
+  const blocks: string[] = [];
+  for (const name of sortedNames) {
+    const group = byName.get(name);
+    if (!group) continue;
+    const block: string[] = [];
+    if (group.help) {
+      block.push(`# HELP ${name} ${group.help.replace(/\n/g, ' ')}`);
+    }
+    block.push(`# TYPE ${name} ${group.type}`);
+    block.push(...group.lines.slice().sort());
+    blocks.push(block.join('\n'));
+  }
+  return blocks.join('\n') + '\n';
+}
+
+/**
+ * Render counter + gauge snapshots as a JSON envelope — useful when
+ * a consumer prefers JSON over Prometheus text parsing.
+ */
+export function renderJsonExposition(
+  counters: readonly CounterSnapshotEntry[],
+  gauges: readonly GaugeSnapshotEntry[] = [],
+): { counters: CounterSnapshotEntry[]; gauges: GaugeSnapshotEntry[] } {
+  return {
+    counters: counters
+      .filter((c) => METRIC_NAME_REGEX.test(c.name) && Number.isFinite(c.count))
+      .map((c) => ({ name: c.name, count: c.count, attributes: { ...(c.attributes ?? {}) } })),
+    gauges: gauges
+      .filter((g) => METRIC_NAME_REGEX.test(g.name) && Number.isFinite(g.value))
+      .map((g) => ({
+        name: g.name,
+        value: g.value,
+        attributes: { ...(g.attributes ?? {}) },
+        ...(g.help ? { help: g.help } : {}),
+      })),
+  };
+}

--- a/libs/observability/src/telemetry/__tests__/telemetry.factory.spec.ts
+++ b/libs/observability/src/telemetry/__tests__/telemetry.factory.spec.ts
@@ -1,0 +1,66 @@
+/**
+ * `TelemetryFactory` tests — the scope-lifetime alternative to
+ * `TelemetryAccessor` used by long-lived objects (BundleStore, etc.) that
+ * don't have a per-request context.
+ *
+ * Covers:
+ *   - `createCounter` delegates to the process-global store and returns a
+ *     usable counter (.inc() doesn't throw).
+ *   - `startSpan` returns a `TelemetrySpan` whose `end()` is callable.
+ *   - `withSpan` ends the span on the success path AND `endWithError`s on
+ *     the failure path (both branches of the try/catch).
+ *   - `withSpan` rethrows the original error untouched.
+ */
+
+import { context } from '@opentelemetry/api';
+
+import { TelemetryFactory } from '../telemetry.factory';
+
+describe('TelemetryFactory', () => {
+  it('createCounter returns a usable counter whose .inc() does not throw', () => {
+    const factory = new TelemetryFactory();
+    const counter = factory.createCounter('frontmcp_test_factory_total', 'unit-test counter');
+    expect(() => counter.inc(1)).not.toThrow();
+    expect(() => counter.inc(2, { tier: 'l1' })).not.toThrow();
+  });
+
+  it('startSpan returns a TelemetrySpan that ends cleanly', () => {
+    const factory = new TelemetryFactory();
+    const span = factory.startSpan('factory.test-span', { 'attr.one': 'a', 'attr.two': 2, 'attr.three': true });
+    expect(() => span.end()).not.toThrow();
+  });
+
+  it('startSpan accepts an explicit parent context', () => {
+    const factory = new TelemetryFactory();
+    // Use the active context — without a registered tracer provider it's a
+    // valid no-op Context that still exercises the `parent` branch of
+    // `tracer.startSpan(name, opts, parent)`.
+    const span = factory.startSpan('factory.child', undefined, context.active());
+    expect(() => span.end()).not.toThrow();
+  });
+
+  it('withSpan resolves with the inner result and ends the span', async () => {
+    const factory = new TelemetryFactory();
+    const result = await factory.withSpan('factory.with-span.ok', async () => 'value');
+    expect(result).toBe('value');
+  });
+
+  it('withSpan rethrows Error instances and ends the span with the error', async () => {
+    const factory = new TelemetryFactory();
+    const boom = new Error('boom');
+    await expect(
+      factory.withSpan('factory.with-span.err', async () => {
+        throw boom;
+      }),
+    ).rejects.toBe(boom);
+  });
+
+  it('withSpan handles non-Error throws by stringifying them', async () => {
+    const factory = new TelemetryFactory();
+    await expect(
+      factory.withSpan('factory.with-span.string-err', async () => {
+        throw 'plain string';
+      }),
+    ).rejects.toBe('plain string');
+  });
+});

--- a/libs/sdk/src/common/metadata/front-mcp.metadata.ts
+++ b/libs/sdk/src/common/metadata/front-mcp.metadata.ts
@@ -17,6 +17,7 @@ import {
   healthOptionsSchema,
   httpOptionsSchema,
   loggingOptionsSchema,
+  metricsOptionsSchema,
   observabilityOptionsSchema,
   paginationOptionsSchema,
   pubsubOptionsSchema,
@@ -32,6 +33,7 @@ import {
   type HealthOptionsInput,
   type HttpOptionsInput,
   type LoggingOptionsInput,
+  type MetricsOptionsInput,
   type ObservabilityOptionsInterface,
   type PaginationOptions,
   type PubsubOptionsInput,
@@ -346,6 +348,35 @@ export interface FrontMcpBaseMetadata {
   health?: HealthOptionsInput;
 
   /**
+   * `/metrics` endpoint configuration (issue #397).
+   *
+   * OFF by default. When `enabled: true`, registers a `GET /metrics`
+   * endpoint on the same HTTP listener as `/healthz` that emits Prometheus
+   * text exposition (or JSON, via `format: 'json'`) covering:
+   *   - process metrics — CPU, RSS, heap, event-loop lag, fd count
+   *   - every `@frontmcp/observability` counter (`frontmcp_*_total`)
+   *
+   * Re-uses the in-memory counter snapshot store from
+   * `@frontmcp/observability`, so counters emitted via `createCounter()`
+   * are scraped without needing an OTel push pipeline.
+   *
+   * @example Enable with defaults
+   * ```typescript
+   * metrics: { enabled: true }
+   * ```
+   *
+   * @example Token-gated for internet-exposed deployments
+   * ```typescript
+   * metrics: {
+   *   enabled: true,
+   *   auth: 'token',
+   *   tokenEnv: 'FRONTMCP_METRICS_TOKEN',
+   * }
+   * ```
+   */
+  metrics?: MetricsOptionsInput;
+
+  /**
    * Observability configuration — OpenTelemetry tracing, structured logging,
    * and per-request log collection.
    *
@@ -536,6 +567,7 @@ export const frontMcpBaseSchema = z.object({
   throttle: guardConfigSchema.optional(),
   observability: observabilityOptionsSchema,
   health: healthOptionsSchema.optional(),
+  metrics: metricsOptionsSchema.optional(),
   channels: channelsConfigSchema.optional(),
   authorities: z
     .object({
@@ -733,6 +765,7 @@ const frontMcpLiteSchema = z.object({
   jobs: z.any().optional(),
   throttle: z.any().optional(),
   health: z.any().optional(),
+  metrics: z.any().optional(),
   // Required by Scope.validateAuthoritiesConfig — when entries declare
   // `authorities` metadata the engine still needs the top-level config
   // to instantiate. Pass-through (`z.any()`) so CLI/MCPB builds work

--- a/libs/sdk/src/common/tokens/front-mcp.tokens.ts
+++ b/libs/sdk/src/common/tokens/front-mcp.tokens.ts
@@ -48,6 +48,8 @@ export const FrontMcpTokens: RawMetadataShape<FrontMcpMetadata> = {
   observability: tokenFactory.meta('observability'),
   // health and readiness endpoints
   health: tokenFactory.meta('health'),
+  // /metrics endpoint (issue #397)
+  metrics: tokenFactory.meta('metrics'),
   // channels configuration (Claude Code notifications)
   channels: tokenFactory.meta('channels'),
   // authorities configuration (RBAC/ABAC/ReBAC)

--- a/libs/sdk/src/common/types/options/index.ts
+++ b/libs/sdk/src/common/types/options/index.ts
@@ -15,3 +15,4 @@ export * from './ext-apps';
 export * from './sqlite';
 export * from './observability';
 export * from './health';
+export * from './metrics';

--- a/libs/sdk/src/common/types/options/metrics/index.ts
+++ b/libs/sdk/src/common/types/options/metrics/index.ts
@@ -1,0 +1,18 @@
+// common/types/options/metrics/index.ts
+// Barrel export for /metrics endpoint configuration.
+
+export type {
+  MetricsAuth,
+  MetricsCategory,
+  MetricsFormat,
+  MetricsOptionsInterface,
+  MetricsProcessOptionsInterface,
+} from './interfaces';
+
+export {
+  DEFAULT_METRICS_OPTIONS,
+  metricsOptionsSchema,
+  metricsProcessOptionsSchema,
+  type MetricsOptions,
+  type MetricsOptionsInput,
+} from './schema';

--- a/libs/sdk/src/common/types/options/metrics/interfaces.ts
+++ b/libs/sdk/src/common/types/options/metrics/interfaces.ts
@@ -1,0 +1,169 @@
+// common/types/options/metrics/interfaces.ts
+// Explicit TypeScript interfaces for better IDE autocomplete.
+//
+// Mirrors the shape used by `HealthOptionsInterface`. Keep these in sync with
+// `schema.ts` via the `RawZodShape<MetricsOptionsInterface>` constraint.
+
+/**
+ * Output format for the /metrics endpoint.
+ *
+ * - `'prometheus'` — text exposition format (Content-Type
+ *   `text/plain; version=0.0.4; charset=utf-8`). The default. Scrape-friendly
+ *   for Prometheus, Grafana Agent, OpenMetrics-aware tooling.
+ * - `'json'` — a `{ counters, gauges }` envelope for tooling that prefers
+ *   JSON over text parsing.
+ */
+export type MetricsFormat = 'prometheus' | 'json';
+
+/**
+ * Authentication shape for the /metrics endpoint.
+ *
+ * - `'public'` — no auth (cluster-local convention, the default).
+ * - `'token'` — `Authorization: Bearer <token>` required. The token is read
+ *   from `process.env[tokenEnv]` at startup; if the env var is unset, the
+ *   service constructor throws so misconfig is loud.
+ * - `{ token: 'literal' }` — inline token (NOT recommended in production —
+ *   tokens in source/config get committed by accident).
+ */
+export type MetricsAuth = 'public' | 'token' | { token: string };
+
+/**
+ * Metric category filter — exposes a knob for trimming the scrape payload.
+ * The /metrics endpoint emits every category by default.
+ */
+export type MetricsCategory = 'process' | 'tools' | 'resources' | 'http' | 'storage' | 'skills' | 'auth' | 'sessions';
+
+/**
+ * Per-probe knobs for the built-in process-stats collector.
+ */
+export interface MetricsProcessOptionsInterface {
+  /**
+   * Emit `frontmcp_nodejs_eventloop_lag_seconds` (mean + p99). Requires
+   * Node.js (uses `perf_hooks.monitorEventLoopDelay`). Auto-suppressed on
+   * edge runtimes.
+   *
+   * @default true
+   */
+  eventLoopLag?: boolean;
+
+  /**
+   * Emit `frontmcp_nodejs_open_fds`. Linux only; collection wraps
+   * `fs.readdirSync('/proc/self/fd')` in try/catch so non-Linux platforms
+   * silently skip this gauge instead of throwing.
+   *
+   * @default true
+   */
+  fdCount?: boolean;
+
+  /**
+   * Emit `frontmcp_nodejs_active_handles` / `frontmcp_nodejs_active_requests`.
+   * Uses `process._getActiveHandles()` / `_getActiveRequests()` which are
+   * undocumented but stable since Node 14. Auto-suppressed when unavailable.
+   *
+   * @default true
+   */
+  activeHandles?: boolean;
+}
+
+/**
+ * `/metrics` endpoint configuration for `@FrontMcp({ metrics: ... })`.
+ *
+ * **Default behaviour: OFF.** No `/metrics` route is registered until
+ * `enabled: true` is set explicitly. This preserves the existing
+ * security posture — process metrics, framework counter names, and tool
+ * vocabularies can hint at deployment scale and feature usage, so the
+ * default is opt-in.
+ *
+ * When enabled, the endpoint:
+ * - Lives on the same HTTP listener as MCP traffic and `/healthz`.
+ * - Defaults to Prometheus text format at `GET /metrics`.
+ * - Is `auth: 'public'` by default (cluster-local convention) — switch to
+ *   `auth: 'token'` for any internet-exposed deployment.
+ * - Re-uses `@frontmcp/observability`'s in-memory counter snapshot store, so
+ *   counters emitted by `createCounter()` are visible without standing up
+ *   an OTel push pipeline.
+ *
+ * @example Enable with defaults
+ * ```typescript
+ * @FrontMcp({
+ *   info: { name: 'my-server', version: '1.0.0' },
+ *   apps: [MyApp],
+ *   metrics: { enabled: true },
+ * })
+ * ```
+ *
+ * @example Token-gated
+ * ```typescript
+ * @FrontMcp({
+ *   metrics: {
+ *     enabled: true,
+ *     auth: 'token',
+ *     tokenEnv: 'FRONTMCP_METRICS_TOKEN',
+ *   },
+ * })
+ * ```
+ *
+ * @example Trim to process metrics only
+ * ```typescript
+ * @FrontMcp({
+ *   metrics: {
+ *     enabled: true,
+ *     include: ['process'],
+ *   },
+ * })
+ * ```
+ */
+export interface MetricsOptionsInterface {
+  /**
+   * Enable the `/metrics` route.
+   *
+   * @default false
+   */
+  enabled?: boolean;
+
+  /**
+   * HTTP path for the endpoint. MUST NOT collide with MCP transport paths
+   * (`/mcp`, `/sse`, `/messages`). A startup assertion in `MetricsService`
+   * throws `MetricsPathConflictError` when a conflict is detected.
+   *
+   * @default '/metrics'
+   */
+  path?: string;
+
+  /**
+   * Output format. Prometheus text exposition (`'prometheus'`) is the
+   * default; switch to `'json'` for tooling that prefers JSON.
+   *
+   * @default 'prometheus'
+   */
+  format?: MetricsFormat;
+
+  /**
+   * Authentication policy. `'public'` is the default to match the
+   * cluster-local convention; switch to `'token'` for any internet-exposed
+   * deployment. When `'token'`, the token is read from
+   * `process.env[tokenEnv]` (default env var: `FRONTMCP_METRICS_TOKEN`).
+   *
+   * @default 'public'
+   */
+  auth?: MetricsAuth;
+
+  /**
+   * Environment variable name to read the bearer token from when
+   * `auth: 'token'`. Ignored for other auth modes.
+   *
+   * @default 'FRONTMCP_METRICS_TOKEN'
+   */
+  tokenEnv?: string;
+
+  /**
+   * Category filter. When set, only categories listed here are emitted.
+   * Omit to emit every category.
+   */
+  include?: MetricsCategory[];
+
+  /**
+   * Per-probe knobs for the built-in process-stats collector.
+   */
+  process?: MetricsProcessOptionsInterface;
+}

--- a/libs/sdk/src/common/types/options/metrics/schema.ts
+++ b/libs/sdk/src/common/types/options/metrics/schema.ts
@@ -1,0 +1,64 @@
+// common/types/options/metrics/schema.ts
+//
+// Configuration schema for the /metrics endpoint (issue #397).
+
+import { z } from '@frontmcp/lazy-zod';
+
+import type { RawZodShape } from '../../common.types';
+import type { MetricsOptionsInterface, MetricsProcessOptionsInterface } from './interfaces';
+
+export type { MetricsOptionsInterface, MetricsProcessOptionsInterface };
+
+export const metricsProcessOptionsSchema = z.object({
+  eventLoopLag: z.boolean().optional(),
+  fdCount: z.boolean().optional(),
+  activeHandles: z.boolean().optional(),
+} satisfies RawZodShape<MetricsProcessOptionsInterface>);
+
+const metricsAuthSchema = z.union([z.literal('public'), z.literal('token'), z.object({ token: z.string().min(1) })]);
+
+export const metricsOptionsSchema = z.object({
+  enabled: z.boolean().optional().default(false),
+  path: z.string().optional().default('/metrics'),
+  format: z
+    .union([z.literal('prometheus'), z.literal('json')])
+    .optional()
+    .default('prometheus'),
+  auth: metricsAuthSchema.optional().default('public'),
+  tokenEnv: z.string().optional().default('FRONTMCP_METRICS_TOKEN'),
+  include: z
+    .array(
+      z.union([
+        z.literal('process'),
+        z.literal('tools'),
+        z.literal('resources'),
+        z.literal('http'),
+        z.literal('storage'),
+        z.literal('skills'),
+        z.literal('auth'),
+        z.literal('sessions'),
+      ]),
+    )
+    .optional(),
+  process: metricsProcessOptionsSchema.optional(),
+} satisfies RawZodShape<MetricsOptionsInterface>);
+
+/**
+ * Default metrics configuration values.
+ *
+ * The endpoint is OFF by default. Enabling it is a deliberate decision —
+ * see `MetricsOptionsInterface` for the rationale.
+ */
+export const DEFAULT_METRICS_OPTIONS: Pick<
+  Required<MetricsOptionsInterface>,
+  'enabled' | 'path' | 'format' | 'auth' | 'tokenEnv'
+> = {
+  enabled: false,
+  path: '/metrics',
+  format: 'prometheus',
+  auth: 'public',
+  tokenEnv: 'FRONTMCP_METRICS_TOKEN',
+};
+
+export type MetricsOptions = z.infer<typeof metricsOptionsSchema>;
+export type MetricsOptionsInput = MetricsOptionsInterface;

--- a/libs/sdk/src/front-mcp/front-mcp.ts
+++ b/libs/sdk/src/front-mcp/front-mcp.ts
@@ -16,7 +16,7 @@ import { InternalMcpError, ServerNotFoundError } from '../errors';
 import { HealthService } from '../health';
 import { FileLogTransportInstance } from '../logger/instances/instance.file-logger';
 import LoggerRegistry from '../logger/logger.registry';
-import { MetricsService } from '../metrics';
+import { createProcessStatsCollectorIfEnabled, MetricsService } from '../metrics';
 import ProviderRegistry from '../provider/provider.registry';
 import { type Scope } from '../scope/scope.instance';
 import { ScopeRegistry } from '../scope/scope.registry';
@@ -148,7 +148,8 @@ export class FrontMcpInstance implements FrontMcpInterface {
     }
 
     try {
-      const service = new MetricsService(metricsConfig);
+      const processCollector = createProcessStatsCollectorIfEnabled(metricsConfig);
+      const service = new MetricsService(metricsConfig, processCollector);
       serverInstance.setMetricsService(service, metricsConfig);
     } catch (err) {
       this.log?.error?.('Failed to wire /metrics endpoint', err as Error);

--- a/libs/sdk/src/front-mcp/front-mcp.ts
+++ b/libs/sdk/src/front-mcp/front-mcp.ts
@@ -16,6 +16,7 @@ import { InternalMcpError, ServerNotFoundError } from '../errors';
 import { HealthService } from '../health';
 import { FileLogTransportInstance } from '../logger/instances/instance.file-logger';
 import LoggerRegistry from '../logger/logger.registry';
+import { MetricsService } from '../metrics';
 import ProviderRegistry from '../provider/provider.registry';
 import { type Scope } from '../scope/scope.instance';
 import { ScopeRegistry } from '../scope/scope.registry';
@@ -64,6 +65,9 @@ export class FrontMcpInstance implements FrontMcpInterface {
 
     // Wire health service from the first scope (if available)
     this.wireHealthService(server);
+
+    // Wire metrics service when configured (issue #397). Off by default.
+    this.wireMetricsService(server);
 
     await server.start();
 
@@ -125,6 +129,33 @@ export class FrontMcpInstance implements FrontMcpInterface {
     }
   }
 
+  /**
+   * Wire the `/metrics` service into the server instance (issue #397).
+   *
+   * Off by default — `metrics.enabled` must be set to `true` explicitly.
+   * The `MetricsService` is instantiated here (not in scope construction)
+   * because the endpoint is server-wide, not per-app — counters and process
+   * stats are process-global.
+   */
+  private wireMetricsService(server: FrontMcpServer): void {
+    const serverInstance = server as FrontMcpServerInstance;
+    if (typeof serverInstance.setMetricsService !== 'function') return;
+
+    const metricsConfig = this.config.metrics;
+    if (!metricsConfig || metricsConfig.enabled !== true) {
+      serverInstance.setMetricsConfig(metricsConfig ?? {});
+      return;
+    }
+
+    try {
+      const service = new MetricsService(metricsConfig);
+      serverInstance.setMetricsService(service, metricsConfig);
+    } catch (err) {
+      this.log?.error?.('Failed to wire /metrics endpoint', err as Error);
+      throw err;
+    }
+  }
+
   public static async bootstrap(options: FrontMcpConfigInput | FrontMcpConfigType) {
     const parsedConfig = frontMcpMetadataSchema.parse(options);
 
@@ -165,6 +196,9 @@ export class FrontMcpInstance implements FrontMcpInterface {
 
     // Wire health service for serverless mode
     frontMcp.wireHealthService(server);
+
+    // Wire metrics service for serverless mode (issue #397)
+    frontMcp.wireMetricsService(server);
 
     server.prepare();
     frontMcp.log?.info('FrontMCP handler created (serverless mode)');

--- a/libs/sdk/src/metrics/__tests__/metrics.routes.spec.ts
+++ b/libs/sdk/src/metrics/__tests__/metrics.routes.spec.ts
@@ -130,4 +130,43 @@ describe('registerMetricsRoutes (issue #397)', () => {
     expect(res.statusCode).toBe(200);
     expect(res.body).toMatchObject({ counters: [{ name: 'foo_total', count: 1 }] });
   });
+
+  it('returns 500 (not silent text-wrapped JSON) when the adapter lacks res.send for Prometheus output', async () => {
+    const { server, routes } = makeServer();
+    const service = new MetricsService({ enabled: true }, undefined, {
+      snapshotSource: () => [{ name: 'foo_total', count: 1, attributes: {} }],
+    });
+    registerMetricsRoutes(server, service, { enabled: true });
+
+    // Strip `send` to simulate an adapter that only exposes `json`. We MUST
+    // NOT wrap Prometheus plaintext in a JSON envelope — scrapers would
+    // silently start parsing JSON-as-text and report no metrics. The route
+    // surfaces the adapter mismatch as a 500 instead.
+    const res = new FakeResponse();
+    (res as unknown as { send?: undefined }).send = undefined;
+    await routes[0].handler({ headers: {} }, res);
+    expect(res.statusCode).toBe(500);
+    expect(res.body).toMatchObject({ error: 'internal_error' });
+  });
+
+  it('returns 500 instead of throwing when the JSON body is unparseable', async () => {
+    const { server, routes } = makeServer();
+    const service = new MetricsService({ enabled: true, format: 'json' }, undefined, {
+      snapshotSource: () => [{ name: 'foo_total', count: 1, attributes: {} }],
+    });
+    // Stub getMetrics so the body returned is malformed JSON — defends
+    // the route handler against a future downstream override producing
+    // bad output (the production `getMetrics` always emits valid JSON
+    // via `JSON.stringify`).
+    jest.spyOn(service, 'getMetrics').mockReturnValue({
+      contentType: 'application/json',
+      body: '{not-valid-json',
+    });
+    registerMetricsRoutes(server, service, { enabled: true, format: 'json' });
+
+    const res = new FakeResponse();
+    await routes[0].handler({ headers: {} }, res);
+    expect(res.statusCode).toBe(500);
+    expect(res.body).toMatchObject({ error: 'internal_error' });
+  });
 });

--- a/libs/sdk/src/metrics/__tests__/metrics.routes.spec.ts
+++ b/libs/sdk/src/metrics/__tests__/metrics.routes.spec.ts
@@ -1,0 +1,133 @@
+import { registerMetricsRoutes, type MetricsResponseLike, type MetricsRouteServer } from '../metrics.routes';
+import { MetricsService } from '../metrics.service';
+
+class FakeResponse implements MetricsResponseLike {
+  statusCode = 0;
+  headers: Record<string, string> = {};
+  body: unknown = undefined;
+  sentBodyString?: string;
+
+  status(code: number) {
+    this.statusCode = code;
+    return this;
+  }
+  setHeader(name: string, value: string) {
+    this.headers[name.toLowerCase()] = value;
+    return this;
+  }
+  send(payload: string) {
+    this.sentBodyString = payload;
+    return this;
+  }
+  json(payload: unknown) {
+    this.body = payload;
+  }
+}
+
+function makeServer() {
+  const routes: Array<{ method: string; path: string; handler: (req: unknown, res: FakeResponse) => unknown }> = [];
+  const server: MetricsRouteServer = {
+    registerRoute(method, path, handler) {
+      routes.push({ method, path, handler: handler as (req: unknown, res: FakeResponse) => unknown });
+    },
+  };
+  return { server, routes };
+}
+
+describe('registerMetricsRoutes (issue #397)', () => {
+  it('does not register a route when config.enabled !== true', () => {
+    const { server, routes } = makeServer();
+    const service = new MetricsService({ enabled: true }, undefined, { snapshotSource: () => [] });
+    registerMetricsRoutes(server, service, { enabled: false });
+    expect(routes).toHaveLength(0);
+  });
+
+  it("registers GET <path> when enabled: true (default '/metrics')", () => {
+    const { server, routes } = makeServer();
+    const service = new MetricsService({ enabled: true }, undefined, { snapshotSource: () => [] });
+    registerMetricsRoutes(server, service, { enabled: true });
+    expect(routes).toHaveLength(1);
+    expect(routes[0].method).toBe('GET');
+    expect(routes[0].path).toBe('/metrics');
+  });
+
+  it('honors a custom path', () => {
+    const { server, routes } = makeServer();
+    const service = new MetricsService({ enabled: true, path: '/internal/m' }, undefined, {
+      snapshotSource: () => [],
+    });
+    registerMetricsRoutes(server, service, { enabled: true, path: '/internal/m' });
+    expect(routes[0].path).toBe('/internal/m');
+  });
+
+  it("returns 200 and Prometheus body with auth='public'", async () => {
+    const { server, routes } = makeServer();
+    const service = new MetricsService({ enabled: true }, undefined, {
+      snapshotSource: () => [{ name: 'requests_total', count: 1, attributes: {} }],
+    });
+    registerMetricsRoutes(server, service, { enabled: true });
+
+    const res = new FakeResponse();
+    await routes[0].handler({ headers: {} }, res);
+    expect(res.statusCode).toBe(200);
+    expect(res.sentBodyString).toContain('requests_total 1');
+    expect(res.headers['cache-control']).toBe('no-store');
+    expect(res.headers['content-type']).toBe('text/plain; version=0.0.4; charset=utf-8');
+  });
+
+  it("returns 401 when auth='token' and no Authorization header is sent", async () => {
+    process.env['FRONTMCP_METRICS_TOKEN'] = 'sekret';
+    const { server, routes } = makeServer();
+    const service = new MetricsService({ enabled: true, auth: 'token' }, undefined, {
+      snapshotSource: () => [],
+    });
+    registerMetricsRoutes(server, service, { enabled: true, auth: 'token' });
+
+    const res = new FakeResponse();
+    await routes[0].handler({ headers: {} }, res);
+    expect(res.statusCode).toBe(401);
+    expect(res.body).toMatchObject({ error: 'unauthorized' });
+    expect(res.headers['cache-control']).toBe('no-store');
+  });
+
+  it("returns 403 when auth='token' and a wrong bearer is sent", async () => {
+    process.env['FRONTMCP_METRICS_TOKEN'] = 'sekret';
+    const { server, routes } = makeServer();
+    const service = new MetricsService({ enabled: true, auth: 'token' }, undefined, {
+      snapshotSource: () => [],
+    });
+    registerMetricsRoutes(server, service, { enabled: true, auth: 'token' });
+
+    const res = new FakeResponse();
+    await routes[0].handler({ headers: { authorization: 'Bearer wrong' } }, res);
+    expect(res.statusCode).toBe(403);
+    expect(res.body).toMatchObject({ error: 'forbidden' });
+  });
+
+  it("returns 200 and body when auth='token' and the correct bearer is sent", async () => {
+    process.env['FRONTMCP_METRICS_TOKEN'] = 'sekret';
+    const { server, routes } = makeServer();
+    const service = new MetricsService({ enabled: true, auth: 'token' }, undefined, {
+      snapshotSource: () => [{ name: 'ok_total', count: 1, attributes: {} }],
+    });
+    registerMetricsRoutes(server, service, { enabled: true, auth: 'token' });
+
+    const res = new FakeResponse();
+    await routes[0].handler({ headers: { authorization: 'Bearer sekret' } }, res);
+    expect(res.statusCode).toBe(200);
+    expect(res.sentBodyString).toContain('ok_total 1');
+  });
+
+  it("returns JSON body when format='json'", async () => {
+    const { server, routes } = makeServer();
+    const service = new MetricsService({ enabled: true, format: 'json' }, undefined, {
+      snapshotSource: () => [{ name: 'foo_total', count: 1, attributes: {} }],
+    });
+    registerMetricsRoutes(server, service, { enabled: true, format: 'json' });
+
+    const res = new FakeResponse();
+    await routes[0].handler({ headers: {} }, res);
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toMatchObject({ counters: [{ name: 'foo_total', count: 1 }] });
+  });
+});

--- a/libs/sdk/src/metrics/__tests__/metrics.service.spec.ts
+++ b/libs/sdk/src/metrics/__tests__/metrics.service.spec.ts
@@ -1,0 +1,141 @@
+import { MetricsPathConflictError, MetricsTokenNotConfiguredError } from '../metrics.errors';
+import { MetricsService } from '../metrics.service';
+
+describe('MetricsService (issue #397)', () => {
+  describe('path-conflict guard', () => {
+    it.each(['/mcp', '/sse', '/messages', '/mcp/streamable'])(
+      'throws MetricsPathConflictError when path is %s',
+      (path) => {
+        expect(() => new MetricsService({ enabled: true, path })).toThrow(MetricsPathConflictError);
+      },
+    );
+
+    it('accepts non-MCP paths', () => {
+      expect(() => new MetricsService({ enabled: true, path: '/metrics' })).not.toThrow();
+      expect(() => new MetricsService({ enabled: true, path: '/internal/metrics' })).not.toThrow();
+    });
+  });
+
+  describe('token auth', () => {
+    const origEnv = { ...process.env };
+    afterEach(() => {
+      process.env = { ...origEnv };
+    });
+
+    it("throws MetricsTokenNotConfiguredError when auth='token' and env var is unset", () => {
+      delete process.env['FRONTMCP_METRICS_TOKEN'];
+      expect(() => new MetricsService({ enabled: true, auth: 'token' })).toThrow(MetricsTokenNotConfiguredError);
+    });
+
+    it('throws with the configured tokenEnv name when that env var is unset', () => {
+      delete process.env['CUSTOM_TOKEN_ENV'];
+      try {
+        new MetricsService({ enabled: true, auth: 'token', tokenEnv: 'CUSTOM_TOKEN_ENV' });
+        fail('expected throw');
+      } catch (err) {
+        expect(err).toBeInstanceOf(MetricsTokenNotConfiguredError);
+        expect((err as MetricsTokenNotConfiguredError).tokenEnv).toBe('CUSTOM_TOKEN_ENV');
+      }
+    });
+
+    it("succeeds when auth='token' env var is set", () => {
+      process.env['FRONTMCP_METRICS_TOKEN'] = 'sekret';
+      expect(() => new MetricsService({ enabled: true, auth: 'token' })).not.toThrow();
+    });
+
+    it('accepts an inline { token } literal without consulting env', () => {
+      delete process.env['FRONTMCP_METRICS_TOKEN'];
+      expect(() => new MetricsService({ enabled: true, auth: { token: 'inline-secret' } })).not.toThrow();
+    });
+  });
+
+  describe('authorize()', () => {
+    it("returns 200 for any header when auth='public'", () => {
+      const service = new MetricsService({ enabled: true });
+      expect(service.authorize(undefined)).toBe(200);
+      expect(service.authorize('Bearer anything')).toBe(200);
+    });
+
+    it("returns 401 when auth='token' and no Authorization header is sent", () => {
+      process.env['FRONTMCP_METRICS_TOKEN'] = 'sekret';
+      const service = new MetricsService({ enabled: true, auth: 'token' });
+      expect(service.authorize(undefined)).toBe(401);
+      expect(service.authorize('NotABearer foo')).toBe(401);
+    });
+
+    it("returns 200 when the bearer token matches, 403 when it doesn't", () => {
+      process.env['FRONTMCP_METRICS_TOKEN'] = 'sekret';
+      const service = new MetricsService({ enabled: true, auth: 'token' });
+      expect(service.authorize('Bearer sekret')).toBe(200);
+      expect(service.authorize('Bearer wrong')).toBe(403);
+    });
+
+    it('accepts the inline { token } form for the same matching/mismatching behaviour', () => {
+      const service = new MetricsService({ enabled: true, auth: { token: 'inline' } });
+      expect(service.authorize('Bearer inline')).toBe(200);
+      expect(service.authorize('Bearer other')).toBe(403);
+    });
+  });
+
+  describe('getMetrics() with injected snapshotSource', () => {
+    it('renders Prometheus format by default with the canonical Content-Type', () => {
+      const service = new MetricsService({ enabled: true }, undefined, {
+        snapshotSource: () => [{ name: 'tool_calls_total', count: 7, attributes: { tool: 'echo' } }],
+      });
+      const result = service.getMetrics();
+      expect(result.contentType).toBe('text/plain; version=0.0.4; charset=utf-8');
+      expect(result.body).toContain('# TYPE tool_calls_total counter');
+      expect(result.body).toContain('tool_calls_total{tool="echo"} 7');
+    });
+
+    it("renders JSON when format='json'", () => {
+      const service = new MetricsService({ enabled: true, format: 'json' }, undefined, {
+        snapshotSource: () => [{ name: 'tool_calls_total', count: 1, attributes: {} }],
+      });
+      const result = service.getMetrics();
+      expect(result.contentType).toBe('application/json');
+      const parsed = JSON.parse(result.body) as { counters: Array<{ name: string; count: number }> };
+      expect(parsed.counters).toEqual([{ name: 'tool_calls_total', count: 1, attributes: {} }]);
+    });
+
+    it('applies include[] filter to counters (skills only)', () => {
+      const service = new MetricsService({ enabled: true, include: ['skills'] }, undefined, {
+        snapshotSource: () => [
+          { name: 'frontmcp_skills_bundle_pulls_total', count: 1, attributes: {} },
+          { name: 'frontmcp_tool_calls_total', count: 1, attributes: {} },
+          { name: 'frontmcp_http_requests_total', count: 1, attributes: {} },
+        ],
+      });
+      const body = service.getMetrics().body;
+      expect(body).toContain('frontmcp_skills_bundle_pulls_total 1');
+      expect(body).not.toContain('frontmcp_tool_calls_total');
+      expect(body).not.toContain('frontmcp_http_requests_total');
+    });
+
+    it("drops gauges entirely when include[] does not contain 'process'", () => {
+      const service = new MetricsService(
+        { enabled: true, include: ['skills'] },
+        {
+          collect: () => [{ name: 'frontmcp_process_uptime_seconds', value: 10 }],
+          close: () => undefined,
+        } as unknown as Parameters<typeof MetricsService>[1],
+        { snapshotSource: () => [] },
+      );
+      const body = service.getMetrics().body;
+      expect(body).not.toContain('frontmcp_process_uptime_seconds');
+    });
+
+    it("keeps process gauges when include[] contains 'process'", () => {
+      const service = new MetricsService(
+        { enabled: true, include: ['process'] },
+        {
+          collect: () => [{ name: 'frontmcp_process_uptime_seconds', value: 99 }],
+          close: () => undefined,
+        } as unknown as Parameters<typeof MetricsService>[1],
+        { snapshotSource: () => [] },
+      );
+      const body = service.getMetrics().body;
+      expect(body).toContain('frontmcp_process_uptime_seconds 99');
+    });
+  });
+});

--- a/libs/sdk/src/metrics/__tests__/metrics.service.spec.ts
+++ b/libs/sdk/src/metrics/__tests__/metrics.service.spec.ts
@@ -1,5 +1,5 @@
 import { MetricsPathConflictError, MetricsTokenNotConfiguredError } from '../metrics.errors';
-import { MetricsService } from '../metrics.service';
+import { createProcessStatsCollectorIfEnabled, MetricsService } from '../metrics.service';
 
 describe('MetricsService (issue #397)', () => {
   describe('path-conflict guard', () => {
@@ -136,6 +136,30 @@ describe('MetricsService (issue #397)', () => {
       );
       const body = service.getMetrics().body;
       expect(body).toContain('frontmcp_process_uptime_seconds 99');
+    });
+  });
+
+  describe('createProcessStatsCollectorIfEnabled', () => {
+    it("returns a collector when 'include' is omitted (= every category)", () => {
+      const collector = createProcessStatsCollectorIfEnabled({ enabled: true });
+      expect(collector).toBeDefined();
+      // Sanity: the returned object is callable as a collector.
+      expect(typeof collector?.collect).toBe('function');
+    });
+
+    it("returns a collector when 'include' explicitly contains 'process'", () => {
+      const collector = createProcessStatsCollectorIfEnabled({ enabled: true, include: ['process', 'tools'] });
+      expect(collector).toBeDefined();
+    });
+
+    it("returns undefined when 'include' is set but excludes 'process'", () => {
+      const collector = createProcessStatsCollectorIfEnabled({ enabled: true, include: ['tools', 'http'] });
+      expect(collector).toBeUndefined();
+    });
+
+    it("returns a collector when 'include' is an empty array (= every category)", () => {
+      const collector = createProcessStatsCollectorIfEnabled({ enabled: true, include: [] });
+      expect(collector).toBeDefined();
     });
   });
 });

--- a/libs/sdk/src/metrics/index.ts
+++ b/libs/sdk/src/metrics/index.ts
@@ -1,6 +1,11 @@
 // metrics/index.ts
 // Barrel export for the /metrics endpoint subsystem (issue #397).
 
-export { MetricsService, type MetricsResponse, type MetricsServiceOptions } from './metrics.service';
+export {
+  MetricsService,
+  createProcessStatsCollectorIfEnabled,
+  type MetricsResponse,
+  type MetricsServiceOptions,
+} from './metrics.service';
 export { registerMetricsRoutes, type MetricsRouteServer, type MetricsResponseLike } from './metrics.routes';
 export { MetricsPathConflictError, MetricsTokenNotConfiguredError } from './metrics.errors';

--- a/libs/sdk/src/metrics/index.ts
+++ b/libs/sdk/src/metrics/index.ts
@@ -1,0 +1,6 @@
+// metrics/index.ts
+// Barrel export for the /metrics endpoint subsystem (issue #397).
+
+export { MetricsService, type MetricsResponse, type MetricsServiceOptions } from './metrics.service';
+export { registerMetricsRoutes, type MetricsRouteServer, type MetricsResponseLike } from './metrics.routes';
+export { MetricsPathConflictError, MetricsTokenNotConfiguredError } from './metrics.errors';

--- a/libs/sdk/src/metrics/metrics.errors.ts
+++ b/libs/sdk/src/metrics/metrics.errors.ts
@@ -1,0 +1,36 @@
+// metrics/metrics.errors.ts
+// Startup errors raised by the metrics service (issue #397).
+
+import { InternalMcpError } from '../errors/mcp.error';
+
+/**
+ * Raised when `metrics.path` collides with an MCP transport route prefix
+ * (`/mcp`, `/sse`, `/messages`).
+ */
+export class MetricsPathConflictError extends InternalMcpError {
+  readonly conflictingPath: string;
+
+  constructor(conflictingPath: string) {
+    super(
+      `metrics.path "${conflictingPath}" conflicts with an MCP transport route. Pick a non-MCP path (e.g. "/metrics", "/internal/metrics").`,
+      'METRICS_PATH_CONFLICT',
+    );
+    this.conflictingPath = conflictingPath;
+  }
+}
+
+/**
+ * Raised when `metrics.auth === 'token'` is configured but the env var
+ * named by `metrics.tokenEnv` is unset.
+ */
+export class MetricsTokenNotConfiguredError extends InternalMcpError {
+  readonly tokenEnv: string;
+
+  constructor(tokenEnv: string) {
+    super(
+      `metrics.auth is "token" but env var "${tokenEnv}" is not set. Set the env var or switch metrics.auth to "public" / { token: "..." }.`,
+      'METRICS_TOKEN_NOT_CONFIGURED',
+    );
+    this.tokenEnv = tokenEnv;
+  }
+}

--- a/libs/sdk/src/metrics/metrics.routes.ts
+++ b/libs/sdk/src/metrics/metrics.routes.ts
@@ -71,7 +71,18 @@ export function registerMetricsRoutes(
     res.setHeader?.('Content-Type', result.contentType);
 
     if ((config.format ?? 'prometheus') === 'json') {
-      res.status(200).json(JSON.parse(result.body));
+      try {
+        res.status(200).json(JSON.parse(result.body));
+      } catch {
+        // `getMetrics()` builds the JSON via `JSON.stringify`, so this
+        // branch should be unreachable — but if a downstream override
+        // produces malformed JSON we surface a 500 rather than letting
+        // the parse exception escape the route handler.
+        res.status(500).json({
+          error: 'internal_error',
+          message: 'Failed to serialise metrics JSON',
+        });
+      }
       return;
     }
     if (typeof res.send === 'function') {
@@ -79,6 +90,12 @@ export function registerMetricsRoutes(
       res.send(result.body);
       return;
     }
-    res.status(200).json({ body: result.body });
+    // Prometheus scrape format is `text/plain` — wrapping it in JSON
+    // would silently break every scraper. Surface a 500 instead so the
+    // adapter mismatch is visible.
+    res.status(500).json({
+      error: 'internal_error',
+      message: 'Server adapter does not support Prometheus text format. Use `format: "json"` or upgrade the adapter.',
+    });
   });
 }

--- a/libs/sdk/src/metrics/metrics.routes.ts
+++ b/libs/sdk/src/metrics/metrics.routes.ts
@@ -1,0 +1,84 @@
+/**
+ * @file metrics.routes.ts
+ * @description HTTP route registration for the `/metrics` endpoint (issue #397).
+ */
+
+import type { MetricsOptionsInterface } from '../common';
+import type { MetricsService } from './metrics.service';
+
+/**
+ * Minimal server interface for route registration. Mirrors `HealthRouteServer`
+ * to avoid importing the full `FrontMcpServerInstance` (circular dependencies).
+ */
+export interface MetricsRouteServer {
+  registerRoute(
+    method: 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE' | 'OPTIONS' | 'HEAD',
+    path: string,
+    handler: (
+      req: { headers?: Record<string, string | string[] | undefined> },
+      res: MetricsResponseLike,
+    ) => Promise<void> | void,
+  ): void;
+}
+
+/** Subset of the Express-style response object the route uses. */
+export interface MetricsResponseLike {
+  status(code: number): MetricsResponseLike;
+  setHeader?(name: string, value: string): MetricsResponseLike | void;
+  type?(contentType: string): MetricsResponseLike;
+  send?(body: string): MetricsResponseLike | void;
+  json(payload: unknown): void;
+}
+
+function readAuthorizationHeader(
+  headers: Record<string, string | string[] | undefined> | undefined,
+): string | undefined {
+  if (!headers) return undefined;
+  const raw = headers['authorization'] ?? headers['Authorization'];
+  if (Array.isArray(raw)) return raw[0];
+  return typeof raw === 'string' ? raw : undefined;
+}
+
+/**
+ * Register the `GET <path>` metrics endpoint. No-op when the config has
+ * `enabled !== true` — callers should already have gated this call but the
+ * extra guard keeps `prepare()` simple.
+ */
+export function registerMetricsRoutes(
+  server: MetricsRouteServer,
+  service: MetricsService,
+  config: MetricsOptionsInterface,
+): void {
+  if (config.enabled !== true) return;
+  const path = config.path ?? '/metrics';
+
+  server.registerRoute('GET', path, async (req, res) => {
+    const status = service.authorize(readAuthorizationHeader(req.headers));
+    if (status !== 200) {
+      res.setHeader?.('Cache-Control', 'no-store');
+      res.status(status).json({
+        error: status === 401 ? 'unauthorized' : 'forbidden',
+        message:
+          status === 401
+            ? 'Missing or malformed Authorization header'
+            : 'Bearer token did not match the configured metrics token',
+      });
+      return;
+    }
+
+    const result = service.getMetrics();
+    res.setHeader?.('Cache-Control', 'no-store');
+    res.setHeader?.('Content-Type', result.contentType);
+
+    if ((config.format ?? 'prometheus') === 'json') {
+      res.status(200).json(JSON.parse(result.body));
+      return;
+    }
+    if (typeof res.send === 'function') {
+      res.status(200);
+      res.send(result.body);
+      return;
+    }
+    res.status(200).json({ body: result.body });
+  });
+}

--- a/libs/sdk/src/metrics/metrics.service.ts
+++ b/libs/sdk/src/metrics/metrics.service.ts
@@ -40,6 +40,14 @@ const PROMETHEUS_CONTENT_TYPE = 'text/plain; version=0.0.4; charset=utf-8';
 // at import time, sdk's init would re-enter observability while observability
 // was still resolving HttpHook, producing `HttpHook is undefined` at decorator
 // application time. require() at first call resolves the cycle naturally.
+interface ProcessStatsCollectorCtorOptions {
+  options?: {
+    eventLoopLag?: boolean;
+    fdCount?: boolean;
+    activeHandles?: boolean;
+  };
+}
+
 type ObservabilityRuntime = {
   getMetricSnapshot: () => CounterSnapshotEntry[];
   renderPrometheusExposition: (counters: CounterSnapshotEntry[], gauges?: GaugeSnapshotEntry[]) => string;
@@ -47,6 +55,7 @@ type ObservabilityRuntime = {
     counters: CounterSnapshotEntry[],
     gauges?: GaugeSnapshotEntry[],
   ) => { counters: CounterSnapshotEntry[]; gauges: GaugeSnapshotEntry[] };
+  ProcessStatsCollector: new (init?: ProcessStatsCollectorCtorOptions) => ProcessStatsCollector;
 };
 
 let observabilityRuntime: ObservabilityRuntime | undefined;
@@ -55,6 +64,27 @@ function loadObservability(): ObservabilityRuntime {
     observabilityRuntime = require('@frontmcp/observability') as ObservabilityRuntime;
   }
   return observabilityRuntime;
+}
+
+/**
+ * Lazily build a `ProcessStatsCollector` when the metrics config selects the
+ * `process` category (or omits `include` entirely, which means "every
+ * category"). Returns `undefined` when process metrics are filtered out so
+ * the per-scrape `process.cpuUsage()` / `monitorEventLoopDelay()` calls don't
+ * run for nothing.
+ *
+ * Uses the same lazy `require('@frontmcp/observability')` as the snapshot
+ * source so the SDK ↔ observability import cycle stays broken at module
+ * init.
+ */
+export function createProcessStatsCollectorIfEnabled(
+  config: MetricsOptionsInterface,
+): ProcessStatsCollector | undefined {
+  const include = config.include;
+  const processEnabled = !include || include.length === 0 || include.includes('process');
+  if (!processEnabled) return undefined;
+  const obs = loadObservability();
+  return new obs.ProcessStatsCollector({ options: config.process });
 }
 
 const MCP_RESERVED_PATH_PREFIXES = ['/mcp', '/sse', '/messages'];

--- a/libs/sdk/src/metrics/metrics.service.ts
+++ b/libs/sdk/src/metrics/metrics.service.ts
@@ -1,0 +1,156 @@
+/**
+ * @file metrics.service.ts
+ * @description Core service backing the `/metrics` endpoint (issue #397).
+ */
+
+import type { CounterSnapshotEntry, GaugeSnapshotEntry, ProcessStatsCollector } from '@frontmcp/observability';
+
+import type { MetricsCategory, MetricsOptionsInterface } from '../common';
+import { MetricsPathConflictError, MetricsTokenNotConfiguredError } from './metrics.errors';
+
+// Canonical Prometheus 0.0.4 content type. Pinned here to avoid a runtime
+// import of @frontmcp/observability at module-init time (sdk → observability
+// → sdk circular load). Must stay byte-identical to
+// `PROMETHEUS_CONTENT_TYPE` exported from @frontmcp/observability.
+const PROMETHEUS_CONTENT_TYPE = 'text/plain; version=0.0.4; charset=utf-8';
+
+// Lazy-loaded handles to break the import cycle between @frontmcp/sdk and
+// @frontmcp/observability. The observability bundle imports HttpHook from
+// @frontmcp/sdk at module init; if metrics.service.ts pulled observability
+// at import time, sdk's init would re-enter observability while observability
+// was still resolving HttpHook, producing `HttpHook is undefined` at decorator
+// application time. require() at first call resolves the cycle naturally.
+type ObservabilityRuntime = {
+  getMetricSnapshot: () => CounterSnapshotEntry[];
+  renderPrometheusExposition: (counters: CounterSnapshotEntry[], gauges?: GaugeSnapshotEntry[]) => string;
+  renderJsonExposition: (
+    counters: CounterSnapshotEntry[],
+    gauges?: GaugeSnapshotEntry[],
+  ) => { counters: CounterSnapshotEntry[]; gauges: GaugeSnapshotEntry[] };
+};
+
+let observabilityRuntime: ObservabilityRuntime | undefined;
+function loadObservability(): ObservabilityRuntime {
+  if (!observabilityRuntime) {
+    observabilityRuntime = require('@frontmcp/observability') as ObservabilityRuntime;
+  }
+  return observabilityRuntime;
+}
+
+const MCP_RESERVED_PATH_PREFIXES = ['/mcp', '/sse', '/messages'];
+
+/** Default category → counter-prefix mapping used when `include` is set. */
+const COUNTER_CATEGORY_PREFIX: Record<MetricsCategory, string[]> = {
+  process: ['frontmcp_process_', 'frontmcp_nodejs_'],
+  skills: ['frontmcp_skills_'],
+  tools: ['frontmcp_tool_'],
+  resources: ['frontmcp_resource_'],
+  http: ['frontmcp_http_'],
+  storage: ['frontmcp_storage_'],
+  auth: ['frontmcp_auth_'],
+  sessions: ['frontmcp_session_'],
+};
+
+/**
+ * Resolved metrics body + content type, returned by `getMetrics()`.
+ */
+export interface MetricsResponse {
+  contentType: string;
+  body: string;
+}
+
+/**
+ * Test-injection seam for the counter snapshot source — production callers
+ * never set this.
+ */
+export interface MetricsServiceOptions {
+  snapshotSource?: () => CounterSnapshotEntry[];
+}
+
+export class MetricsService {
+  private readonly config: MetricsOptionsInterface;
+  private readonly processCollector?: ProcessStatsCollector;
+  private readonly snapshotSource: () => CounterSnapshotEntry[];
+  private readonly resolvedToken?: string;
+
+  constructor(
+    config: MetricsOptionsInterface,
+    processCollector?: ProcessStatsCollector,
+    options: MetricsServiceOptions = {},
+  ) {
+    this.config = config;
+    this.processCollector = processCollector;
+    this.snapshotSource = options.snapshotSource ?? (() => loadObservability().getMetricSnapshot());
+
+    const path = config.path ?? '/metrics';
+    for (const prefix of MCP_RESERVED_PATH_PREFIXES) {
+      if (path === prefix || path.startsWith(`${prefix}/`)) {
+        throw new MetricsPathConflictError(path);
+      }
+    }
+
+    if (config.auth === 'token') {
+      const envName = config.tokenEnv ?? 'FRONTMCP_METRICS_TOKEN';
+      const value = process.env[envName];
+      if (!value) {
+        throw new MetricsTokenNotConfiguredError(envName);
+      }
+      this.resolvedToken = value;
+    } else if (typeof config.auth === 'object' && config.auth !== null && 'token' in config.auth) {
+      this.resolvedToken = config.auth.token;
+    }
+  }
+
+  /**
+   * Render the current metrics scrape in the configured format.
+   */
+  getMetrics(): MetricsResponse {
+    const format = this.config.format ?? 'prometheus';
+    const include = this.config.include;
+
+    let counters = this.snapshotSource();
+    let gauges: GaugeSnapshotEntry[] = this.processCollector?.collect() ?? [];
+
+    if (include && include.length > 0) {
+      const includeSet = new Set(include);
+      const allowedPrefixes = include.flatMap((category) => COUNTER_CATEGORY_PREFIX[category] ?? []);
+      const matchesAllowed = (name: string) => allowedPrefixes.some((prefix) => name.startsWith(prefix));
+      counters = counters.filter((c) => matchesAllowed(c.name));
+      if (!includeSet.has('process')) {
+        gauges = [];
+      } else {
+        gauges = gauges.filter((g) => matchesAllowed(g.name));
+      }
+    }
+
+    const obs = loadObservability();
+    if (format === 'json') {
+      return {
+        contentType: 'application/json',
+        body: JSON.stringify(obs.renderJsonExposition(counters, gauges)),
+      };
+    }
+    return {
+      contentType: PROMETHEUS_CONTENT_TYPE,
+      body: obs.renderPrometheusExposition(counters, gauges),
+    };
+  }
+
+  /**
+   * Check the supplied `Authorization` header against the configured auth
+   * policy. Returns the HTTP status the route should respond with:
+   *   - 200 — the request is allowed to read metrics
+   *   - 401 — missing credentials when token auth is configured
+   *   - 403 — wrong credentials
+   */
+  authorize(authorizationHeader: string | undefined): 200 | 401 | 403 {
+    const auth = this.config.auth ?? 'public';
+    if (auth === 'public') return 200;
+    if (!authorizationHeader) return 401;
+    const expected = this.resolvedToken;
+    if (!expected) return 401;
+    const match = /^Bearer\s+(.+)$/i.exec(authorizationHeader);
+    if (!match) return 401;
+    return match[1] === expected ? 200 : 403;
+  }
+}

--- a/libs/sdk/src/metrics/metrics.service.ts
+++ b/libs/sdk/src/metrics/metrics.service.ts
@@ -3,10 +3,30 @@
  * @description Core service backing the `/metrics` endpoint (issue #397).
  */
 
-import type { CounterSnapshotEntry, GaugeSnapshotEntry, ProcessStatsCollector } from '@frontmcp/observability';
-
 import type { MetricsCategory, MetricsOptionsInterface } from '../common';
 import { MetricsPathConflictError, MetricsTokenNotConfiguredError } from './metrics.errors';
+
+// Local mirrors of @frontmcp/observability public types. The SDK cannot
+// import these from @frontmcp/observability because observability depends
+// on @frontmcp/sdk, and libs/sdk/project.json explicitly excludes
+// observability from sdk's build deps (`implicitDependencies: ["!observability"]`).
+// Keep these structurally identical to the upstream exports.
+interface CounterSnapshotEntry {
+  name: string;
+  count: number;
+  attributes: Record<string, string>;
+}
+
+interface GaugeSnapshotEntry {
+  name: string;
+  value: number;
+  attributes?: Record<string, string>;
+  help?: string;
+}
+
+interface ProcessStatsCollector {
+  collect(): GaugeSnapshotEntry[];
+}
 
 // Canonical Prometheus 0.0.4 content type. Pinned here to avoid a runtime
 // import of @frontmcp/observability at module-init time (sdk → observability

--- a/libs/sdk/src/server/server.instance.ts
+++ b/libs/sdk/src/server/server.instance.ts
@@ -10,7 +10,9 @@ import {
   type ServerRequestHandler,
 } from '../common';
 import { type HealthOptionsInterface } from '../common/types/options/health';
+import { type MetricsOptionsInterface } from '../common/types/options/metrics';
 import { registerHealthRoutes, type HealthService } from '../health';
+import { registerMetricsRoutes, type MetricsService } from '../metrics';
 import { type HostServerAdapter } from './adapters/base.host.adapter';
 import { auditSecurityDefaults, logSecurityFindings, resolveBindAddress } from './security/security-audit';
 
@@ -22,6 +24,9 @@ export class FrontMcpServerInstance extends FrontMcpServer {
   private healthRouteRegistered = false;
   private _healthService?: HealthService;
   private _healthConfig?: HealthOptionsInterface;
+  private metricsRouteRegistered = false;
+  private _metricsService?: MetricsService;
+  private _metricsConfig?: MetricsOptionsInterface;
 
   constructor(httpConfig: HttpOptions) {
     super();
@@ -75,6 +80,24 @@ export class FrontMcpServerInstance extends FrontMcpServer {
     this._healthConfig = healthConfig;
   }
 
+  /**
+   * Set the metrics service and config for route registration (issue #397).
+   * Must be called before prepare() to enable the `/metrics` endpoint.
+   */
+  setMetricsService(metricsService: MetricsService, metricsConfig: MetricsOptionsInterface): void {
+    this._metricsService = metricsService;
+    this._metricsConfig = metricsConfig;
+  }
+
+  /**
+   * Set metrics config without a service (e.g., when metrics is explicitly disabled
+   * or running on a transport without a listener). Allows prepare() to skip route
+   * registration without ambiguity.
+   */
+  setMetricsConfig(metricsConfig: MetricsOptionsInterface): void {
+    this._metricsConfig = metricsConfig;
+  }
+
   prepare() {
     if (!this.healthRouteRegistered) {
       this.healthRouteRegistered = true;
@@ -89,6 +112,14 @@ export class FrontMcpServerInstance extends FrontMcpServer {
           res.status(200).json({ status: 'ok' });
         });
       }
+    }
+    if (!this.metricsRouteRegistered) {
+      this.metricsRouteRegistered = true;
+      if (this._metricsService && this._metricsConfig?.enabled === true) {
+        registerMetricsRoutes(this, this._metricsService, this._metricsConfig);
+      }
+      // Any other state (no service, disabled, or no config) → no route. The
+      // endpoint is OFF by default per issue #397.
     }
     this.host.prepare();
   }

--- a/libs/skills/__tests__/skills-validation.spec.ts
+++ b/libs/skills/__tests__/skills-validation.spec.ts
@@ -460,7 +460,16 @@ describe('skills catalog validation', () => {
 
     it('should not use auth string shorthand in decorator context', () => {
       const violations: string[] = [];
+      // The /metrics endpoint (issue #397) has its OWN `auth` option whose
+      // legal values include 'public' and 'token'. The decorator-level auth
+      // shorthand deprecation does NOT apply to it, so the metrics skill
+      // surface is exempted from this guard.
+      const METRICS_AUTH_FILES = new Set([
+        'frontmcp-observability/metrics-endpoint.md',
+        'frontmcp-observability/examples/metrics-endpoint/enable-metrics-endpoint.md',
+      ]);
       for (const { skill, file, fullPath } of documentationFiles) {
+        if (METRICS_AUTH_FILES.has(`${skill}/${file}`)) continue;
         const content = fs.readFileSync(fullPath, 'utf-8');
         // Match auth: 'remote', auth: 'public', auth: 'transparent' as standalone config values
         const authShorthand = content.match(/auth:\s*['"](?:remote|public|transparent)['"]/g);

--- a/libs/skills/catalog/frontmcp-observability/SKILL.md
+++ b/libs/skills/catalog/frontmcp-observability/SKILL.md
@@ -54,6 +54,7 @@ Router for adding observability to FrontMCP servers. Covers distributed tracing 
 | Create custom spans in tools/plugins               | `references/telemetry-api.md`         |
 | Connect Coralogix, Datadog, Logz.io, Grafana       | `references/vendor-integrations.md`   |
 | Test that spans and logs are correct               | `references/testing-observability.md` |
+| Expose Prometheus `/metrics` endpoint              | `references/metrics-endpoint.md`      |
 
 ## Step 2: Enable Observability
 
@@ -83,13 +84,14 @@ Follow the scenario routing table above to find the right reference for your use
 
 ## Scenario Routing Table
 
-| Scenario                             | Reference                             | Description                                                                 |
-| ------------------------------------ | ------------------------------------- | --------------------------------------------------------------------------- |
-| Enable OpenTelemetry tracing         | `references/tracing-setup.md`         | Zero-config auto-instrumentation, setupOTel(), span hierarchy               |
-| Add JSON logs with trace correlation | `references/structured-logging.md`    | Sinks (stdout, console, OTLP, winston, pino), redaction, log format         |
-| Custom spans in tools/plugins        | `references/telemetry-api.md`         | `this.telemetry.startSpan()`, `withSpan()`, `addEvent()`, `setAttributes()` |
-| Connect to monitoring platforms      | `references/vendor-integrations.md`   | Coralogix, Datadog, Logz.io, Grafana — OTLP and direct                      |
-| Test spans and log entries           | `references/testing-observability.md` | `createTestTracer()`, `assertSpanExists()`, integration test patterns       |
+| Scenario                              | Reference                             | Description                                                                 |
+| ------------------------------------- | ------------------------------------- | --------------------------------------------------------------------------- |
+| Enable OpenTelemetry tracing          | `references/tracing-setup.md`         | Zero-config auto-instrumentation, setupOTel(), span hierarchy               |
+| Add JSON logs with trace correlation  | `references/structured-logging.md`    | Sinks (stdout, console, OTLP, winston, pino), redaction, log format         |
+| Custom spans in tools/plugins         | `references/telemetry-api.md`         | `this.telemetry.startSpan()`, `withSpan()`, `addEvent()`, `setAttributes()` |
+| Connect to monitoring platforms       | `references/vendor-integrations.md`   | Coralogix, Datadog, Logz.io, Grafana — OTLP and direct                      |
+| Test spans and log entries            | `references/testing-observability.md` | `createTestTracer()`, `assertSpanExists()`, integration test patterns       |
+| Expose Prometheus `/metrics` endpoint | `references/metrics-endpoint.md`      | Off-by-default Prometheus scrape endpoint with process + framework counters |
 
 ## Common Patterns
 
@@ -186,6 +188,12 @@ Each reference has matching examples under [`examples/<reference>/`](./examples/
 | ---------------------------------------------------------------------------------- | ------------ | ------------------------------------------------------------------------------------------- |
 | [`test-custom-spans`](./examples/testing-observability/test-custom-spans.md)       | Basic        | Verify that your tool creates the expected child spans with correct attributes.             |
 | [`test-log-correlation`](./examples/testing-observability/test-log-correlation.md) | Intermediate | Verify that structured log entries include trace context fields for correlation with spans. |
+
+### `metrics-endpoint`
+
+| Example                                                                             | Level | Description                                                          |
+| ----------------------------------------------------------------------------------- | ----- | -------------------------------------------------------------------- |
+| [`enable-metrics-endpoint`](./examples/metrics-endpoint/enable-metrics-endpoint.md) | Basic | Turn on the /metrics endpoint with defaults and scrape it with curl. |
 
 ## Accessing This Skill
 

--- a/libs/skills/catalog/frontmcp-observability/examples/metrics-endpoint/enable-metrics-endpoint.md
+++ b/libs/skills/catalog/frontmcp-observability/examples/metrics-endpoint/enable-metrics-endpoint.md
@@ -1,0 +1,77 @@
+---
+name: enable-metrics-endpoint
+reference: metrics-endpoint
+level: basic
+description: 'Turn on the /metrics endpoint with defaults and scrape it with curl.'
+tags: [observability, metrics, prometheus]
+features:
+  - 'Setting `metrics: { enabled: true }` on `@FrontMcp` to register `GET /metrics`'
+  - 'Verifying the Prometheus text-exposition response with `curl`'
+  - 'Reading process metrics + framework counters from a single scrape'
+---
+
+# Enable the /metrics endpoint
+
+Turn on the /metrics endpoint with defaults and scrape it with curl.
+
+## Code
+
+```typescript
+// src/main.ts
+import { App, FrontMcp, Tool, ToolContext, z } from '@frontmcp/sdk';
+
+@Tool({
+  name: 'echo',
+  description: 'Echo the input back',
+  inputSchema: { message: z.string() },
+  outputSchema: { message: z.string() },
+})
+class EchoTool extends ToolContext {
+  async execute(input: { message: string }): Promise<{ message: string }> {
+    return { message: input.message };
+  }
+}
+
+@App({ name: 'main', tools: [EchoTool] })
+class MainApp {}
+
+@FrontMcp({
+  info: { name: 'my-server', version: '1.0.0' },
+  apps: [MainApp],
+  // Off by default — turn it on explicitly.
+  metrics: { enabled: true },
+})
+export default class Server {}
+```
+
+```bash
+# In a terminal:
+$ frontmcp dev
+[dev] listening on port 3000
+
+# In a second terminal:
+$ curl -s http://localhost:3000/metrics | head -20
+# HELP frontmcp_process_resident_memory_bytes Resident memory size in bytes
+# TYPE frontmcp_process_resident_memory_bytes gauge
+frontmcp_process_resident_memory_bytes 50331648
+# HELP frontmcp_process_uptime_seconds Time since process start in seconds
+# TYPE frontmcp_process_uptime_seconds gauge
+frontmcp_process_uptime_seconds 14
+# HELP frontmcp_process_cpu_seconds_total CPU time consumed since collector start, by mode (seconds)
+# TYPE frontmcp_process_cpu_seconds_total counter
+frontmcp_process_cpu_seconds_total{mode="user"} 0.123
+frontmcp_process_cpu_seconds_total{mode="system"} 0.045
+
+$ curl -sI http://localhost:3000/metrics | grep -i content-type
+content-type: text/plain; version=0.0.4; charset=utf-8
+```
+
+## What This Demonstrates
+
+- Setting `metrics: { enabled: true }` on `@FrontMcp` to register `GET /metrics`
+- Verifying the Prometheus text-exposition response with `curl`
+- Reading process metrics + framework counters from a single scrape
+
+## Related
+
+- See `metrics-endpoint` for full configuration (auth, format, include filter, custom counters via `createCounter()`)

--- a/libs/skills/catalog/frontmcp-observability/references/metrics-endpoint.md
+++ b/libs/skills/catalog/frontmcp-observability/references/metrics-endpoint.md
@@ -1,0 +1,161 @@
+---
+name: metrics-endpoint
+description: Configure the off-by-default /metrics endpoint that exposes process metrics and framework counters in Prometheus text format
+---
+
+# /metrics Endpoint (issue #397)
+
+Expose process metrics (CPU, RSS, heap, event-loop lag) and every framework counter (`frontmcp_skills_*_total`, plus any counter emitted via `createCounter()`) as a Prometheus scrape endpoint on the same HTTP listener as `/healthz`. The endpoint is **OFF by default** — turn it on with `metrics: { enabled: true }`.
+
+## When to use
+
+- Cluster operators want a `/metrics` URL for Prometheus / Grafana Agent / OpenTelemetry Collector to scrape.
+- Kubernetes HPA / Vercel autoscaling needs a pull endpoint instead of an OTel push pipeline.
+- On-call engineers need `curl :PORT/metrics | grep event_loop` without installing cluster-side tooling first.
+- The host wants both push (via OTel `MeterProvider`) and pull (this endpoint) — they read from the same in-memory counter store, so values stay consistent.
+
+## Enable with defaults
+
+```typescript
+import { FrontMcp } from '@frontmcp/sdk';
+
+@FrontMcp({
+  info: { name: 'my-server', version: '1.0.0' },
+  apps: [MyApp],
+  metrics: { enabled: true },
+})
+class Server {}
+```
+
+Then scrape: `curl http://localhost:3001/metrics` — Content-Type is the canonical Prometheus `text/plain; version=0.0.4; charset=utf-8`.
+
+## Configuration
+
+```typescript
+@FrontMcp({
+  metrics: {
+    enabled: true,                       // default: false
+    path: '/metrics',                    // default: '/metrics'
+    format: 'prometheus',                // 'prometheus' | 'json'
+    auth: 'public',                      // 'public' | 'token' | { token: string }
+    tokenEnv: 'FRONTMCP_METRICS_TOKEN',  // env var read at startup when auth: 'token'
+    include: ['process', 'skills'],      // optional category filter
+    process: {
+      eventLoopLag: true,                // mean + p99 event-loop lag gauge
+      fdCount: true,                     // Linux /proc/self/fd count
+      activeHandles: true,               // libuv handle / request counts
+    },
+  },
+})
+```
+
+## What gets emitted
+
+| Category           | Examples                                                                                                                                                        |
+| ------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Process gauges     | `frontmcp_process_resident_memory_bytes`, `frontmcp_process_heap_bytes`, `frontmcp_process_uptime_seconds`, `frontmcp_process_cpu_seconds_total{mode}`          |
+| Node.js gauges     | `frontmcp_nodejs_eventloop_lag_seconds{quantile}`, `frontmcp_nodejs_active_handles`, `frontmcp_nodejs_active_requests`, `frontmcp_nodejs_open_fds` (Linux only) |
+| Framework counters | `frontmcp_skills_bundle_pulls_total`, `frontmcp_skills_signature_*_total`, `frontmcp_skills_replay_*_total`, `frontmcp_skills_audit_*_total`                    |
+| Custom counters    | Anything emitted via `createCounter('my_total').inc()` from `@frontmcp/observability`                                                                           |
+
+## Token auth
+
+```typescript
+metrics: {
+  enabled: true,
+  auth: 'token',
+  tokenEnv: 'FRONTMCP_METRICS_TOKEN',
+}
+```
+
+Fails fast at startup with `MetricsTokenNotConfiguredError` when the env var is unset — a token-gated endpoint never silently downgrades to public.
+
+| Request                           | Status |
+| --------------------------------- | ------ |
+| no `Authorization` header         | 401    |
+| `Authorization: Bearer <wrong>`   | 403    |
+| `Authorization: Bearer <correct>` | 200    |
+
+## Off-by-default rationale
+
+Process metrics, framework counter names, and tool vocabularies can hint at deployment scale and feature usage (e.g. `frontmcp_skills_signature_failures_total` reveals a signing infra exists). Recommendations:
+
+- **Internet-exposed deployments**: use `auth: 'token'` or terminate at a sidecar/ingress with a network ACL.
+- **Cluster-local deployments**: `auth: 'public'` matches the Prometheus / Kubernetes convention.
+
+## Add custom counters
+
+```typescript
+import { createCounter } from '@frontmcp/observability';
+
+const cacheHits = createCounter('my_cache_hits_total', 'Cache hits by tier');
+
+// In a tool / provider:
+cacheHits.inc(1, { tier: 'l1' });
+```
+
+The next scrape will include:
+
+```
+# TYPE my_cache_hits_total counter
+my_cache_hits_total{tier="l1"} 1
+```
+
+Keep label values bounded (status codes, enum members, tool names) — unbounded values blow up the timeseries count.
+
+## Path conflict guard
+
+`metrics.path` MUST NOT collide with MCP transport paths (`/mcp`, `/sse`, `/messages`). The service constructor throws `MetricsPathConflictError` at startup if it detects an overlap.
+
+## Common Patterns
+
+| Pattern           | Correct                                                                         | Incorrect                                                     | Why                                                                                                           |
+| ----------------- | ------------------------------------------------------------------------------- | ------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------- |
+| Enable endpoint   | `metrics: { enabled: true }`                                                    | Omit `metrics:` and hope it's on                              | The endpoint is opt-in; default is OFF for security                                                           |
+| Internet exposure | `metrics: { enabled: true, auth: 'token', tokenEnv: 'FRONTMCP_METRICS_TOKEN' }` | `metrics: { enabled: true, auth: 'public' }` on a public host | `auth: 'public'` is for cluster-local convention only                                                         |
+| Custom counters   | `createCounter('foo_total').inc(1, { status: 'ok' })`                           | `prom-client` `new Counter({...})`                            | The framework reads from `@frontmcp/observability`'s in-memory store; only `createCounter()` flows through it |
+| Label cardinality | `{ status: 'ok' \| 'error' }`                                                   | `{ user_id: '<jwt-sub>' }`                                    | Unbounded label values blow up the timeseries count                                                           |
+
+## Verification Checklist
+
+### Configuration
+
+- [ ] `metrics: { enabled: true }` is set in `@FrontMcp({ ... })`
+- [ ] For internet-exposed deployments, `auth: 'token'` + `tokenEnv` are set AND the env var is exported in the deployment
+- [ ] `metrics.path` does NOT start with `/mcp`, `/sse`, or `/messages`
+- [ ] If using `include[]`, every category name is from the enum (`process` | `tools` | `resources` | `http` | `storage` | `skills` | `auth` | `sessions`)
+
+### Runtime
+
+- [ ] `curl http://<host>:<port>/metrics` returns 200 with Content-Type `text/plain; version=0.0.4; charset=utf-8`
+- [ ] Output contains at least one `frontmcp_process_*` gauge (proves the process-stats collector ran)
+- [ ] Output contains every `frontmcp_skills_*_total` counter incremented since startup
+- [ ] When `auth: 'token'`, requests without `Authorization: Bearer …` return 401 and wrong tokens return 403
+- [ ] Default `@FrontMcp({})` (no `metrics:` key) → `GET /metrics` returns 404 (route was never registered)
+
+## Troubleshooting
+
+| Problem                                                 | Cause                                                                                                          | Solution                                                                                             |
+| ------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------- |
+| `GET /metrics` returns 404                              | `metrics.enabled` is `false` (default)                                                                         | Set `metrics: { enabled: true }`                                                                     |
+| Server throws `MetricsTokenNotConfiguredError` at boot  | `auth: 'token'` set but the env var is empty                                                                   | Export the env var, or switch `auth` to `'public'` / `{ token: '...' }`                              |
+| Server throws `MetricsPathConflictError` at boot        | `metrics.path` starts with `/mcp`, `/sse`, or `/messages`                                                      | Pick a non-MCP path like `/metrics` or `/internal/metrics`                                           |
+| Custom `createCounter()` values missing from the scrape | Counter was created on a different `@frontmcp/observability` module instance (e.g. duplicated in node_modules) | Ensure single `@frontmcp/observability` install via `yarn dedupe` / `npm ls @frontmcp/observability` |
+| OTel push pipeline and `/metrics` show different values | Counters created outside `createCounter()` (e.g. raw `prom-client`) bypass the in-memory store                 | Use `createCounter()` from `@frontmcp/observability` for everything; both paths read the same store  |
+
+## Examples
+
+| Example                                                                              | Level | Description                                                          |
+| ------------------------------------------------------------------------------------ | ----- | -------------------------------------------------------------------- |
+| [`enable-metrics-endpoint`](../examples/metrics-endpoint/enable-metrics-endpoint.md) | Basic | Turn on the /metrics endpoint with defaults and scrape it with curl. |
+
+## Accessing This Skill
+
+This skill is available over MCP under the `skill://metrics-endpoint/SKILL.md` URI per SEP-2640, and as a reference page in the `frontmcp-observability` router.
+
+## Reference
+
+- Docs: https://docs.agentfront.dev/frontmcp/deployment/metrics
+- Issue tracker: https://github.com/agentfront/frontmcp/issues/397
+- SDK exports: `MetricsService`, `registerMetricsRoutes`, `MetricsPathConflictError`, `MetricsTokenNotConfiguredError`
+- Observability exports: `renderPrometheusExposition`, `renderJsonExposition`, `ProcessStatsCollector`, `PROMETHEUS_CONTENT_TYPE`

--- a/libs/skills/catalog/frontmcp-observability/references/metrics-endpoint.md
+++ b/libs/skills/catalog/frontmcp-observability/references/metrics-endpoint.md
@@ -96,7 +96,7 @@ cacheHits.inc(1, { tier: 'l1' });
 
 The next scrape will include:
 
-```
+```text
 # TYPE my_cache_hits_total counter
 my_cache_hits_total{tier="l1"} 1
 ```
@@ -151,7 +151,7 @@ Keep label values bounded (status codes, enum members, tool names) — unbounded
 
 ## Accessing This Skill
 
-This skill is available over MCP under the `skill://metrics-endpoint/SKILL.md` URI per SEP-2640, and as a reference page in the `frontmcp-observability` router.
+This skill is available over MCP under `skill://frontmcp-observability/SKILL.md` per SEP-2640. This reference page is served at `skill://frontmcp-observability/references/metrics-endpoint.md`.
 
 ## Reference
 

--- a/libs/skills/catalog/skills-manifest.json
+++ b/libs/skills/catalog/skills-manifest.json
@@ -3097,6 +3097,23 @@
           ]
         },
         {
+          "name": "metrics-endpoint",
+          "description": "Configure the off-by-default /metrics endpoint that exposes process metrics and framework counters in Prometheus text format",
+          "examples": [
+            {
+              "name": "enable-metrics-endpoint",
+              "description": "Turn on the /metrics endpoint with defaults and scrape it with curl.",
+              "level": "basic",
+              "tags": ["observability", "metrics", "prometheus"],
+              "features": [
+                "Setting `metrics: { enabled: true }` on `@FrontMcp` to register `GET /metrics`",
+                "Verifying the Prometheus text-exposition response with `curl`",
+                "Reading process metrics + framework counters from a single scrape"
+              ]
+            }
+          ]
+        },
+        {
           "name": "vendor-integrations",
           "description": "Connect FrontMCP observability to Coralogix, Datadog, Logz.io, Grafana Cloud, or any OTLP backend.",
           "examples": [

--- a/libs/utils/src/fs/fs.ts
+++ b/libs/utils/src/fs/fs.ts
@@ -335,6 +335,25 @@ export async function readdir(p: string): Promise<string[]> {
 }
 
 /**
+ * List directory contents synchronously.
+ *
+ * **Node.js only** - throws an error if called in browser.
+ *
+ * Use this only when async operations are not possible (e.g., per-scrape
+ * synchronous metrics collectors). Prefer the async `readdir` in most cases.
+ *
+ * @param p - Path to directory
+ * @returns Array of file/directory names
+ *
+ * @example
+ * const files = readdirSync('/proc/self/fd');
+ */
+export function readdirSync(p: string): string[] {
+  const fs = getFs();
+  return fs.readdirSync(p);
+}
+
+/**
  * Remove a file or directory recursively.
  *
  * **Node.js only** - throws an error if called in browser.

--- a/libs/utils/src/fs/index.ts
+++ b/libs/utils/src/fs/index.ts
@@ -11,6 +11,7 @@ export {
   copyFile,
   cp,
   readdir,
+  readdirSync,
   realpath,
   rm,
   mkdtemp,

--- a/libs/utils/src/index.ts
+++ b/libs/utils/src/index.ts
@@ -46,6 +46,7 @@ export {
   copyFile,
   cp,
   readdir,
+  readdirSync,
   realpath,
   rm,
   mkdtemp,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added optional `/metrics` endpoint for Prometheus metrics scraping (disabled by default; enable via `metrics: { enabled: true }` configuration).
  * Metrics endpoint exposes process statistics, framework counters, and custom counters with configurable output format (Prometheus text or JSON).
  * Optional token-based authentication for metrics endpoint.
  * Category filtering to include/exclude specific metric types.

* **Documentation**
  * Added comprehensive metrics endpoint documentation, configuration reference, and getting-started example.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/agentfront/frontmcp/pull/431?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->