### PR TITLE
Add command registration and validation for security

### DIFF
--- a/docs/frontmcp/getting-started/cli-reference.mdx
+++ b/docs/frontmcp/getting-started/cli-reference.mdx
@@ -61,6 +61,47 @@ Install, configure, and manage MCP apps from npm, local paths, or git repositori
 
 ---
 
+## Plugin Commands (issue #411)
+
+Emit the current FrontMCP server as a plugin for an AI tool. Today supports
+Claude Code (`.claude/plugins/<name>/`) and Codex (`~/.codex/config.toml`).
+
+| Command                                            | Description                                                              |
+| -------------------------------------------------- | ------------------------------------------------------------------------ |
+| `plugin install --claude` / `--codex`              | Emit a Claude Code plugin folder and/or Codex `mcp_servers` entry        |
+| `plugin uninstall --claude` / `--codex`            | Remove what `plugin install` wrote, preserving any user files            |
+| `plugin status --claude` / `--codex`               | Report install state per provider (installed v X / outdated / missing)   |
+
+Flags shared across the three subcommands:
+
+| Flag                | Description                                                                  |
+| ------------------- | ---------------------------------------------------------------------------- |
+| `--scope <s>`       | `project` (default → `./.claude/plugins/`) or `user` (→ `~/.claude/plugins/`) |
+| `--dir <path>`      | Override the plugin destination root (testing or non-standard installs)      |
+| `--no-skills`       | Skip the `skills/` subtree                                                   |
+| `--no-commands`     | Skip the `commands/` subtree                                                 |
+| `--only-mcp`        | Skip the plugin folder; just write the `mcpServers` entry                    |
+| `--command <cmd>`   | Override the MCP server invocation in the plugin manifest                    |
+| `--env <NAME>`      | Surface an env-var placeholder in the plugin (repeatable)                    |
+| `--dry-run`         | Print the plan; do not write                                                 |
+
+**End-user path (built bin):** every CLI built with `frontmcp build --target cli`
+inherits `install -p claude|codex`. Pass `-p` (repeatable) plus the same scope
+flags above to get the same plugin emit from the installed binary.
+
+```bash
+# Dev-time: from a FrontMCP project root
+frontmcp plugin install --claude
+frontmcp plugin install --codex --dry-run
+frontmcp plugin status --claude
+
+# End-user: from the installed bin
+my-bin install -p claude -p codex
+my-bin install --status
+```
+
+---
+
 ## Options Reference
 
 ### General Options

--- a/libs/cli/src/commands/build/exec/__tests__/bin-meta.spec.ts
+++ b/libs/cli/src/commands/build/exec/__tests__/bin-meta.spec.ts
@@ -1,0 +1,103 @@
+import * as os from 'os';
+import * as path from 'path';
+
+import { mkdtemp, readJSON, rm } from '@frontmcp/utils';
+
+import { writeBinMeta } from '../bin-meta';
+import type { FrontmcpExecConfig } from '../config';
+import type { ExtractedSchema } from '../cli-runtime/schema-extractor';
+
+function makeSchema(overrides?: Partial<ExtractedSchema>): ExtractedSchema {
+  return {
+    tools: [],
+    resources: [],
+    resourceTemplates: [],
+    prompts: [],
+    jobs: [],
+    capabilities: { skills: false, jobs: false, workflows: false },
+    skillAssets: [],
+    ...overrides,
+  };
+}
+
+function makeConfig(overrides?: Partial<FrontmcpExecConfig>): FrontmcpExecConfig {
+  return {
+    name: 'my-bin',
+    version: '1.0.0',
+    ...overrides,
+  } as FrontmcpExecConfig;
+}
+
+describe('writeBinMeta (issue #411)', () => {
+  let tmp: string;
+
+  beforeEach(async () => {
+    tmp = await mkdtemp(path.join(os.tmpdir(), 'frontmcp-411-binmeta-'));
+  });
+  afterEach(async () => {
+    await rm(tmp, { recursive: true, force: true });
+  });
+
+  it('writes a complete bin-meta.json with name, version, prompts, and skills', async () => {
+    const schema = makeSchema({
+      prompts: [
+        { name: 'do-it', description: 'Do the thing', arguments: [{ name: 'target', required: true }] },
+      ],
+      skillAssets: [
+        {
+          skillName: 'review-pr',
+          baseDir: '/abs/skill-src',
+          instructionFile: '/abs/skill-src/SKILL.md',
+          resourceDirs: { references: '/abs/skill-src/references' },
+        },
+      ],
+    });
+    await writeBinMeta(tmp, makeConfig({ name: 'my-bin', version: '1.2.3' }), schema);
+
+    const meta = (await readJSON(path.join(tmp, 'bin-meta.json'))) as Record<string, unknown>;
+    expect(meta.name).toBe('my-bin');
+    expect(meta.version).toBe('1.2.3');
+    expect(meta.description).toBe('my-bin (FrontMCP server)');
+    expect(meta.mcpDefault).toEqual({ command: 'my-bin', args: ['serve', '--stdio'] });
+    expect(meta.prompts).toEqual([
+      { name: 'do-it', description: 'Do the thing', arguments: [{ name: 'target', required: true }] },
+    ]);
+    expect(meta.skills).toEqual([
+      {
+        name: 'review-pr',
+        instructionFile: path.join('_skills', 'review-pr--SKILL.md'),
+        resourceDirs: { references: path.join('_skills', 'review-pr--references') },
+      },
+    ]);
+  });
+
+  it('omits undefined skill fields (description, resourceDirs) instead of emitting "key: null"', async () => {
+    const schema = makeSchema({
+      skillAssets: [
+        { skillName: 'no-resources', baseDir: '/abs', instructionFile: '/abs/SKILL.md' },
+        { skillName: 'no-instr', baseDir: '/abs' },
+      ],
+    });
+    await writeBinMeta(tmp, makeConfig(), schema);
+
+    const meta = (await readJSON(path.join(tmp, 'bin-meta.json'))) as { skills: Record<string, unknown>[] };
+    expect(meta.skills[0]).not.toHaveProperty('description');
+    expect(meta.skills[0]).not.toHaveProperty('resourceDirs');
+    expect(meta.skills[1]).not.toHaveProperty('instructionFile');
+  });
+
+  it('uses cli.description when provided in config', async () => {
+    const config = makeConfig({ name: 'my-bin', cli: { description: 'My custom CLI' } as never });
+    await writeBinMeta(tmp, config, makeSchema());
+
+    const meta = (await readJSON(path.join(tmp, 'bin-meta.json'))) as { description: string };
+    expect(meta.description).toBe('My custom CLI');
+  });
+
+  it('produces an empty skills array when no skills are extracted', async () => {
+    await writeBinMeta(tmp, makeConfig(), makeSchema());
+    const meta = (await readJSON(path.join(tmp, 'bin-meta.json'))) as { skills: unknown[]; prompts: unknown[] };
+    expect(meta.skills).toEqual([]);
+    expect(meta.prompts).toEqual([]);
+  });
+});

--- a/libs/cli/src/commands/build/exec/__tests__/build-exec-cli.integration.spec.ts
+++ b/libs/cli/src/commands/build/exec/__tests__/build-exec-cli.integration.spec.ts
@@ -14,6 +14,7 @@ jest.mock('@frontmcp/utils', () => ({
   ensureDir: jest.fn().mockResolvedValue(undefined),
   fileExists: jest.fn().mockResolvedValue(false),
   runCmd: jest.fn().mockResolvedValue(undefined),
+  writeJSON: jest.fn().mockResolvedValue(undefined),
 }));
 
 jest.mock('../../../../core/colors', () => ({

--- a/libs/cli/src/commands/build/exec/__tests__/generate-cli-entry.spec.ts
+++ b/libs/cli/src/commands/build/exec/__tests__/generate-cli-entry.spec.ts
@@ -1273,3 +1273,54 @@ describe('RESERVED_COMMANDS', () => {
     expect(RESERVED_COMMANDS.has('query')).toBe(false);
   });
 });
+
+describe('generateCliEntry — install -p claude|codex (issue #411)', () => {
+  it('extends the generated install command with the new -p flags', () => {
+    const source = generateCliEntry(makeOptions());
+    // The new flags on the install command.
+    expect(source).toMatch(/-p, --provider <provider>/);
+    expect(source).toMatch(/--scope <scope>/);
+    expect(source).toMatch(/--no-skills/);
+    expect(source).toMatch(/--no-commands/);
+    expect(source).toMatch(/--only-mcp/);
+    expect(source).toMatch(/--command <cmd>/);
+    expect(source).toMatch(/--env <name>/);
+    expect(source).toMatch(/--dir <dir>/);
+    expect(source).toMatch(/--dry-run/);
+    expect(source).toMatch(/--status/);
+  });
+
+  it('requires the plugin-emitter and bin-meta.json at install time', () => {
+    const source = generateCliEntry(makeOptions());
+    expect(source).toContain("require('./plugin-emitter')");
+    expect(source).toContain("'bin-meta.json'");
+  });
+
+  it('dispatches to emitClaudePlugin / emitCodexEntry per provider', () => {
+    const source = generateCliEntry(makeOptions());
+    expect(source).toContain('emitClaudePlugin');
+    expect(source).toContain('emitCodexEntry');
+    // Branch labels for unknown providers
+    expect(source).toMatch(/Unknown provider/);
+  });
+
+  it('emits a runtime placeholder like ${NAME} for --env entries', () => {
+    const source = generateCliEntry(makeOptions());
+    // The GENERATION-time concat produces a runtime string literal `${NAME}`.
+    expect(source).toContain("'${' + envList[ei] + '}'");
+  });
+
+  it('emits --status output that branches on installed/outdated/not installed', () => {
+    const source = generateCliEntry(makeOptions());
+    expect(source).toContain("'installed'");
+    expect(source).toContain("'outdated'");
+    expect(source).toContain('not installed');
+  });
+
+  it('preserves the legacy ~/.frontmcp install body when -p is absent', () => {
+    const source = generateCliEntry(makeOptions());
+    // Sanity: the original "Installing <name>..." path is still present.
+    expect(source).toContain("'Installing ");
+    expect(source).toContain("'apps'");
+  });
+});

--- a/libs/cli/src/commands/build/exec/bin-meta.ts
+++ b/libs/cli/src/commands/build/exec/bin-meta.ts
@@ -1,0 +1,93 @@
+/**
+ * Issue #411 — write `bin-meta.json` next to the CLI bundle. The per-bin
+ * `<bin> install -p claude|codex` reads this sidecar at runtime to drive
+ * the shared plugin-emitter without re-running schema extraction.
+ *
+ * Shape:
+ * {
+ *   "name": "<bin>",
+ *   "version": "<bin-version>",
+ *   "description": "<from cliConfig or package.json>",
+ *   "mcpDefault": { "command": "<bin>", "args": ["serve", "--stdio"] },
+ *   "prompts": [{ "name", "description", "arguments": [...] }],
+ *   "skills": [{ "name", "description", "instructionFile" (path under _skills/), "resourceDirs": { references?, examples?, scripts?, assets? } }]
+ * }
+ */
+
+import * as path from 'path';
+
+import { writeJSON } from '@frontmcp/utils';
+
+import type { FrontmcpExecConfig } from './config';
+import type { ExtractedSchema } from './cli-runtime/schema-extractor';
+
+export interface BinMeta {
+  name: string;
+  version: string;
+  description: string;
+  mcpDefault: { command: string; args: string[] };
+  prompts: Array<{
+    name: string;
+    description?: string;
+    arguments?: Array<{ name: string; description?: string; required?: boolean }>;
+  }>;
+  skills: Array<{
+    name: string;
+    description?: string;
+    instructionFile?: string;
+    resourceDirs?: { references?: string; examples?: string; scripts?: string; assets?: string };
+  }>;
+}
+
+export async function writeBinMeta(
+  outDir: string,
+  config: FrontmcpExecConfig,
+  schema: ExtractedSchema,
+): Promise<void> {
+  const meta: BinMeta = {
+    name: config.name,
+    version: config.version ?? '0.0.0',
+    description: config.cli?.description ?? `${config.name} (FrontMCP server)`,
+    mcpDefault: { command: config.name, args: ['serve', '--stdio'] },
+    prompts: schema.prompts.map((p) => ({
+      name: p.name,
+      description: p.description,
+      arguments: p.arguments,
+    })),
+    skills: schema.skillAssets.map((asset) => {
+      // The bin runtime expects RELATIVE paths under `_skills/` so the bundle
+      // is portable across install destinations.
+      const instructionFile = asset.instructionFile
+        ? path.join('_skills', `${asset.skillName}--${path.basename(asset.instructionFile)}`)
+        : undefined;
+      const resourceDirs: BinMeta['skills'][number]['resourceDirs'] = {};
+      for (const kind of ['references', 'examples', 'scripts', 'assets'] as const) {
+        if (asset.resourceDirs?.[kind]) {
+          resourceDirs[kind] = path.join('_skills', `${asset.skillName}--${kind}`);
+        }
+      }
+      return {
+        name: asset.skillName,
+        // `description` is not yet plumbed through ExtractedSkillAsset; the
+        // emitter falls back to a generic phrase. Wiring `getDescription()`
+        // through `collectSkillAssets()` is a separate follow-up.
+        description: undefined,
+        instructionFile,
+        resourceDirs: Object.keys(resourceDirs).length > 0 ? resourceDirs : undefined,
+      };
+    }),
+  };
+
+  // Drop undefined fields so the JSON payload matches the TS interface (no
+  // explicit "description": undefined keys land in stringified output).
+  const cleanSkills = meta.skills.map((s) => omitUndefined(s));
+  await writeJSON(path.join(outDir, 'bin-meta.json'), { ...meta, skills: cleanSkills });
+}
+
+function omitUndefined<T extends Record<string, unknown>>(obj: T): Partial<T> {
+  const out: Partial<T> = {};
+  for (const [k, v] of Object.entries(obj)) {
+    if (v !== undefined) out[k as keyof T] = v as T[keyof T];
+  }
+  return out;
+}

--- a/libs/cli/src/commands/build/exec/cli-runtime/__tests__/plugin-emitter.spec.ts
+++ b/libs/cli/src/commands/build/exec/cli-runtime/__tests__/plugin-emitter.spec.ts
@@ -1,0 +1,446 @@
+import * as os from 'os';
+import * as path from 'path';
+
+import { mkdtemp, readFile, rm, writeFile, fileExists, mkdir } from '@frontmcp/utils';
+
+import {
+  assertValidPluginName,
+  emitClaudePlugin,
+  emitCodexEntry,
+  isPluginContainedPath,
+  readInstalledPluginVersion,
+  removeClaudePlugin,
+  removeCodexEntry,
+} from '../plugin-emitter';
+
+describe('plugin-emitter (issue #411)', () => {
+  let tmp: string;
+
+  beforeEach(async () => {
+    tmp = await mkdtemp(path.join(os.tmpdir(), 'frontmcp-411-emitter-'));
+  });
+  afterEach(async () => {
+    await rm(tmp, { recursive: true, force: true });
+  });
+
+  describe('emitClaudePlugin', () => {
+    it('writes a complete plugin folder (manifest + skills + commands)', async () => {
+      const skillSrc = path.join(tmp, 'src-skill');
+      await mkdir(skillSrc, { recursive: true });
+      await writeFile(path.join(skillSrc, 'SKILL.md'), '---\nname: review-pr\n---\nReview PRs.');
+      await mkdir(path.join(skillSrc, 'references'), { recursive: true });
+      await writeFile(path.join(skillSrc, 'references', 'note.md'), 'note');
+
+      const destRoot = path.join(tmp, 'plugins');
+      const result = await emitClaudePlugin({
+        destRoot,
+        name: 'my-bin',
+        version: '1.2.3',
+        description: 'My MCP server',
+        mcpCommand: 'my-bin',
+        mcpArgs: ['serve', '--stdio'],
+        envHints: ['MY_SECRET'],
+        skills: [
+          {
+            name: 'review-pr',
+            description: 'Review pull requests',
+            instructionFile: path.join(skillSrc, 'SKILL.md'),
+            resourceDirs: { references: path.join(skillSrc, 'references') },
+          },
+        ],
+        commands: [
+          {
+            name: 'do-it',
+            description: 'Do the thing',
+            arguments: [{ name: 'target', required: true }],
+          },
+        ],
+        cliVersion: '0.5.0',
+      });
+
+      const pluginDir = path.join(destRoot, 'my-bin');
+      expect(result.pluginDir).toBe(pluginDir);
+      expect(await fileExists(path.join(pluginDir, '.claude-plugin', 'plugin.json'))).toBe(true);
+      expect(await fileExists(path.join(pluginDir, 'skills', 'review-pr', 'SKILL.md'))).toBe(true);
+      expect(await fileExists(path.join(pluginDir, 'skills', 'review-pr', 'references', 'note.md'))).toBe(true);
+      expect(await fileExists(path.join(pluginDir, 'commands', 'do-it.md'))).toBe(true);
+
+      const manifest = JSON.parse(await readFile(path.join(pluginDir, '.claude-plugin', 'plugin.json')));
+      expect(manifest.name).toBe('my-bin');
+      expect(manifest.version).toBe('1.2.3');
+      expect(manifest.skills).toEqual(['review-pr']);
+      expect(manifest.commands).toEqual(['do-it']);
+      expect(manifest.mcpServers['my-bin'].command).toBe('my-bin');
+      expect(manifest.mcpServers['my-bin'].args).toEqual(['serve', '--stdio']);
+      expect(manifest.mcpServers['my-bin'].env).toEqual({ MY_SECRET: '${MY_SECRET}' });
+      expect(manifest._meta.frontmcp.installedBy).toBe('frontmcp@0.5.0');
+      expect(manifest._meta.frontmcp.binVersion).toBe('1.2.3');
+      expect(manifest._meta.frontmcp.managedFiles).toContain('skills/review-pr/SKILL.md');
+      expect(manifest._meta.frontmcp.managedFiles).toContain('commands/do-it.md');
+    });
+
+    it('is idempotent — second emit with same inputs produces the same managed-file set', async () => {
+      const destRoot = path.join(tmp, 'plugins');
+      const opts = {
+        destRoot,
+        name: 'idempotent',
+        version: '1.0.0',
+        description: 'd',
+        mcpCommand: 'idempotent',
+        mcpArgs: ['serve', '--stdio'],
+        envHints: [],
+        skills: [],
+        commands: [],
+        cliVersion: '0.5.0',
+      } as const;
+      const first = await emitClaudePlugin(opts);
+      const second = await emitClaudePlugin(opts);
+      expect(second.manifest._meta.frontmcp.managedFiles).toEqual(first.manifest._meta.frontmcp.managedFiles);
+    });
+
+    it('removes previously-managed files that disappear on re-install', async () => {
+      const destRoot = path.join(tmp, 'plugins');
+      const base = {
+        destRoot,
+        name: 'shrinks',
+        version: '1.0.0',
+        description: 'd',
+        mcpCommand: 'shrinks',
+        mcpArgs: ['serve', '--stdio'],
+        envHints: [],
+        cliVersion: '0.5.0',
+      } as const;
+      await emitClaudePlugin({
+        ...base,
+        skills: [],
+        commands: [
+          { name: 'one', description: 'one' },
+          { name: 'two', description: 'two' },
+        ],
+      });
+      const pluginDir = path.join(destRoot, 'shrinks');
+      expect(await fileExists(path.join(pluginDir, 'commands', 'one.md'))).toBe(true);
+      expect(await fileExists(path.join(pluginDir, 'commands', 'two.md'))).toBe(true);
+
+      const result = await emitClaudePlugin({
+        ...base,
+        skills: [],
+        commands: [{ name: 'one', description: 'one' }],
+      });
+      expect(await fileExists(path.join(pluginDir, 'commands', 'one.md'))).toBe(true);
+      expect(await fileExists(path.join(pluginDir, 'commands', 'two.md'))).toBe(false);
+      expect(result.filesRemoved.length).toBeGreaterThan(0);
+    });
+
+    it('preserves user-added top-level keys in plugin.json on re-install', async () => {
+      const destRoot = path.join(tmp, 'plugins');
+      const base = {
+        destRoot,
+        name: 'preserves',
+        version: '1.0.0',
+        description: 'd',
+        mcpCommand: 'preserves',
+        mcpArgs: ['serve', '--stdio'],
+        envHints: [],
+        skills: [],
+        commands: [],
+        cliVersion: '0.5.0',
+      } as const;
+      await emitClaudePlugin(base);
+      const manifestPath = path.join(destRoot, 'preserves', '.claude-plugin', 'plugin.json');
+      const orig = JSON.parse(await readFile(manifestPath));
+      orig['hooks'] = { 'on-call': './my-hook.sh' };
+      orig.mcpServers['another-server'] = { command: 'other', args: [] };
+      await writeFile(manifestPath, JSON.stringify(orig, null, 2));
+
+      await emitClaudePlugin(base);
+
+      const after = JSON.parse(await readFile(manifestPath));
+      expect(after.hooks).toEqual({ 'on-call': './my-hook.sh' });
+      expect(after.mcpServers['another-server']).toEqual({ command: 'other', args: [] });
+      expect(after.mcpServers['preserves'].command).toBe('preserves');
+    });
+
+    it('dryRun does not touch the filesystem', async () => {
+      const destRoot = path.join(tmp, 'plugins');
+      const result = await emitClaudePlugin({
+        destRoot,
+        name: 'dry',
+        version: '1.0.0',
+        description: 'd',
+        mcpCommand: 'dry',
+        mcpArgs: ['serve', '--stdio'],
+        envHints: [],
+        skills: [],
+        commands: [],
+        cliVersion: '0.5.0',
+        dryRun: true,
+      });
+      expect(await fileExists(result.pluginDir)).toBe(false);
+      expect(result.filesWritten.length).toBeGreaterThan(0); // planned, not actual
+    });
+  });
+
+  describe('assertValidPluginName (issue #411 security)', () => {
+    it('accepts well-formed names', () => {
+      for (const name of ['my-bin', 'my_bin', 'my.bin', 'a1', 'Plugin99', 'Long-Name.with.dots-and-underscores']) {
+        expect(() => assertValidPluginName(name, 'test')).not.toThrow();
+      }
+    });
+
+    it.each([
+      ['', 'empty string'],
+      ['.', 'literal "."'],
+      ['..', 'literal ".." (path traversal)'],
+      ['../etc/passwd', '../ traversal'],
+      ['has/slash', 'forward slash'],
+      ['has\\backslash', 'backslash'],
+      ['has space', 'whitespace'],
+      ['has\nnewline', 'newline (TOML injection)'],
+      ['has\0null', 'NULL byte'],
+      ['has\rcr', 'CR'],
+      ['.hidden', 'leading dot (hidden dir)'],
+      ['-leading-dash', 'leading dash'],
+      ['hash#sign', 'hash (codex marker char)'],
+      ['has[bracket', 'TOML bracket'],
+      ['has=eq', 'TOML equals'],
+      ['a'.repeat(65), 'name longer than 64 chars'],
+    ])('rejects %o (%s)', (name, _why) => {
+      expect(() => assertValidPluginName(name, 'test')).toThrow();
+    });
+  });
+
+  describe('isPluginContainedPath (issue #411 security)', () => {
+    it('accepts paths strictly inside the plugin dir', () => {
+      const pluginDir = '/tmp/plugins/my-bin';
+      expect(isPluginContainedPath(pluginDir, 'commands/foo.md')).toBe(true);
+      expect(isPluginContainedPath(pluginDir, 'skills/x/SKILL.md')).toBe(true);
+      expect(isPluginContainedPath(pluginDir, '.claude-plugin/plugin.json')).toBe(true);
+    });
+
+    it('rejects path-traversal escapes', () => {
+      const pluginDir = '/tmp/plugins/my-bin';
+      expect(isPluginContainedPath(pluginDir, '../escape')).toBe(false);
+      expect(isPluginContainedPath(pluginDir, '../../etc/passwd')).toBe(false);
+      expect(isPluginContainedPath(pluginDir, 'commands/../../../etc/passwd')).toBe(false);
+    });
+
+    it('rejects absolute paths', () => {
+      const pluginDir = '/tmp/plugins/my-bin';
+      expect(isPluginContainedPath(pluginDir, '/etc/passwd')).toBe(false);
+    });
+
+    it('rejects empty paths and the plugin dir itself', () => {
+      const pluginDir = '/tmp/plugins/my-bin';
+      expect(isPluginContainedPath(pluginDir, '')).toBe(false);
+      expect(isPluginContainedPath(pluginDir, '.')).toBe(false);
+    });
+  });
+
+  describe('removeClaudePlugin', () => {
+    it('removes only managed files; leaves user files in place', async () => {
+      const destRoot = path.join(tmp, 'plugins');
+      const opts = {
+        destRoot,
+        name: 'cleanup',
+        version: '1.0.0',
+        description: 'd',
+        mcpCommand: 'cleanup',
+        mcpArgs: ['serve', '--stdio'],
+        envHints: [],
+        skills: [],
+        commands: [{ name: 'one' }],
+        cliVersion: '0.5.0',
+      } as const;
+      await emitClaudePlugin(opts);
+      const pluginDir = path.join(destRoot, 'cleanup');
+      await writeFile(path.join(pluginDir, 'USER-FILE.txt'), 'mine');
+
+      const result = await removeClaudePlugin({ destRoot, name: 'cleanup' });
+      expect(result.removed.length).toBeGreaterThan(0);
+      expect(await fileExists(path.join(pluginDir, 'commands', 'one.md'))).toBe(false);
+      expect(await fileExists(path.join(pluginDir, 'USER-FILE.txt'))).toBe(true);
+    });
+
+    it('is a no-op when nothing is installed', async () => {
+      const result = await removeClaudePlugin({ destRoot: path.join(tmp, 'nope'), name: 'never' });
+      expect(result.removed).toEqual([]);
+    });
+
+    it('preserves nested user files inside skills/ and leaves the plugin dir intact', async () => {
+      const destRoot = path.join(tmp, 'plugins');
+      const opts = {
+        destRoot,
+        name: 'nested',
+        version: '1.0.0',
+        description: 'd',
+        mcpCommand: 'nested',
+        mcpArgs: ['serve', '--stdio'],
+        envHints: [],
+        skills: [
+          {
+            name: 'managed',
+            description: 'managed skill',
+            instructionFile: undefined,
+          },
+        ],
+        commands: [],
+        cliVersion: '0.5.0',
+      } as const;
+      await emitClaudePlugin(opts);
+      const pluginDir = path.join(destRoot, 'nested');
+      // User drops a file inside skills/managed/ alongside the managed SKILL.md,
+      // and another inside skills/ at the second level.
+      await writeFile(path.join(pluginDir, 'skills', 'managed', 'NOTES.md'), 'user');
+      await mkdir(path.join(pluginDir, 'skills', 'my-tool'), { recursive: true });
+      await writeFile(path.join(pluginDir, 'skills', 'my-tool', 'README.md'), 'user');
+
+      await removeClaudePlugin({ destRoot, name: 'nested' });
+
+      expect(await fileExists(path.join(pluginDir, 'skills', 'managed', 'NOTES.md'))).toBe(true);
+      expect(await fileExists(path.join(pluginDir, 'skills', 'my-tool', 'README.md'))).toBe(true);
+      expect(await fileExists(pluginDir)).toBe(true);
+    });
+
+    it('refuses to delete files outside the plugin dir when managedFiles is tampered (issue #411 security)', async () => {
+      const destRoot = path.join(tmp, 'plugins');
+      const opts = {
+        destRoot,
+        name: 'tamper',
+        version: '1.0.0',
+        description: 'd',
+        mcpCommand: 'tamper',
+        mcpArgs: ['serve', '--stdio'],
+        envHints: [],
+        skills: [],
+        commands: [],
+        cliVersion: '0.5.0',
+      } as const;
+      await emitClaudePlugin(opts);
+      const pluginDir = path.join(destRoot, 'tamper');
+      const manifestPath = path.join(pluginDir, '.claude-plugin', 'plugin.json');
+
+      // Write a sentinel file OUTSIDE the plugin dir that a traversal payload
+      // would target.
+      const sentinel = path.join(tmp, 'sensitive.txt');
+      await writeFile(sentinel, 'should-not-be-deleted');
+
+      // Inject a path-traversal payload into managedFiles.
+      const traversal = path.relative(pluginDir, sentinel); // computes the ../../sensitive.txt path
+      const manifest = JSON.parse(await readFile(manifestPath));
+      manifest._meta.frontmcp.managedFiles = [...manifest._meta.frontmcp.managedFiles, traversal];
+      await writeFile(manifestPath, JSON.stringify(manifest, null, 2));
+
+      await removeClaudePlugin({ destRoot, name: 'tamper' });
+
+      expect(await fileExists(sentinel)).toBe(true);
+      expect(await readFile(sentinel)).toBe('should-not-be-deleted');
+    });
+  });
+
+  describe('readInstalledPluginVersion', () => {
+    it('returns binVersion from plugin.json when installed', async () => {
+      const destRoot = path.join(tmp, 'plugins');
+      await emitClaudePlugin({
+        destRoot,
+        name: 'has-version',
+        version: '2.0.0',
+        description: 'd',
+        mcpCommand: 'has-version',
+        mcpArgs: ['serve', '--stdio'],
+        envHints: [],
+        skills: [],
+        commands: [],
+        cliVersion: '0.5.0',
+      });
+      const version = await readInstalledPluginVersion(path.join(destRoot, 'has-version'));
+      expect(version).toBe('2.0.0');
+    });
+
+    it('returns undefined when not installed', async () => {
+      const version = await readInstalledPluginVersion(path.join(tmp, 'nothing'));
+      expect(version).toBeUndefined();
+    });
+  });
+
+  describe('emitCodexEntry', () => {
+    it('writes a new [[mcp_servers]] block when config.toml does not exist', async () => {
+      const configPath = path.join(tmp, '.codex', 'config.toml');
+      const result = await emitCodexEntry({
+        configPath,
+        name: 'codex-bin',
+        command: 'codex-bin',
+        args: ['serve', '--stdio'],
+        env: { TOKEN: '${TOKEN}' },
+      });
+      expect(result.written).toBe(true);
+      const content = await readFile(configPath);
+      expect(content).toContain('[[mcp_servers]]');
+      expect(content).toContain('name = "codex-bin"');
+      expect(content).toContain('command = "codex-bin"');
+      expect(content).toContain('args = ["serve", "--stdio"]');
+      expect(content).toContain('TOKEN = "${TOKEN}"');
+      expect(content).toContain('# frontmcp:codex-start:codex-bin');
+      expect(content).toContain('# frontmcp:codex-end:codex-bin');
+    });
+
+    it('replaces an existing block on re-emit (idempotent)', async () => {
+      const configPath = path.join(tmp, '.codex', 'config.toml');
+      await emitCodexEntry({ configPath, name: 'x', command: 'x', args: ['serve'] });
+      await emitCodexEntry({ configPath, name: 'x', command: 'x', args: ['serve', '--new-flag'] });
+      const content = await readFile(configPath);
+      const startCount = (content.match(/# frontmcp:codex-start:x/g) ?? []).length;
+      expect(startCount).toBe(1);
+      expect(content).toContain('--new-flag');
+    });
+
+    it('preserves user content in the file when adding/removing blocks', async () => {
+      const configPath = path.join(tmp, '.codex', 'config.toml');
+      await mkdir(path.dirname(configPath), { recursive: true });
+      await writeFile(configPath, '# user comment\n[other_section]\nfoo = "bar"\n');
+      await emitCodexEntry({ configPath, name: 'add', command: 'add', args: [] });
+      const content = await readFile(configPath);
+      expect(content).toContain('# user comment');
+      expect(content).toContain('foo = "bar"');
+      expect(content).toContain('# frontmcp:codex-start:add');
+      // Regression guard for the double-newline bug fixed in pass 2: at most a
+      // single blank line should separate the user content from the new block.
+      expect(content).not.toMatch(/\n\n\n+# frontmcp:codex-start/);
+    });
+
+    it('produces single-blank-line separator when appending to file without trailing newline', async () => {
+      const configPath = path.join(tmp, '.codex', 'config.toml');
+      await mkdir(path.dirname(configPath), { recursive: true });
+      await writeFile(configPath, 'foo'); // no trailing newline
+      await emitCodexEntry({ configPath, name: 'first', command: 'first', args: [] });
+      const content = await readFile(configPath);
+      // Expect "foo\n\n# frontmcp:codex-start:first\n..." — single blank line.
+      expect(content).toMatch(/^foo\n\n# frontmcp:codex-start:first\n/);
+    });
+
+    it('collapses multiple trailing newlines into a single blank-line separator', async () => {
+      const configPath = path.join(tmp, '.codex', 'config.toml');
+      await mkdir(path.dirname(configPath), { recursive: true });
+      await writeFile(configPath, 'foo\n\n\n');
+      await emitCodexEntry({ configPath, name: 'second', command: 'second', args: [] });
+      const content = await readFile(configPath);
+      expect(content).toMatch(/^foo\n\n# frontmcp:codex-start:second\n/);
+    });
+  });
+
+  describe('removeCodexEntry', () => {
+    it('removes only the named block, preserving user content', async () => {
+      const configPath = path.join(tmp, '.codex', 'config.toml');
+      await mkdir(path.dirname(configPath), { recursive: true });
+      await writeFile(configPath, '# user comment\n');
+      await emitCodexEntry({ configPath, name: 'a', command: 'a', args: [] });
+      await emitCodexEntry({ configPath, name: 'b', command: 'b', args: [] });
+      const result = await removeCodexEntry({ configPath, name: 'a' });
+      expect(result.removed).toBe(true);
+      const content = await readFile(configPath);
+      expect(content).toContain('# user comment');
+      expect(content).toContain('# frontmcp:codex-start:b');
+      expect(content).not.toContain('# frontmcp:codex-start:a');
+    });
+  });
+});

--- a/libs/cli/src/commands/build/exec/cli-runtime/__tests__/plugin-emitter.spec.ts
+++ b/libs/cli/src/commands/build/exec/cli-runtime/__tests__/plugin-emitter.spec.ts
@@ -181,6 +181,26 @@ describe('plugin-emitter (issue #411)', () => {
     });
   });
 
+  describe('command-name validation (issue #411 security pass 3)', () => {
+    it('rejects emitClaudePlugin when a command name contains injection-prone chars', async () => {
+      const destRoot = path.join(tmp, 'plugins');
+      await expect(
+        emitClaudePlugin({
+          destRoot,
+          name: 'safe-bin',
+          version: '1.0.0',
+          description: 'd',
+          mcpCommand: 'safe-bin',
+          mcpArgs: ['serve', '--stdio'],
+          envHints: [],
+          skills: [],
+          commands: [{ name: 'evil\ninjected: true' }],
+          cliVersion: '0.5.0',
+        }),
+      ).rejects.toThrow(/emitClaudePlugin\.command/);
+    });
+  });
+
   describe('assertValidPluginName (issue #411 security)', () => {
     it('accepts well-formed names', () => {
       for (const name of ['my-bin', 'my_bin', 'my.bin', 'a1', 'Plugin99', 'Long-Name.with.dots-and-underscores']) {

--- a/libs/cli/src/commands/build/exec/cli-runtime/generate-cli-entry.ts
+++ b/libs/cli/src/commands/build/exec/cli-runtime/generate-cli-entry.ts
@@ -1453,16 +1453,156 @@ function generateInstallCommand(
     }
   }
 
-  return `program
+  return `function _frontmcpCollectArg(value, acc) { return Array.isArray(acc) ? acc.concat(value) : [value]; }
+
+program
   .command('install')
-  .description('Install to ~/.frontmcp/ and set up dependencies')
+  .description('Install to ~/.frontmcp/ and set up dependencies, OR emit an IDE plugin (use -p)')
   .option('--prefix <path>', 'Installation prefix directory')
   .option('--bin-dir <path>', 'Directory for symlink (default: ~/.local/bin or /usr/local/bin)')
+  .option('-p, --provider <provider>', 'Emit plugin for provider: claude | codex (repeatable)', _frontmcpCollectArg, [])
+  .option('--scope <scope>', 'Plugin scope when -p is set: project | user', 'project')
+  .option('--no-skills', 'Skip the skills/ subtree (when -p claude)')
+  .option('--no-commands', 'Skip the commands/ subtree (when -p claude)')
+  .option('--only-mcp', 'Skip plugin folder; just register the MCP server')
+  .option('--command <cmd>', 'Override MCP server invocation in the plugin manifest')
+  .option('--env <name>', 'Add env-var placeholder to plugin manifest (repeatable)', _frontmcpCollectArg, [])
+  .option('--dir <dir>', 'Override plugin destination root')
+  .option('--dry-run', 'Print plan; do not write')
+  .option('--status', 'Print install status per provider; exit 0')
   .action(async function(opts) {
     var fs = require('fs');
     var pathMod = require('path');
     var os = require('os');
     var exec = require('child_process').execSync;
+
+    // Issue #411 — when -p is set OR --status is set, run the plugin-install
+    // path instead of the legacy bundle-copy + symlink behavior.
+    var providers = Array.isArray(opts.provider) ? opts.provider : [];
+    if (opts.status || providers.length > 0) {
+      var emitter = require('./plugin-emitter');
+      var binMetaPath = pathMod.join(SCRIPT_DIR, 'bin-meta.json');
+      var meta;
+      try { meta = JSON.parse(fs.readFileSync(binMetaPath, 'utf8')); }
+      catch (e) {
+        console.error('Could not read bin-meta.json at ' + binMetaPath + '. Was the bin built with a recent frontmcp?');
+        process.exit(1);
+      }
+      var pkgJsonPath = pathMod.join(__dirname, '..', '..', 'package.json');
+      var cliVersion = '0.0.0';
+      try { cliVersion = (require(pkgJsonPath) || {}).version || '0.0.0'; } catch (e) { /* ok */ }
+
+      function resolveDestRoot() {
+        if (opts.dir) return pathMod.resolve(opts.dir);
+        if (opts.scope === 'user') return pathMod.join(os.homedir(), '.claude', 'plugins');
+        return pathMod.join(process.cwd(), '.claude', 'plugins');
+      }
+
+      if (opts.status) {
+        console.log(meta.name + ' install --status');
+        var destRootSt = resolveDestRoot();
+        var pluginDirSt = pathMod.join(destRootSt, meta.name);
+        var installed = await emitter.readInstalledPluginVersion(pluginDirSt);
+        if (installed) {
+          var tag = installed === meta.version ? 'installed' : 'outdated';
+          console.log('  claude:    ' + tag + ' v' + installed + (tag === 'outdated' ? ' (bin at v' + meta.version + ')' : '') + ' at ' + pluginDirSt);
+        } else {
+          console.log('  claude:    not installed at ' + pluginDirSt);
+        }
+        var codexConfigSt = pathMod.join(os.homedir(), '.codex', 'config.toml');
+        if (fs.existsSync(codexConfigSt) && fs.readFileSync(codexConfigSt, 'utf8').indexOf('# frontmcp:codex-start:' + meta.name) !== -1) {
+          console.log('  codex:     installed entry for ' + meta.name + ' in ' + codexConfigSt);
+        } else {
+          console.log('  codex:     not installed in ' + codexConfigSt);
+        }
+        return;
+      }
+
+      function buildSkills() {
+        if (opts.skills === false || opts.onlyMcp) return [];
+        var out = [];
+        for (var i = 0; i < (meta.skills || []).length; i++) {
+          var s = meta.skills[i];
+          var resourceDirs = {};
+          if (s.resourceDirs) {
+            for (var k in s.resourceDirs) {
+              if (Object.prototype.hasOwnProperty.call(s.resourceDirs, k)) {
+                resourceDirs[k] = pathMod.join(SCRIPT_DIR, s.resourceDirs[k]);
+              }
+            }
+          }
+          out.push({
+            name: s.name,
+            description: s.description || (s.name + ' skill from ' + meta.name),
+            instructionFile: s.instructionFile ? pathMod.join(SCRIPT_DIR, s.instructionFile) : undefined,
+            resourceDirs: Object.keys(resourceDirs).length > 0 ? resourceDirs : undefined,
+          });
+        }
+        return out;
+      }
+
+      function buildCommands() {
+        if (opts.commands === false || opts.onlyMcp) return [];
+        return (meta.prompts || []).map(function(p) {
+          return { name: p.name, description: p.description, arguments: p.arguments };
+        });
+      }
+
+      for (var pi = 0; pi < providers.length; pi++) {
+        var provider = providers[pi];
+        if (provider === 'claude') {
+          var destRoot = resolveDestRoot();
+          var result = await emitter.emitClaudePlugin({
+            destRoot: destRoot,
+            name: meta.name,
+            version: meta.version,
+            description: meta.description,
+            mcpCommand: opts.command || meta.mcpDefault.command,
+            mcpArgs: meta.mcpDefault.args,
+            envHints: Array.isArray(opts.env) ? opts.env : [],
+            skills: buildSkills(),
+            commands: buildCommands(),
+            cliVersion: cliVersion,
+            dryRun: opts.dryRun,
+          });
+          if (opts.dryRun) {
+            console.log('[install:claude] dry-run plan');
+            console.log('  pluginDir: ' + result.pluginDir);
+            console.log('  filesWritten (planned):');
+            for (var fwi = 0; fwi < result.filesWritten.length; fwi++) console.log('    + ' + result.filesWritten[fwi]);
+          } else {
+            console.log('✓ Wrote ' + result.pluginDir + '/ (' + (result.manifest.skills || []).length + ' skills, ' + ((result.manifest.commands || []).length) + ' commands, 1 MCP server)');
+            console.log('  Restart Claude Code (or run /plugins reload) to pick up the plugin.');
+          }
+        } else if (provider === 'codex') {
+          var codexConfig = pathMod.join(os.homedir(), '.codex', 'config.toml');
+          var env = {};
+          var envList = Array.isArray(opts.env) ? opts.env : [];
+          for (var ei = 0; ei < envList.length; ei++) env[envList[ei]] = '${'$'}{' + envList[ei] + '}';
+          var codexResult = await emitter.emitCodexEntry({
+            configPath: codexConfig,
+            name: meta.name,
+            command: opts.command || meta.mcpDefault.command,
+            args: meta.mcpDefault.args,
+            env: env,
+            dryRun: opts.dryRun,
+          });
+          if (opts.dryRun) {
+            console.log('[install:codex] dry-run plan');
+            console.log('  configPath: ' + codexConfig);
+            console.log(codexResult.configContent);
+          } else {
+            console.log('✓ Updated ' + codexConfig + ' with [[mcp_servers]] entry for ' + meta.name);
+          }
+        } else {
+          console.error('Unknown provider: ' + provider);
+          process.exitCode = 1;
+          return;
+        }
+      }
+      return;
+    }
+
     var installBase = opts.prefix || FRONTMCP_HOME;
     var appDir = pathMod.join(installBase, 'apps', ${JSON.stringify(appName)});
     var dirs = ['', '/data', '/sessions', '/credentials'].map(function(s) { return appDir + s; });

--- a/libs/cli/src/commands/build/exec/cli-runtime/plugin-emitter.ts
+++ b/libs/cli/src/commands/build/exec/cli-runtime/plugin-emitter.ts
@@ -142,6 +142,16 @@ export interface EmitCodexResult {
  * still produce surprising directory layouts. Callers that need scoped
  * names should sanitise first.
  */
+/**
+ * Validate a slash-command name (frontmatter / body content). Same rules
+ * as `assertValidPluginName` so a malicious command name cannot inject
+ * YAML directives or new markdown sections via interpolated body text
+ * in `renderCommandFile`.
+ */
+export function assertValidCommandName(name: string, where: string): void {
+  assertValidPluginName(name, where);
+}
+
 export function assertValidPluginName(name: string, where: string): void {
   if (typeof name !== 'string' || name.length === 0) {
     throw new Error(`Invalid plugin name passed to ${where}: must be a non-empty string`);
@@ -233,8 +243,10 @@ export async function emitClaudePlugin(opts: EmitClaudePluginOptions): Promise<E
     }
   }
 
-  // Commands subtree
+  // Commands subtree. Validate each command name before it lands in the
+  // markdown body or the filesystem path — same rules as the plugin name.
   for (const cmd of [...opts.commands].sort((a, b) => a.name.localeCompare(b.name))) {
+    assertValidCommandName(cmd.name, 'emitClaudePlugin.command');
     const cmdPath = path.join(pluginDir, 'commands', `${cmd.name}.md`);
     plannedFiles.push({
       absPath: cmdPath,

--- a/libs/cli/src/commands/build/exec/cli-runtime/plugin-emitter.ts
+++ b/libs/cli/src/commands/build/exec/cli-runtime/plugin-emitter.ts
@@ -1,0 +1,637 @@
+/**
+ * Plugin emitter for issue #411 — turn a FrontMCP server's metadata into
+ * a Claude Code plugin folder (`.claude/plugins/<bin>/`) or a Codex
+ * `mcp_servers` entry. Shared by the dev-tool `frontmcp install` command
+ * and the per-bin `<bin> install -p claude|codex` command.
+ *
+ * Design constraints (from planning/issues/411.md):
+ *  - Pure helper module — no side-effects at import time.
+ *  - All filesystem ops go through `@frontmcp/utils`.
+ *  - Re-running install must be idempotent: managed files tracked in
+ *    `_meta.frontmcp.managedFiles`; user-added files in the plugin
+ *    directory are NEVER deleted.
+ *  - Manifest written deterministically (sorted keys, fixed spacing) so
+ *    snapshots are stable and re-runs are no-ops when nothing changed.
+ *  - Codex emitter writes a TOML fragment without pulling in a TOML
+ *    dependency — only the `[[mcp_servers]]` shape is needed.
+ */
+
+import * as path from 'path';
+
+import {
+  cp,
+  ensureDir,
+  fileExists,
+  readFile,
+  rm,
+  writeFile,
+} from '@frontmcp/utils';
+
+// ============================================================================
+// Public types
+// ============================================================================
+
+export interface PluginEmitterSkillInput {
+  name: string;
+  description: string;
+  /** Absolute path to SKILL.md. When missing, only frontmatter is emitted. */
+  instructionFile?: string;
+  /** Absolute paths to the skill's resource subdirectories. */
+  resourceDirs?: {
+    references?: string;
+    examples?: string;
+    scripts?: string;
+    assets?: string;
+  };
+}
+
+export interface PluginEmitterCommandInput {
+  /** Slash-command name without leading `/`. */
+  name: string;
+  description?: string;
+  arguments?: Array<{ name: string; description?: string; required?: boolean }>;
+}
+
+export interface EmitClaudePluginOptions {
+  /** Root dir under which `<name>/` will be created. */
+  destRoot: string;
+  name: string;
+  version: string;
+  description: string;
+  /** MCP server invocation command (e.g. the bin name, or `node ./dist/main.js`). */
+  mcpCommand: string;
+  /** Typically `['serve', '--stdio']`. */
+  mcpArgs: string[];
+  /** Env-var names (placeholder values) to surface in `mcpServers.<bin>.env`. */
+  envHints: string[];
+  skills: PluginEmitterSkillInput[];
+  commands: PluginEmitterCommandInput[];
+  /** Used for `_meta.frontmcp.installedBy`. */
+  cliVersion: string;
+  /** If true: plan only, do not write. */
+  dryRun?: boolean;
+}
+
+export interface EmitClaudePluginResult {
+  pluginDir: string;
+  manifest: ClaudePluginManifest;
+  /** Absolute paths written (or that WOULD be written when dryRun). */
+  filesWritten: string[];
+  /** Absolute paths of pre-existing user files left in place. */
+  filesPreserved: string[];
+  /** Managed files from a previous install that were removed this run. */
+  filesRemoved: string[];
+}
+
+export interface ClaudePluginManifest {
+  name: string;
+  version: string;
+  description: string;
+  mcpServers: Record<string, McpServerEntry>;
+  skills: string[];
+  commands?: string[];
+  _meta: {
+    frontmcp: {
+      installedBy: string;
+      installedAt: string;
+      bin: string;
+      binVersion: string;
+      managedFields: string[];
+      managedFiles: string[];
+    };
+  };
+}
+
+export interface McpServerEntry {
+  command: string;
+  args: string[];
+  transport?: 'stdio';
+  env?: Record<string, string>;
+}
+
+export interface EmitCodexOptions {
+  /** `~/.codex/config.toml` typically. */
+  configPath: string;
+  name: string;
+  command: string;
+  args: string[];
+  env?: Record<string, string>;
+  dryRun?: boolean;
+}
+
+export interface EmitCodexResult {
+  written: boolean;
+  previousVersion?: string;
+  /** Final TOML content (or what would be written when dryRun). */
+  configContent: string;
+}
+
+// ============================================================================
+// Claude plugin emitter
+// ============================================================================
+
+/**
+ * Validate a plugin name before it touches the filesystem or TOML blocks.
+ * Rejects anything that could traverse out of the destination directory,
+ * inject newlines into the codex block markers (`# frontmcp:codex-start:<name>`
+ * / `# frontmcp:codex-end:<name>` — finding from #411 review), or smuggle
+ * TOML-significant characters past the `tomlString` quoting.
+ *
+ * The allowed set is intentionally narrow — npm-style scoped names
+ * (`@scope/name`) are NOT allowed since the `@` and `/` characters would
+ * still produce surprising directory layouts. Callers that need scoped
+ * names should sanitise first.
+ */
+export function assertValidPluginName(name: string, where: string): void {
+  if (typeof name !== 'string' || name.length === 0) {
+    throw new Error(`Invalid plugin name passed to ${where}: must be a non-empty string`);
+  }
+  if (name.length > 64) {
+    throw new Error(`Invalid plugin name "${name}" passed to ${where}: must be 64 chars or fewer`);
+  }
+  if (name === '.' || name === '..') {
+    throw new Error(`Invalid plugin name "${name}" passed to ${where}: must not be "." or ".."`);
+  }
+  if (!/^[a-zA-Z0-9][a-zA-Z0-9._-]*$/.test(name)) {
+    throw new Error(
+      `Invalid plugin name "${name}" passed to ${where}: must match /^[a-zA-Z0-9][a-zA-Z0-9._-]*$/ (no slashes, newlines, or special chars)`,
+    );
+  }
+}
+
+/**
+ * Returns true when `rel` resolves to a path strictly inside `pluginDir`.
+ * Defends `emitClaudePlugin` and `removeClaudePlugin` against a tampered
+ * prior `plugin.json` whose `_meta.frontmcp.managedFiles` entries try to
+ * escape the plugin root with `../` traversals or absolute paths.
+ */
+export function isPluginContainedPath(pluginDir: string, rel: string): boolean {
+  if (typeof rel !== 'string' || rel.length === 0) return false;
+  if (path.isAbsolute(rel)) return false;
+  const resolved = path.resolve(pluginDir, rel);
+  const relative = path.relative(pluginDir, resolved);
+  if (relative === '') return false; // never delete the plugin dir itself via a managedFile entry
+  return !relative.startsWith('..') && !path.isAbsolute(relative);
+}
+
+const FRAMEWORK_MANAGED_FIELDS = [
+  'name',
+  'version',
+  'description',
+  'mcpServers',
+  'skills',
+  'commands',
+  '_meta.frontmcp',
+];
+
+export async function emitClaudePlugin(opts: EmitClaudePluginOptions): Promise<EmitClaudePluginResult> {
+  assertValidPluginName(opts.name, 'emitClaudePlugin');
+  const pluginDir = path.join(opts.destRoot, opts.name);
+  const claudePluginDir = path.join(pluginDir, '.claude-plugin');
+  const manifestPath = path.join(claudePluginDir, 'plugin.json');
+
+  // Read prior manifest (idempotency baseline) — file may not exist on first install.
+  const previousManifest = await readPluginManifest(manifestPath);
+  const previouslyManaged = previousManifest?._meta?.frontmcp?.managedFiles ?? [];
+
+  // Build the new file plan in deterministic order.
+  const plannedFiles: Array<{ absPath: string; relPath: string; action: () => Promise<void> }> = [];
+
+  // Skills subtree
+  for (const skill of [...opts.skills].sort((a, b) => a.name.localeCompare(b.name))) {
+    const skillDir = path.join(pluginDir, 'skills', skill.name);
+    const skillMd = path.join(skillDir, 'SKILL.md');
+    plannedFiles.push({
+      absPath: skillMd,
+      relPath: path.relative(pluginDir, skillMd),
+      action: async () => {
+        await ensureDir(skillDir);
+        if (skill.instructionFile && (await fileExists(skill.instructionFile))) {
+          const body = await readFile(skill.instructionFile);
+          await writeFile(skillMd, body);
+        } else {
+          // No file on disk — emit a minimal SKILL.md from frontmatter so the
+          // plugin folder is still loadable.
+          await writeFile(skillMd, renderSkillStub(skill));
+        }
+      },
+    });
+    for (const kind of ['references', 'examples', 'scripts', 'assets'] as const) {
+      const src = skill.resourceDirs?.[kind];
+      if (!src) continue;
+      const dest = path.join(skillDir, kind);
+      plannedFiles.push({
+        absPath: dest,
+        relPath: path.relative(pluginDir, dest),
+        action: async () => {
+          await ensureDir(skillDir);
+          if (await fileExists(src)) {
+            await cp(src, dest, { recursive: true });
+          }
+        },
+      });
+    }
+  }
+
+  // Commands subtree
+  for (const cmd of [...opts.commands].sort((a, b) => a.name.localeCompare(b.name))) {
+    const cmdPath = path.join(pluginDir, 'commands', `${cmd.name}.md`);
+    plannedFiles.push({
+      absPath: cmdPath,
+      relPath: path.relative(pluginDir, cmdPath),
+      action: async () => {
+        await ensureDir(path.dirname(cmdPath));
+        await writeFile(cmdPath, renderCommandFile(cmd, opts.name));
+      },
+    });
+  }
+
+  // Build the manifest. Manifest is itself a managed file and appears last in
+  // managedFiles so removal-on-uninstall happens after subtree cleanup.
+  const newManagedFiles = plannedFiles.map((f) => f.relPath).sort();
+  const manifest: ClaudePluginManifest = {
+    name: opts.name,
+    version: opts.version,
+    description: opts.description,
+    mcpServers: {
+      [opts.name]: makeMcpServerEntry(opts),
+    },
+    skills: opts.skills.map((s) => s.name).sort(),
+    ...(opts.commands.length > 0 ? { commands: opts.commands.map((c) => c.name).sort() } : {}),
+    _meta: {
+      frontmcp: {
+        installedBy: `frontmcp@${opts.cliVersion}`,
+        installedAt: new Date().toISOString(),
+        bin: opts.name,
+        binVersion: opts.version,
+        managedFields: [...FRAMEWORK_MANAGED_FIELDS].sort(),
+        managedFiles: newManagedFiles,
+      },
+    },
+  };
+
+  // Merge any user-owned top-level keys back in from the previous manifest.
+  const mergedManifest = mergeUserManifestFields(manifest, previousManifest);
+
+  // Compute the file delta. We don't `rm -rf` the plugin dir; we only:
+  //   1. Remove previously-managed files that are no longer in newManagedFiles.
+  //   2. Write/overwrite the new managed files.
+  //   3. Write the manifest.
+  const previousSet = new Set(previouslyManaged);
+  const newSet = new Set(newManagedFiles);
+  const removed: string[] = [];
+  const written: string[] = [];
+
+  if (!opts.dryRun) {
+    await ensureDir(claudePluginDir);
+    // 1. Drop stale managed files. Guard against a tampered prior manifest
+    // that may have injected escape-paths into `managedFiles`.
+    for (const rel of previousSet) {
+      if (newSet.has(rel)) continue;
+      if (!isPluginContainedPath(pluginDir, rel)) continue;
+      const abs = path.join(pluginDir, rel);
+      if (await fileExists(abs)) {
+        await rm(abs, { recursive: true, force: true });
+        removed.push(abs);
+      }
+    }
+    // 2. Write new/refreshed managed files.
+    for (const f of plannedFiles) {
+      await f.action();
+      written.push(f.absPath);
+    }
+    // 3. Manifest.
+    await writeFile(manifestPath, serializeManifest(mergedManifest));
+    written.push(manifestPath);
+  } else {
+    written.push(...plannedFiles.map((f) => f.absPath), manifestPath);
+  }
+
+  const preserved = previousManifest
+    ? Object.keys(previousManifest)
+        .filter((k) => !FRAMEWORK_MANAGED_FIELDS.includes(k) && k !== '_meta')
+        .map((k) => `<plugin.json>.${k}`)
+    : [];
+
+  return {
+    pluginDir,
+    manifest: mergedManifest,
+    filesWritten: written,
+    filesPreserved: preserved,
+    filesRemoved: removed,
+  };
+}
+
+export async function removeClaudePlugin(args: {
+  destRoot: string;
+  name: string;
+}): Promise<{ removed: string[]; preserved: string[]; pluginDir: string }> {
+  assertValidPluginName(args.name, 'removeClaudePlugin');
+  const pluginDir = path.join(args.destRoot, args.name);
+  const manifestPath = path.join(pluginDir, '.claude-plugin', 'plugin.json');
+  const manifest = await readPluginManifest(manifestPath);
+  const removed: string[] = [];
+  const preserved: string[] = [];
+
+  if (!manifest) {
+    return { removed, preserved, pluginDir };
+  }
+
+  // A tampered `plugin.json` could have injected paths like `../../etc/foo`
+  // into `_meta.frontmcp.managedFiles` to coerce `rm` outside `pluginDir`
+  // on uninstall. Guard each entry against escaping the plugin root.
+  const managed = manifest._meta?.frontmcp?.managedFiles ?? [];
+  for (const rel of managed) {
+    if (!isPluginContainedPath(pluginDir, rel)) continue;
+    const abs = path.join(pluginDir, rel);
+    if (await fileExists(abs)) {
+      await rm(abs, { recursive: true, force: true });
+      removed.push(abs);
+    }
+  }
+  if (await fileExists(manifestPath)) {
+    await rm(manifestPath, { force: true });
+    removed.push(manifestPath);
+  }
+
+  // Bottom-up empty-dir cleanup. Stops at first non-empty dir, preserving
+  // user-added files.
+  await cleanupEmptyDirs(pluginDir, preserved);
+
+  return { removed, preserved, pluginDir };
+}
+
+export async function readInstalledPluginVersion(pluginDir: string): Promise<string | undefined> {
+  const manifestPath = path.join(pluginDir, '.claude-plugin', 'plugin.json');
+  const manifest = await readPluginManifest(manifestPath);
+  return manifest?._meta?.frontmcp?.binVersion;
+}
+
+// ============================================================================
+// Codex emitter
+// ============================================================================
+
+const CODEX_BLOCK_START = '# frontmcp:codex-start';
+const CODEX_BLOCK_END = '# frontmcp:codex-end';
+
+export async function emitCodexEntry(opts: EmitCodexOptions): Promise<EmitCodexResult> {
+  assertValidPluginName(opts.name, 'emitCodexEntry');
+  const existing = (await fileExists(opts.configPath)) ? await readFile(opts.configPath) : '';
+  const previousVersion = extractCodexEntryComment(existing, opts.name);
+  const newBlock = renderCodexBlock(opts);
+  const merged = replaceCodexBlock(existing, opts.name, newBlock);
+
+  if (!opts.dryRun) {
+    await ensureDir(path.dirname(opts.configPath));
+    await writeFile(opts.configPath, merged);
+  }
+
+  return {
+    written: !opts.dryRun,
+    previousVersion,
+    configContent: merged,
+  };
+}
+
+export async function removeCodexEntry(args: {
+  configPath: string;
+  name: string;
+}): Promise<{ removed: boolean; configContent: string }> {
+  assertValidPluginName(args.name, 'removeCodexEntry');
+  if (!(await fileExists(args.configPath))) {
+    return { removed: false, configContent: '' };
+  }
+  const existing = await readFile(args.configPath);
+  const stripped = stripCodexBlock(existing, args.name);
+  const removed = stripped !== existing;
+  if (removed) {
+    await writeFile(args.configPath, stripped);
+  }
+  return { removed, configContent: stripped };
+}
+
+// ============================================================================
+// Internals
+// ============================================================================
+
+function makeMcpServerEntry(opts: EmitClaudePluginOptions): McpServerEntry {
+  const entry: McpServerEntry = {
+    command: opts.mcpCommand,
+    args: opts.mcpArgs,
+    transport: 'stdio',
+  };
+  if (opts.envHints.length > 0) {
+    const env: Record<string, string> = {};
+    for (const name of opts.envHints.slice().sort()) {
+      env[name] = `\${${name}}`;
+    }
+    entry.env = env;
+  }
+  return entry;
+}
+
+async function readPluginManifest(manifestPath: string): Promise<ClaudePluginManifest | undefined> {
+  if (!(await fileExists(manifestPath))) return undefined;
+  try {
+    const raw = await readFile(manifestPath);
+    return JSON.parse(raw) as ClaudePluginManifest;
+  } catch {
+    return undefined;
+  }
+}
+
+function mergeUserManifestFields(
+  next: ClaudePluginManifest,
+  previous: ClaudePluginManifest | undefined,
+): ClaudePluginManifest {
+  if (!previous) return next;
+  const out = { ...next } as Record<string, unknown>;
+  // Preserve user-added entries in mcpServers other than the framework-owned one.
+  if (previous.mcpServers && typeof previous.mcpServers === 'object') {
+    const mergedMcp: Record<string, McpServerEntry> = { ...next.mcpServers };
+    for (const [k, v] of Object.entries(previous.mcpServers)) {
+      if (k !== next.name) mergedMcp[k] = v;
+    }
+    out.mcpServers = sortObjectKeys(mergedMcp);
+  }
+  // Preserve any unknown top-level key the user added.
+  for (const [k, v] of Object.entries(previous)) {
+    if (!FRAMEWORK_MANAGED_FIELDS.includes(k) && k !== '_meta' && !(k in out)) {
+      out[k] = v;
+    }
+  }
+  return out as unknown as ClaudePluginManifest;
+}
+
+function serializeManifest(manifest: ClaudePluginManifest): string {
+  return JSON.stringify(sortObjectKeys(manifest), null, 2) + '\n';
+}
+
+function sortObjectKeys<T>(value: T): T {
+  if (Array.isArray(value)) {
+    return value.map((v) => sortObjectKeys(v)) as unknown as T;
+  }
+  if (value && typeof value === 'object') {
+    const sorted: Record<string, unknown> = {};
+    for (const key of Object.keys(value as object).sort()) {
+      sorted[key] = sortObjectKeys((value as Record<string, unknown>)[key]);
+    }
+    return sorted as unknown as T;
+  }
+  return value;
+}
+
+function renderSkillStub(skill: PluginEmitterSkillInput): string {
+  return `---\nname: ${skill.name}\ndescription: ${JSON.stringify(skill.description)}\n---\n\n${skill.description}\n`;
+}
+
+function renderCommandFile(cmd: PluginEmitterCommandInput, binName: string): string {
+  const args = cmd.arguments ?? [];
+  const argHint = args
+    .map((a) => (a.required === false ? `[${a.name}]` : `<${a.name}>`))
+    .join(' ');
+  const fm = ['---'];
+  if (cmd.description) fm.push(`description: ${JSON.stringify(cmd.description)}`);
+  if (argHint) fm.push(`argument-hint: ${JSON.stringify(argHint)}`);
+  fm.push('---', '');
+  const body = [
+    `Invokes the MCP prompt \`${cmd.name}\` from the \`${binName}\` server.`,
+    '',
+    `See \`${binName} prompt get ${cmd.name}\` for the latest argument list.`,
+    '',
+  ];
+  return fm.join('\n') + '\n' + body.join('\n');
+}
+
+/**
+ * Bottom-up empty-directory cleanup after `removeClaudePlugin`. We only
+ * remove a directory when:
+ *   1. it's a framework-managed directory we know we created
+ *      (`commands/`, `skills/`, `skills/<name>/`, `.claude-plugin/`,
+ *      and the plugin root itself), AND
+ *   2. it is empty (`readdir` returns []).
+ *
+ * Any user-added file under those dirs blocks the cleanup at that level
+ * and bubbles all the way up — so a single user file anywhere in the
+ * plugin tree leaves the entire tree (and the plugin dir itself) intact.
+ * We never traverse INTO user-added subdirs.
+ */
+async function cleanupEmptyDirs(root: string, _preserved: string[]): Promise<void> {
+  if (!(await fileExists(root))) return;
+  const { readdir, rm: rmFn } = await import('@frontmcp/utils');
+
+  // Pass 1: each per-skill folder under skills/ (one level deep).
+  const skillsDir = path.join(root, 'skills');
+  if (await fileExists(skillsDir)) {
+    for (const entry of await safeReaddir(readdir, skillsDir)) {
+      const sub = path.join(skillsDir, entry);
+      await removeIfEmpty(sub, rmFn, readdir);
+    }
+  }
+
+  // Pass 2: framework-managed dirs directly under the plugin root.
+  for (const sub of ['commands', 'skills', '.claude-plugin']) {
+    await removeIfEmpty(path.join(root, sub), rmFn, readdir);
+  }
+
+  // Pass 3: the plugin root itself (only if user added nothing).
+  await removeIfEmpty(root, rmFn, readdir);
+}
+
+async function removeIfEmpty(
+  dir: string,
+  rmFn: (p: string, opts?: { recursive?: boolean; force?: boolean }) => Promise<void>,
+  readdirFn: (p: string) => Promise<string[]>,
+): Promise<void> {
+  if (!(await fileExists(dir))) return;
+  const entries = await safeReaddir(readdirFn, dir);
+  if (entries.length === 0) {
+    await rmFn(dir, { recursive: true, force: true });
+  }
+}
+
+async function safeReaddir(
+  readdirFn: (p: string) => Promise<string[]>,
+  dir: string,
+): Promise<string[]> {
+  try {
+    return await readdirFn(dir);
+  } catch {
+    return [];
+  }
+}
+
+// ----- Codex TOML -----
+
+function renderCodexBlock(opts: EmitCodexOptions): string {
+  const lines: string[] = [];
+  lines.push(`${CODEX_BLOCK_START}:${opts.name}`);
+  lines.push(`[[mcp_servers]]`);
+  lines.push(`name = ${tomlString(opts.name)}`);
+  lines.push(`command = ${tomlString(opts.command)}`);
+  lines.push(`args = [${opts.args.map(tomlString).join(', ')}]`);
+  if (opts.env && Object.keys(opts.env).length > 0) {
+    const entries = Object.entries(opts.env)
+      .sort(([a], [b]) => a.localeCompare(b))
+      .map(([k, v]) => `${tomlBareKey(k)} = ${tomlString(v)}`);
+    lines.push(`env = { ${entries.join(', ')} }`);
+  }
+  lines.push(`${CODEX_BLOCK_END}:${opts.name}`);
+  return lines.join('\n');
+}
+
+function replaceCodexBlock(existing: string, name: string, newBlock: string): string {
+  const start = `${CODEX_BLOCK_START}:${name}`;
+  const end = `${CODEX_BLOCK_END}:${name}`;
+  const startIdx = existing.indexOf(start);
+  if (startIdx === -1) {
+    // Normalize the existing content to end in exactly one newline before
+    // appending the new block, so we don't double-up on first insert.
+    const normalized = existing.length === 0 ? '' : existing.replace(/\n*$/, '\n');
+    const sep = normalized.length === 0 ? '' : '\n';
+    return `${normalized}${sep}${newBlock}\n`;
+  }
+  const endIdx = existing.indexOf(end, startIdx);
+  if (endIdx === -1) {
+    // Corrupt block — treat as missing and append fresh.
+    return `${existing.replace(/\n*$/, '\n')}\n${newBlock}\n`;
+  }
+  const before = existing.slice(0, startIdx);
+  const after = existing.slice(endIdx + end.length).replace(/^\n/, '');
+  return `${before}${newBlock}\n${after}`;
+}
+
+function stripCodexBlock(existing: string, name: string): string {
+  const start = `${CODEX_BLOCK_START}:${name}`;
+  const end = `${CODEX_BLOCK_END}:${name}`;
+  const startIdx = existing.indexOf(start);
+  if (startIdx === -1) return existing;
+  const endIdx = existing.indexOf(end, startIdx);
+  if (endIdx === -1) return existing;
+  const before = existing.slice(0, startIdx).replace(/\n+$/, '\n');
+  const after = existing.slice(endIdx + end.length).replace(/^\n+/, '\n');
+  return (before + after).replace(/\n{3,}/g, '\n\n');
+}
+
+function extractCodexEntryComment(content: string, name: string): string | undefined {
+  // Optional: look for an `# version:` comment inside the block; for now we
+  // just return undefined since the block itself doesn't carry a version.
+  void content;
+  void name;
+  return undefined;
+}
+
+function tomlString(value: string): string {
+  // Basic strings: escape backslash + double-quote, encode common control chars.
+  const escaped = value
+    .replace(/\\/g, '\\\\')
+    .replace(/"/g, '\\"')
+    .replace(/\n/g, '\\n')
+    .replace(/\r/g, '\\r')
+    .replace(/\t/g, '\\t');
+  return `"${escaped}"`;
+}
+
+function tomlBareKey(key: string): string {
+  return /^[A-Za-z0-9_-]+$/.test(key) ? key : tomlString(key);
+}

--- a/libs/cli/src/commands/build/exec/index.ts
+++ b/libs/cli/src/commands/build/exec/index.ts
@@ -208,6 +208,14 @@ export async function buildExec(
       console.log(`${c('green', '[build:exec]')} copied ${copiedCount} skill content file(s) to _skills/`);
     }
 
+    // bin-meta.json (issue #411) — sidecar carrying everything the per-bin
+    // `<bin> install -p claude|codex` needs without re-running schema
+    // extraction at install time. The bin-runtime install command reads
+    // this file + the staged _skills/ directory and hands the result to the
+    // shared plugin-emitter.
+    const { writeBinMeta } = await import('./bin-meta.js');
+    await writeBinMeta(outDir, config, schema);
+
     // Log tool name conflicts
     const cliConfig = config.cli || { enabled: true };
     const excludeTools = cliConfig.excludeTools || [];
@@ -252,6 +260,15 @@ export async function buildExec(
       path.join(tempDir, 'daemon-client.js'),
       generateDaemonClientSource(),
     );
+
+    // Issue #411 — copy the compiled plugin-emitter so the per-bin
+    // `<bin> install -p claude|codex` can `require('./plugin-emitter')`.
+    // esbuild then bundles it (and its `@frontmcp/utils` deps) into the
+    // final CLI bundle. Tolerate absence in test/source-only contexts.
+    const pluginEmitterSrc = path.join(__dirname, 'cli-runtime', 'plugin-emitter.js');
+    if (fs.existsSync(pluginEmitterSrc)) {
+      fs.copyFileSync(pluginEmitterSrc, path.join(tempDir, 'plugin-emitter.js'));
+    }
 
     // Generate CLI entry
     const cliEntrySource = generateCliEntry({

--- a/libs/cli/src/commands/install/__tests__/install-claude-plugin.spec.ts
+++ b/libs/cli/src/commands/install/__tests__/install-claude-plugin.spec.ts
@@ -1,0 +1,57 @@
+/**
+ * Unit tests for `frontmcp plugin install` runner internals (issue #411).
+ *
+ * Covers:
+ *   - `--scope` validation: only 'project' | 'user' | undefined are accepted;
+ *     anything else fails fast instead of silently writing files to the wrong
+ *     root.
+ *   - Best-effort skill/prompt collection: a missing/broken project entry
+ *     surfaces a stderr warning and yields an empty array fallback so the
+ *     install never crashes the user's session.
+ */
+
+import { runInstallCurrentProject } from '../install-claude-plugin';
+
+describe('runInstallCurrentProject — option normalization (issue #411)', () => {
+  let exitSpy: jest.SpyInstance<never, [code?: number | undefined]>;
+  let stderrSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    // process.exit is invoked when no provider is selected; stub so the test
+    // can assert without bringing the runner down. Throw a sentinel so the
+    // runner stops at the first exit() like the real flow.
+    exitSpy = jest.spyOn(process, 'exit').mockImplementation((() => {
+      throw new Error('__exit__');
+    }) as never);
+    stderrSpy = jest.spyOn(process.stderr, 'write').mockImplementation(() => true);
+  });
+
+  afterEach(() => {
+    exitSpy.mockRestore();
+    stderrSpy.mockRestore();
+  });
+
+  it('rejects a bogus --scope value before any side-effects run', async () => {
+    await expect(runInstallCurrentProject({ scope: 'usr', claudePlugin: true })).rejects.toThrow(
+      /Invalid --scope value: usr\. Expected "project" or "user"\./,
+    );
+    expect(exitSpy).not.toHaveBeenCalled();
+  });
+
+  it('accepts --scope user without complaint', async () => {
+    // No provider selected → runner exits 1; that means scope validation
+    // already passed.
+    await expect(runInstallCurrentProject({ scope: 'user' })).rejects.toThrow(/__exit__/);
+    expect(exitSpy).toHaveBeenCalledWith(1);
+  });
+
+  it('accepts --scope project without complaint', async () => {
+    await expect(runInstallCurrentProject({ scope: 'project' })).rejects.toThrow(/__exit__/);
+    expect(exitSpy).toHaveBeenCalledWith(1);
+  });
+
+  it('accepts an absent --scope (default project)', async () => {
+    await expect(runInstallCurrentProject({})).rejects.toThrow(/__exit__/);
+    expect(exitSpy).toHaveBeenCalledWith(1);
+  });
+});

--- a/libs/cli/src/commands/install/__tests__/install-claude-plugin.spec.ts
+++ b/libs/cli/src/commands/install/__tests__/install-claude-plugin.spec.ts
@@ -32,6 +32,10 @@ describe('runInstallCurrentProject — option normalization (issue #411)', () =>
   });
 
   it('rejects a bogus --scope value before any side-effects run', async () => {
+    // Assert both the error class AND the message — message-only checks pass
+    // even when the runner rejects with a plain string or a non-Error object,
+    // which loses stack traces in production logs.
+    await expect(runInstallCurrentProject({ scope: 'usr', claudePlugin: true })).rejects.toBeInstanceOf(Error);
     await expect(runInstallCurrentProject({ scope: 'usr', claudePlugin: true })).rejects.toThrow(
       /Invalid --scope value: usr\. Expected "project" or "user"\./,
     );

--- a/libs/cli/src/commands/install/__tests__/register.spec.ts
+++ b/libs/cli/src/commands/install/__tests__/register.spec.ts
@@ -1,0 +1,60 @@
+import { Command } from 'commander';
+
+import { registerInstallCommands } from '../register';
+
+/**
+ * Surface-lock for issue #411 — pins the exact set of `frontmcp plugin`
+ * subcommands and the documented flag set. Any addition or rename here
+ * forces a doc + catalog update.
+ */
+function getSubcommand(name: string): Command {
+  const program = new Command();
+  registerInstallCommands(program);
+  const plugin = program.commands.find((c) => c.name() === 'plugin');
+  expect(plugin).toBeDefined();
+  const sub = plugin?.commands.find((c) => c.name() === name);
+  expect(sub).toBeDefined();
+  return sub as Command;
+}
+
+describe('registerInstallCommands — `frontmcp plugin` surface lock (issue #411)', () => {
+  it('registers exactly these subcommands under `plugin`', () => {
+    const program = new Command();
+    registerInstallCommands(program);
+    const plugin = program.commands.find((c) => c.name() === 'plugin');
+    expect(plugin).toBeDefined();
+    const subs = (plugin?.commands ?? []).map((c) => c.name()).sort();
+    expect(subs).toEqual(['install', 'status', 'uninstall']);
+  });
+
+  it('install exposes all documented flags', () => {
+    const install = getSubcommand('install');
+    const longs = install.options.map((o) => o.long).filter(Boolean) as string[];
+    expect(longs).toEqual(
+      expect.arrayContaining([
+        '--claude',
+        '--codex',
+        '--scope',
+        '--no-skills',
+        '--no-commands',
+        '--only-mcp',
+        '--command',
+        '--env',
+        '--dir',
+        '--dry-run',
+      ]),
+    );
+  });
+
+  it('uninstall exposes --claude / --codex / --scope / --dir', () => {
+    const uninstall = getSubcommand('uninstall');
+    const longs = uninstall.options.map((o) => o.long).filter(Boolean) as string[];
+    expect(longs).toEqual(expect.arrayContaining(['--claude', '--codex', '--scope', '--dir']));
+  });
+
+  it('status exposes --claude / --codex / --scope / --dir', () => {
+    const status = getSubcommand('status');
+    const longs = status.options.map((o) => o.long).filter(Boolean) as string[];
+    expect(longs).toEqual(expect.arrayContaining(['--claude', '--codex', '--scope', '--dir']));
+  });
+});

--- a/libs/cli/src/commands/install/__tests__/register.spec.ts
+++ b/libs/cli/src/commands/install/__tests__/register.spec.ts
@@ -46,15 +46,28 @@ describe('registerInstallCommands — `frontmcp plugin` surface lock (issue #411
     );
   });
 
-  it('uninstall exposes --claude / --codex / --scope / --dir', () => {
-    const uninstall = getSubcommand('uninstall');
-    const longs = uninstall.options.map((o) => o.long).filter(Boolean) as string[];
-    expect(longs).toEqual(expect.arrayContaining(['--claude', '--codex', '--scope', '--dir']));
-  });
+  // Uniform-flag contract (issue #411 / cli-reference.mdx): install, uninstall,
+  // and status all accept the same shared plugin-flag surface so docs + scripts
+  // can rely on a single invocation contract. `uninstall` and `status` ignore
+  // the `--dry-run` / `--only-mcp` / `--command` / `--env` / `--no-*` flags,
+  // but accepting them keeps `Unknown option` from being thrown when callers
+  // script the three subcommands together.
+  const SHARED_PLUGIN_FLAGS = [
+    '--claude',
+    '--codex',
+    '--scope',
+    '--no-skills',
+    '--no-commands',
+    '--only-mcp',
+    '--command',
+    '--env',
+    '--dir',
+    '--dry-run',
+  ];
 
-  it('status exposes --claude / --codex / --scope / --dir', () => {
-    const status = getSubcommand('status');
-    const longs = status.options.map((o) => o.long).filter(Boolean) as string[];
-    expect(longs).toEqual(expect.arrayContaining(['--claude', '--codex', '--scope', '--dir']));
+  it.each(['install', 'uninstall', 'status'])('%s exposes the full shared-plugin flag set', (name) => {
+    const sub = getSubcommand(name);
+    const longs = sub.options.map((o) => o.long).filter(Boolean) as string[];
+    expect(longs).toEqual(expect.arrayContaining(SHARED_PLUGIN_FLAGS));
   });
 });

--- a/libs/cli/src/commands/install/install-claude-plugin.ts
+++ b/libs/cli/src/commands/install/install-claude-plugin.ts
@@ -158,6 +158,25 @@ async function runClaudeInstall(args: {
   if (result.filesRemoved.length > 0) {
     process.stdout.write(`  Cleaned up ${result.filesRemoved.length} stale file(s) from previous install.\n`);
   }
+  // Surface the dev-tool limitation explicitly: today this command only
+  // emits the MCP server entry; per-project @Skill / @Prompt enumeration
+  // is wired through the per-bin path (`<bin> install -p claude`). Don't
+  // let users assume zero counts mean "your project has no skills".
+  if (
+    args.skills.length === 0 &&
+    args.commands.length === 0 &&
+    args.opts.skills !== false &&
+    args.opts.commands !== false &&
+    !args.opts.onlyMcp
+  ) {
+    process.stdout.write(
+      c(
+        'yellow',
+        '  Note: the dev-tool path does not yet enumerate @Skill or @Prompt from project source.\n' +
+          '  Build with `frontmcp build --target cli` and run `<bin> install -p claude` for full plugin coverage.\n',
+      ),
+    );
+  }
   process.stdout.write(c('dim', '  Restart Claude Code (or run `/plugins reload`) to pick up the plugin.\n'));
 }
 

--- a/libs/cli/src/commands/install/install-claude-plugin.ts
+++ b/libs/cli/src/commands/install/install-claude-plugin.ts
@@ -163,6 +163,13 @@ async function getProjectExtraction(cwd: string): Promise<{
         await rm(tempDir, { recursive: true, force: true }).catch(() => undefined);
       }
     } catch (err) {
+      // Drop the cache entry so the NEXT install from this cwd retries
+      // extraction — without this, a transient esbuild/SDK-boot failure
+      // would freeze the project at `{ skills: [], commands: [] }` for
+      // the rest of the process even after the user fixes the entry.
+      // The current caller still gets the empty fallback so the install
+      // itself doesn't crash.
+      cachedExtractionByCwd.delete(cwd);
       process.stderr.write(
         c(
           'yellow',
@@ -174,6 +181,9 @@ async function getProjectExtraction(cwd: string): Promise<{
       return { skills: [], commands: [] };
     }
   })();
+  // Set BEFORE awaiting so concurrent callers within the same install
+  // (collectSkillsFromProject + collectPromptsFromProject) share the
+  // single bundle+extract pass. The catch above un-sets on failure.
   cachedExtractionByCwd.set(cwd, extractionPromise);
   return extractionPromise;
 }

--- a/libs/cli/src/commands/install/install-claude-plugin.ts
+++ b/libs/cli/src/commands/install/install-claude-plugin.ts
@@ -106,14 +106,24 @@ async function loadProjectMeta(): Promise<ProjectMeta | undefined> {
  * spawning two extractor passes would double the SDK boot cost on every
  * dev-tool install.
  */
-let cachedExtraction: Promise<{ skills: PluginEmitterSkillInput[]; commands: PluginEmitterCommandInput[] }> | undefined;
+// Keyed by absolute `cwd` so two installs invoked back-to-back from
+// different project roots (e.g. an integration test, or a script that
+// `cd`s between projects) don't reuse the first project's skill/prompt
+// extraction. Each project gets its own cached promise — and within a
+// single project both `collectSkillsFromProject` and
+// `collectPromptsFromProject` share the one bundle+extract pass.
+const cachedExtractionByCwd = new Map<
+  string,
+  Promise<{ skills: PluginEmitterSkillInput[]; commands: PluginEmitterCommandInput[] }>
+>();
 
 async function getProjectExtraction(cwd: string): Promise<{
   skills: PluginEmitterSkillInput[];
   commands: PluginEmitterCommandInput[];
 }> {
-  if (cachedExtraction) return cachedExtraction;
-  cachedExtraction = (async () => {
+  const cached = cachedExtractionByCwd.get(cwd);
+  if (cached) return cached;
+  const extractionPromise = (async () => {
     try {
       const { resolveEntry } = await import('../../shared/fs.js');
       const { mkdtemp, rm } = await import('@frontmcp/utils');
@@ -164,7 +174,8 @@ async function getProjectExtraction(cwd: string): Promise<{
       return { skills: [], commands: [] };
     }
   })();
-  return cachedExtraction;
+  cachedExtractionByCwd.set(cwd, extractionPromise);
+  return extractionPromise;
 }
 
 async function collectSkillsFromProject(): Promise<PluginEmitterSkillInput[]> {

--- a/libs/cli/src/commands/install/install-claude-plugin.ts
+++ b/libs/cli/src/commands/install/install-claude-plugin.ts
@@ -1,0 +1,286 @@
+/**
+ * Implementation of `frontmcp install --claude-plugin [--codex]` (issue #411).
+ *
+ * Flow:
+ *   1. Load frontmcp.config + package.json to determine name/version/description.
+ *   2. Spin up a transient direct-mode SDK instance to enumerate skills and
+ *      prompts (the same surfaces a built bin would expose).
+ *   3. Delegate to the shared `plugin-emitter.ts` helper.
+ *
+ * Status / dry-run paths are short-circuited before the SDK is loaded.
+ */
+
+import * as os from 'os';
+import * as path from 'path';
+
+import { tryLoadFrontMcpConfig } from '../../config/frontmcp-config.loader';
+import { c } from '../../core/colors';
+import {
+  emitClaudePlugin,
+  emitCodexEntry,
+  readInstalledPluginVersion,
+  removeClaudePlugin,
+  removeCodexEntry,
+  type EmitClaudePluginOptions,
+  type PluginEmitterCommandInput,
+  type PluginEmitterSkillInput,
+} from '../build/exec/cli-runtime/plugin-emitter';
+
+interface InstallOptions {
+  claudePlugin?: boolean;
+  codex?: boolean;
+  scope?: 'project' | 'user';
+  skills?: boolean;
+  commands?: boolean;
+  onlyMcp?: boolean;
+  command?: string;
+  env?: string[];
+  dir?: string;
+  dryRun?: boolean;
+  status?: boolean;
+}
+
+export async function runInstallCurrentProject(rawOpts: Record<string, unknown>): Promise<void> {
+  const opts = normalizeOptions(rawOpts);
+
+  if (!opts.claudePlugin && !opts.codex) {
+    process.stderr.write(c('red', 'Specify --claude and/or --codex.\n'));
+    process.exit(1);
+  }
+
+  const projectMeta = await loadProjectMeta();
+  if (!projectMeta) {
+    process.stderr.write(
+      c('red', 'No frontmcp.config found in this directory. Run `frontmcp install` from a FrontMCP project root.\n'),
+    );
+    process.exit(1);
+  }
+
+  if (opts.status) {
+    await printStatus(projectMeta, opts);
+    return;
+  }
+
+  const cliVersion = await getCliVersion();
+  const skills = opts.skills === false || opts.onlyMcp ? [] : await collectSkillsFromProject();
+  const commands = opts.commands === false || opts.onlyMcp ? [] : await collectPromptsFromProject();
+
+  if (opts.claudePlugin) {
+    await runClaudeInstall({ projectMeta, opts, cliVersion, skills, commands });
+  }
+  if (opts.codex) {
+    await runCodexInstall({ projectMeta, opts, cliVersion });
+  }
+}
+
+interface ProjectMeta {
+  name: string;
+  version: string;
+  description: string;
+}
+
+async function loadProjectMeta(): Promise<ProjectMeta | undefined> {
+  const cwd = process.cwd();
+  const cfg = await tryLoadFrontMcpConfig(cwd).catch(() => undefined);
+  if (!cfg) return undefined;
+  const { readJSON, fileExists } = await import('@frontmcp/utils');
+  const pkgPath = path.join(cwd, 'package.json');
+  const pkg: { name?: string; version?: string; description?: string } = (await fileExists(pkgPath))
+    ? ((await readJSON(pkgPath)) as { name?: string; version?: string; description?: string })
+    : {};
+  return {
+    name: cfg.name ?? pkg.name ?? path.basename(cwd),
+    version: cfg.version ?? pkg.version ?? '0.0.0',
+    description: pkg.description ?? `${cfg.name ?? pkg.name ?? 'FrontMCP server'} (FrontMCP plugin)`,
+  };
+}
+
+async function collectSkillsFromProject(): Promise<PluginEmitterSkillInput[]> {
+  // Best-effort: try to import the project's entry and enumerate @Skill registrations.
+  // When this isn't feasible (no built artifact, transitive import errors), return [].
+  // The per-bin path will always have full coverage; the dev-tool path is a convenience.
+  return [];
+}
+
+async function collectPromptsFromProject(): Promise<PluginEmitterCommandInput[]> {
+  return [];
+}
+
+async function getCliVersion(): Promise<string> {
+  try {
+    const { readJSON } = await import('@frontmcp/utils');
+    const pkg = (await readJSON(path.join(__dirname, '..', '..', '..', 'package.json'))) as { version?: string };
+    return pkg.version ?? '0.0.0';
+  } catch {
+    return '0.0.0';
+  }
+}
+
+async function runClaudeInstall(args: {
+  projectMeta: ProjectMeta;
+  opts: InstallOptions;
+  cliVersion: string;
+  skills: PluginEmitterSkillInput[];
+  commands: PluginEmitterCommandInput[];
+}): Promise<void> {
+  const destRoot = resolveDestRoot(args.opts);
+  const emitOpts: EmitClaudePluginOptions = {
+    destRoot,
+    name: args.projectMeta.name,
+    version: args.projectMeta.version,
+    description: args.projectMeta.description,
+    mcpCommand: args.opts.command ?? args.projectMeta.name,
+    mcpArgs: ['serve', '--stdio'],
+    envHints: args.opts.env ?? [],
+    skills: args.skills,
+    commands: args.commands,
+    cliVersion: args.cliVersion,
+    dryRun: args.opts.dryRun,
+  };
+
+  const result = await emitClaudePlugin(emitOpts);
+
+  if (args.opts.dryRun) {
+    process.stdout.write(`${c('cyan', '[install:claude] dry-run plan')}\n`);
+    process.stdout.write(`  pluginDir: ${result.pluginDir}\n`);
+    process.stdout.write(`  manifest: ${JSON.stringify(result.manifest, null, 2)}\n`);
+    process.stdout.write(`  filesWritten (planned):\n`);
+    for (const f of result.filesWritten) process.stdout.write(`    + ${f}\n`);
+    return;
+  }
+
+  process.stdout.write(
+    c(
+      'green',
+      `✓ Wrote ${result.pluginDir}/ (${args.skills.length} skills, ${args.commands.length} commands, 1 MCP server)\n`,
+    ),
+  );
+  if (result.filesRemoved.length > 0) {
+    process.stdout.write(`  Cleaned up ${result.filesRemoved.length} stale file(s) from previous install.\n`);
+  }
+  process.stdout.write(c('dim', '  Restart Claude Code (or run `/plugins reload`) to pick up the plugin.\n'));
+}
+
+async function runCodexInstall(args: {
+  projectMeta: ProjectMeta;
+  opts: InstallOptions;
+  cliVersion: string;
+}): Promise<void> {
+  void args.cliVersion;
+  const configPath = path.join(os.homedir(), '.codex', 'config.toml');
+  const env: Record<string, string> = {};
+  for (const name of args.opts.env ?? []) env[name] = `\${${name}}`;
+  const result = await emitCodexEntry({
+    configPath,
+    name: args.projectMeta.name,
+    command: args.opts.command ?? args.projectMeta.name,
+    args: ['serve', '--stdio'],
+    env,
+    dryRun: args.opts.dryRun,
+  });
+
+  if (args.opts.dryRun) {
+    process.stdout.write(`${c('cyan', '[install:codex] dry-run plan')}\n`);
+    process.stdout.write(`  configPath: ${configPath}\n`);
+    process.stdout.write(`  configContent:\n${indentBlock(result.configContent, 4)}\n`);
+    return;
+  }
+
+  process.stdout.write(c('green', `✓ Updated ${configPath} with [[mcp_servers]] entry for ${args.projectMeta.name}\n`));
+}
+
+async function printStatus(projectMeta: ProjectMeta, opts: InstallOptions): Promise<void> {
+  process.stdout.write(`${c('bold', `${projectMeta.name} install --status`)}\n`);
+  if (opts.claudePlugin || !opts.codex) {
+    const destRoot = resolveDestRoot(opts);
+    const pluginDir = path.join(destRoot, projectMeta.name);
+    const installed = await readInstalledPluginVersion(pluginDir);
+    if (installed) {
+      const tag = installed === projectMeta.version ? 'installed' : 'outdated';
+      process.stdout.write(
+        `  claude:    ${tag} v${installed}${tag === 'outdated' ? ` (project at v${projectMeta.version})` : ''} at ${pluginDir}\n`,
+      );
+    } else {
+      process.stdout.write(`  claude:    not installed at ${pluginDir}\n`);
+    }
+  }
+  if (opts.codex) {
+    const configPath = path.join(os.homedir(), '.codex', 'config.toml');
+    const { fileExists, readFile } = await import('@frontmcp/utils');
+    if (!(await fileExists(configPath))) {
+      process.stdout.write(`  codex:     not installed (${configPath} does not exist)\n`);
+    } else {
+      const content = await readFile(configPath);
+      const present = content.includes(`# frontmcp:codex-start:${projectMeta.name}`);
+      process.stdout.write(
+        present
+          ? `  codex:     installed entry for ${projectMeta.name} in ${configPath}\n`
+          : `  codex:     not installed in ${configPath}\n`,
+      );
+    }
+  }
+}
+
+export async function runUninstallCurrentProject(rawOpts: Record<string, unknown>): Promise<void> {
+  const opts = normalizeOptions(rawOpts);
+
+  if (!opts.claudePlugin && !opts.codex) {
+    process.stderr.write(c('red', 'Specify --claude and/or --codex.\n'));
+    process.exit(1);
+  }
+
+  const projectMeta = await loadProjectMeta();
+  if (!projectMeta) {
+    process.stderr.write(c('red', 'No frontmcp.config found in this directory.\n'));
+    process.exit(1);
+  }
+
+  if (opts.claudePlugin) {
+    const destRoot = resolveDestRoot(opts);
+    const result = await removeClaudePlugin({ destRoot, name: projectMeta.name });
+    if (result.removed.length === 0) {
+      process.stdout.write(c('dim', `  claude: nothing to remove at ${result.pluginDir}\n`));
+    } else {
+      process.stdout.write(c('green', `✓ Removed ${result.removed.length} file(s) from ${result.pluginDir}\n`));
+    }
+  }
+  if (opts.codex) {
+    const configPath = path.join(os.homedir(), '.codex', 'config.toml');
+    const result = await removeCodexEntry({ configPath, name: projectMeta.name });
+    if (result.removed) {
+      process.stdout.write(c('green', `✓ Removed [[mcp_servers]] entry for ${projectMeta.name} from ${configPath}\n`));
+    } else {
+      process.stdout.write(c('dim', `  codex: no entry for ${projectMeta.name} in ${configPath}\n`));
+    }
+  }
+}
+
+function resolveDestRoot(opts: InstallOptions): string {
+  if (opts.dir) return path.resolve(opts.dir);
+  if (opts.scope === 'user') return path.join(os.homedir(), '.claude', 'plugins');
+  return path.join(process.cwd(), '.claude', 'plugins');
+}
+
+function normalizeOptions(raw: Record<string, unknown>): InstallOptions {
+  return {
+    claudePlugin: raw['claudePlugin'] === true,
+    codex: raw['codex'] === true,
+    scope: (raw['scope'] === 'user' ? 'user' : 'project') as InstallOptions['scope'],
+    skills: raw['skills'] !== false,
+    commands: raw['commands'] !== false,
+    onlyMcp: raw['onlyMcp'] === true,
+    command: typeof raw['command'] === 'string' ? (raw['command'] as string) : undefined,
+    env: Array.isArray(raw['env']) ? (raw['env'] as string[]) : [],
+    dir: typeof raw['dir'] === 'string' ? (raw['dir'] as string) : undefined,
+    dryRun: raw['dryRun'] === true,
+    status: raw['status'] === true,
+  };
+}
+
+function indentBlock(text: string, n: number): string {
+  const pad = ' '.repeat(n);
+  return text
+    .split('\n')
+    .map((line) => pad + line)
+    .join('\n');
+}

--- a/libs/cli/src/commands/install/install-claude-plugin.ts
+++ b/libs/cli/src/commands/install/install-claude-plugin.ts
@@ -95,15 +95,84 @@ async function loadProjectMeta(): Promise<ProjectMeta | undefined> {
   };
 }
 
+/**
+ * Best-effort: bundle the project's entry to a temp file, hand the bundle
+ * to the schema-extractor (the same routine the per-bin path uses at build
+ * time), and return the enumerated skills / prompts. Failures are logged
+ * and the empty-array fallback is returned so a partial setup never blocks
+ * an install — the per-bin path remains the authoritative source.
+ *
+ * Wrapped in a single bundle+extract pass so both collectors share work:
+ * spawning two extractor passes would double the SDK boot cost on every
+ * dev-tool install.
+ */
+let cachedExtraction: Promise<{ skills: PluginEmitterSkillInput[]; commands: PluginEmitterCommandInput[] }> | undefined;
+
+async function getProjectExtraction(cwd: string): Promise<{
+  skills: PluginEmitterSkillInput[];
+  commands: PluginEmitterCommandInput[];
+}> {
+  if (cachedExtraction) return cachedExtraction;
+  cachedExtraction = (async () => {
+    try {
+      const { resolveEntry } = await import('../../shared/fs.js');
+      const { mkdtemp, rm } = await import('@frontmcp/utils');
+      const entry = await resolveEntry(cwd);
+      const tempDir = await mkdtemp(path.join(os.tmpdir(), 'frontmcp-install-'));
+      const bundlePath = path.join(tempDir, 'entry.cjs');
+      try {
+        const esbuild = require('esbuild') as typeof import('esbuild');
+        await esbuild.build({
+          entryPoints: [entry],
+          bundle: true,
+          write: true,
+          outfile: bundlePath,
+          platform: 'node',
+          format: 'cjs',
+          target: 'es2022',
+          packages: 'external',
+          sourcemap: false,
+          logLevel: 'silent',
+          absWorkingDir: cwd,
+        });
+        const { extractSchemas } = await import('../build/exec/cli-runtime/schema-extractor.js');
+        const schema = await extractSchemas(bundlePath);
+        const skills: PluginEmitterSkillInput[] = (schema.skillAssets ?? []).map((entry) => ({
+          name: entry.skillName,
+          description: `${entry.skillName} skill`,
+          instructionFile: entry.instructionFile,
+          resourceDirs: entry.resourceDirs,
+        }));
+        const commands: PluginEmitterCommandInput[] = (schema.prompts ?? []).map((p) => ({
+          name: p.name,
+          description: p.description,
+          arguments: p.arguments,
+        }));
+        return { skills, commands };
+      } finally {
+        await rm(tempDir, { recursive: true, force: true }).catch(() => undefined);
+      }
+    } catch (err) {
+      process.stderr.write(
+        c(
+          'yellow',
+          `[install] could not enumerate skills/prompts from project (${(err as Error).message}); ` +
+            `emitting plugin without them. Use the per-bin install (\`<bin> install -p claude\`) ` +
+            `after \`frontmcp build:exec\` if you need the full set.\n`,
+        ),
+      );
+      return { skills: [], commands: [] };
+    }
+  })();
+  return cachedExtraction;
+}
+
 async function collectSkillsFromProject(): Promise<PluginEmitterSkillInput[]> {
-  // Best-effort: try to import the project's entry and enumerate @Skill registrations.
-  // When this isn't feasible (no built artifact, transitive import errors), return [].
-  // The per-bin path will always have full coverage; the dev-tool path is a convenience.
-  return [];
+  return (await getProjectExtraction(process.cwd())).skills;
 }
 
 async function collectPromptsFromProject(): Promise<PluginEmitterCommandInput[]> {
-  return [];
+  return (await getProjectExtraction(process.cwd())).commands;
 }
 
 async function getCliVersion(): Promise<string> {
@@ -281,10 +350,18 @@ function resolveDestRoot(opts: InstallOptions): string {
 }
 
 function normalizeOptions(raw: Record<string, unknown>): InstallOptions {
+  // Fail fast on bogus `--scope` values rather than silently coercing them to
+  // 'project' — `--scope usr` would otherwise write files to the wrong root
+  // (cwd's `.claude/plugins/` instead of `~/.claude/plugins/`) with no signal.
+  const rawScope = raw['scope'];
+  if (rawScope !== undefined && rawScope !== 'project' && rawScope !== 'user') {
+    throw new Error(`Invalid --scope value: ${String(rawScope)}. Expected "project" or "user".`);
+  }
+  const scope: InstallOptions['scope'] = rawScope === 'user' ? 'user' : 'project';
   return {
     claudePlugin: raw['claudePlugin'] === true,
     codex: raw['codex'] === true,
-    scope: (raw['scope'] === 'user' ? 'user' : 'project') as InstallOptions['scope'],
+    scope,
     skills: raw['skills'] !== false,
     commands: raw['commands'] !== false,
     onlyMcp: raw['onlyMcp'] === true,

--- a/libs/cli/src/commands/install/register.ts
+++ b/libs/cli/src/commands/install/register.ts
@@ -1,0 +1,73 @@
+/**
+ * Issue #411 — registers the dev-tool side `frontmcp plugin` command tree
+ * (uses `plugin` as the noun because `install` is already taken by the
+ * npm-package install command at `package/register.ts`).
+ *
+ * Subcommands:
+ *   frontmcp plugin install   — emit a Claude Code plugin folder + Codex entry
+ *   frontmcp plugin uninstall — remove what `install` wrote
+ *   frontmcp plugin status    — report install state per provider
+ *
+ * The per-bin equivalent (auto-included in every built CLI) extends the
+ * existing `<bin> install` with `-p claude|codex` and shares the same
+ * emitter under `cli-runtime/plugin-emitter.ts`.
+ */
+
+import { type Command } from 'commander';
+
+export function registerInstallCommands(program: Command): void {
+  const plugin = program
+    .command('plugin')
+    .description('Install the current FrontMCP server as a plugin for an AI tool');
+
+  plugin
+    .command('install')
+    .description('Emit a Claude Code plugin folder and/or Codex mcp_servers entry from the current project')
+    .option('--claude', 'Emit a Claude Code plugin into <scope>/.claude/plugins/<name>/')
+    .option('--codex', 'Emit a Codex mcp_servers entry into ~/.codex/config.toml')
+    .option('--scope <scope>', 'project | user (default: project)', 'project')
+    .option('--no-skills', 'Skip the skills/ subtree')
+    .option('--no-commands', 'Skip the commands/ subtree')
+    .option('--only-mcp', 'Skip the plugin folder; just register the MCP server')
+    .option('--command <cmd>', 'Override the MCP server invocation in the plugin manifest')
+    .option(
+      '--env <name>',
+      'Env-var placeholder to surface on the plugin (repeatable)',
+      (v: string, acc: string[]) => [...acc, v],
+      [] as string[],
+    )
+    .option('--dir <dir>', 'Override the plugin destination root')
+    .option('--dry-run', 'Print the planned tree and exit without writing')
+    .action(async (opts: Record<string, unknown>) => {
+      // Map flag name to the legacy internal option name expected by the runner.
+      const mappedOpts = { ...opts, claudePlugin: opts['claude'] === true };
+      const { runInstallCurrentProject } = await import('./install-claude-plugin.js');
+      await runInstallCurrentProject(mappedOpts);
+    });
+
+  plugin
+    .command('uninstall')
+    .description('Remove what `frontmcp plugin install` previously wrote')
+    .option('--claude', 'Remove the Claude Code plugin folder')
+    .option('--codex', 'Remove the Codex mcp_servers entry')
+    .option('--scope <scope>', 'project | user (default: project)', 'project')
+    .option('--dir <dir>', 'Override the plugin destination root')
+    .action(async (opts: Record<string, unknown>) => {
+      const mappedOpts = { ...opts, claudePlugin: opts['claude'] === true };
+      const { runUninstallCurrentProject } = await import('./install-claude-plugin.js');
+      await runUninstallCurrentProject(mappedOpts);
+    });
+
+  plugin
+    .command('status')
+    .description('Report install state per provider')
+    .option('--claude', 'Check Claude Code plugin state')
+    .option('--codex', 'Check Codex mcp_servers entry')
+    .option('--scope <scope>', 'project | user (default: project)', 'project')
+    .option('--dir <dir>', 'Override the plugin destination root')
+    .action(async (opts: Record<string, unknown>) => {
+      const mappedOpts = { ...opts, claudePlugin: opts['claude'] === true, status: true };
+      const { runInstallCurrentProject } = await import('./install-claude-plugin.js');
+      await runInstallCurrentProject(mappedOpts);
+    });
+}

--- a/libs/cli/src/commands/install/register.ts
+++ b/libs/cli/src/commands/install/register.ts
@@ -15,17 +15,17 @@
 
 import { type Command } from 'commander';
 
-export function registerInstallCommands(program: Command): void {
-  const plugin = program
-    .command('plugin')
-    .description('Install the current FrontMCP server as a plugin for an AI tool');
-
-  plugin
-    .command('install')
-    .description('Emit a Claude Code plugin folder and/or Codex mcp_servers entry from the current project')
-    .option('--claude', 'Emit a Claude Code plugin into <scope>/.claude/plugins/<name>/')
-    .option('--codex', 'Emit a Codex mcp_servers entry into ~/.codex/config.toml')
-    .option('--scope <scope>', 'project | user (default: project)', 'project')
+/**
+ * Attach the shared plugin-flag surface to a subcommand. `install`,
+ * `uninstall`, and `status` all accept the same flag set so docs +
+ * tests can rely on a uniform invocation contract (issue #411). The
+ * dry-run / skip-tree / mcp-override flags are no-ops on `status` but
+ * keeping the surface uniform avoids `Unknown option` errors when the
+ * caller scripts the three subcommands together.
+ */
+function withSharedPluginFlags(cmd: Command, scopeDescription: string): Command {
+  return cmd
+    .option('--scope <scope>', scopeDescription, 'project')
     .option('--no-skills', 'Skip the skills/ subtree')
     .option('--no-commands', 'Skip the commands/ subtree')
     .option('--only-mcp', 'Skip the plugin folder; just register the MCP server')
@@ -37,37 +37,51 @@ export function registerInstallCommands(program: Command): void {
       [] as string[],
     )
     .option('--dir <dir>', 'Override the plugin destination root')
-    .option('--dry-run', 'Print the planned tree and exit without writing')
-    .action(async (opts: Record<string, unknown>) => {
-      // Map flag name to the legacy internal option name expected by the runner.
-      const mappedOpts = { ...opts, claudePlugin: opts['claude'] === true };
-      const { runInstallCurrentProject } = await import('./install-claude-plugin.js');
-      await runInstallCurrentProject(mappedOpts);
-    });
+    .option('--dry-run', 'Print the planned tree and exit without writing');
+}
 
-  plugin
-    .command('uninstall')
-    .description('Remove what `frontmcp plugin install` previously wrote')
-    .option('--claude', 'Remove the Claude Code plugin folder')
-    .option('--codex', 'Remove the Codex mcp_servers entry')
-    .option('--scope <scope>', 'project | user (default: project)', 'project')
-    .option('--dir <dir>', 'Override the plugin destination root')
-    .action(async (opts: Record<string, unknown>) => {
-      const mappedOpts = { ...opts, claudePlugin: opts['claude'] === true };
-      const { runUninstallCurrentProject } = await import('./install-claude-plugin.js');
-      await runUninstallCurrentProject(mappedOpts);
-    });
+export function registerInstallCommands(program: Command): void {
+  const plugin = program
+    .command('plugin')
+    .description('Install the current FrontMCP server as a plugin for an AI tool');
 
-  plugin
-    .command('status')
-    .description('Report install state per provider')
-    .option('--claude', 'Check Claude Code plugin state')
-    .option('--codex', 'Check Codex mcp_servers entry')
-    .option('--scope <scope>', 'project | user (default: project)', 'project')
-    .option('--dir <dir>', 'Override the plugin destination root')
-    .action(async (opts: Record<string, unknown>) => {
-      const mappedOpts = { ...opts, claudePlugin: opts['claude'] === true, status: true };
-      const { runInstallCurrentProject } = await import('./install-claude-plugin.js');
-      await runInstallCurrentProject(mappedOpts);
-    });
+  withSharedPluginFlags(
+    plugin
+      .command('install')
+      .description('Emit a Claude Code plugin folder and/or Codex mcp_servers entry from the current project')
+      .option('--claude', 'Emit a Claude Code plugin into <scope>/.claude/plugins/<name>/')
+      .option('--codex', 'Emit a Codex mcp_servers entry into ~/.codex/config.toml'),
+    'project | user (default: project)',
+  ).action(async (opts: Record<string, unknown>) => {
+    // Map flag name to the legacy internal option name expected by the runner.
+    const mappedOpts = { ...opts, claudePlugin: opts['claude'] === true };
+    const { runInstallCurrentProject } = await import('./install-claude-plugin.js');
+    await runInstallCurrentProject(mappedOpts);
+  });
+
+  withSharedPluginFlags(
+    plugin
+      .command('uninstall')
+      .description('Remove what `frontmcp plugin install` previously wrote')
+      .option('--claude', 'Remove the Claude Code plugin folder')
+      .option('--codex', 'Remove the Codex mcp_servers entry'),
+    'project | user (default: project)',
+  ).action(async (opts: Record<string, unknown>) => {
+    const mappedOpts = { ...opts, claudePlugin: opts['claude'] === true };
+    const { runUninstallCurrentProject } = await import('./install-claude-plugin.js');
+    await runUninstallCurrentProject(mappedOpts);
+  });
+
+  withSharedPluginFlags(
+    plugin
+      .command('status')
+      .description('Report install state per provider')
+      .option('--claude', 'Check Claude Code plugin state')
+      .option('--codex', 'Check Codex mcp_servers entry'),
+    'project | user (default: project)',
+  ).action(async (opts: Record<string, unknown>) => {
+    const mappedOpts = { ...opts, claudePlugin: opts['claude'] === true, status: true };
+    const { runInstallCurrentProject } = await import('./install-claude-plugin.js');
+    await runInstallCurrentProject(mappedOpts);
+  });
 }

--- a/libs/cli/src/core/__tests__/program.spec.ts
+++ b/libs/cli/src/core/__tests__/program.spec.ts
@@ -26,6 +26,7 @@ describe('createProgram', () => {
       'list',
       'logs',
       'mcpb',
+      'plugin',
       'restart',
       'service',
       'skills',

--- a/libs/cli/src/core/program.ts
+++ b/libs/cli/src/core/program.ts
@@ -2,6 +2,7 @@ import { Command } from 'commander';
 
 import { registerBuildCommands } from '../commands/build/register';
 import { registerDevCommands } from '../commands/dev/register';
+import { registerInstallCommands } from '../commands/install/register';
 import { registerMcpbCommands } from '../commands/mcpb/register';
 import { registerPackageCommands } from '../commands/package/register';
 import { registerPmCommands } from '../commands/pm/register';
@@ -25,6 +26,7 @@ export function createProgram(): Command {
   registerPackageCommands(program);
   registerSkillsCommands(program);
   registerMcpbCommands(program);
+  registerInstallCommands(program);
   customizeHelp(program);
 
   return program;

--- a/libs/skills/catalog/frontmcp-deployment/references/mcp-client-integration.md
+++ b/libs/skills/catalog/frontmcp-deployment/references/mcp-client-integration.md
@@ -190,6 +190,60 @@ The `url` hostname is ignored for Unix sockets; only the path (`/mcp`) is used f
 | VS Code        | `.vscode/mcp.json`           | Project root                                    |
 | Windsurf       | `mcp_config.json`            | `~/.codeium/windsurf/`                          |
 
+## Claude Code plugin install (issue #411)
+
+For Claude Code specifically, you can ship the whole server — MCP entry +
+prompts (as slash commands) + `@Skill`s — as a single Claude Code plugin
+folder, registered in one command. This is the recommended path when you
+want users to enable/disable the server from `/plugins` rather than
+hand-edit `.mcp.json`.
+
+### From a project source (dev tool)
+
+```bash
+# At a FrontMCP project root — emits .claude/plugins/<name>/ in cwd
+frontmcp plugin install --claude
+
+# Inspect the plan without writing
+frontmcp plugin install --claude --dry-run
+
+# Also drop a Codex mcp_servers entry into ~/.codex/config.toml
+frontmcp plugin install --claude --codex
+
+# Report install state
+frontmcp plugin status --claude
+
+# Remove what install wrote (preserves user-added files)
+frontmcp plugin uninstall --claude
+```
+
+### From a built bin (end-user)
+
+Every CLI built with `frontmcp build --target cli` inherits the same
+behavior under its `install` verb (no new top-level verb):
+
+```bash
+my-bin install -p claude              # write .claude/plugins/my-bin/
+my-bin install -p claude --scope user # ~/.claude/plugins/my-bin/
+my-bin install -p claude -p codex     # both providers in one call
+my-bin install --status               # report state per provider
+my-bin uninstall -p claude            # remove only managed files
+```
+
+### What gets written
+
+```text
+.claude/plugins/<bin>/
+├── .claude-plugin/plugin.json   # name, version, mcpServers, skills, _meta.frontmcp.managedFiles
+├── commands/<prompt>.md         # one per @Prompt the server advertises
+└── skills/<name>/SKILL.md       # one per @Skill, with references/examples/scripts/assets subdirs
+```
+
+Re-runs are idempotent: any file not listed in `_meta.frontmcp.managedFiles`
+(including unknown top-level keys the user added to `plugin.json`, like
+`hooks` or extra `mcpServers`) is preserved. Use `--dry-run` to inspect
+the planned tree before writing.
+
 ## Common Patterns
 
 | Pattern     | Correct                       | Incorrect              | Why                                                 |


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `frontmcp plugin` commands: `install`, `uninstall`, and `status` with Claude Code and Codex support, shared flags (scope, dir, env, dry-run, component toggles), dry-run previews, status reporting, and user-facing install/uninstall messaging.

* **Documentation**
  * Added CLI reference and MCP client guide documenting plugin install/uninstall flows, files written, idempotency, and dry-run behavior.

* **Tests**
  * Added tests for command registration, option surfaces, and scope validation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/agentfront/frontmcp/pull/434?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->