### PR TITLE
feat: add end-to-end tests for stdio transport and ensure no HTTP port is bound

### DIFF
--- a/apps/e2e/demo-e2e-cli-exec/e2e/cli-stdio.e2e.spec.ts
+++ b/apps/e2e/demo-e2e-cli-exec/e2e/cli-stdio.e2e.spec.ts
@@ -1,0 +1,81 @@
+/**
+ * E2E: the built bundle serves MCP over stdio with `--stdio`, binding NO TCP
+ * port.
+ *
+ * Drives the compiled bundle (not tsx), so this exercises the real artifact
+ * users ship:
+ *  - #448 — `--stdio` is honored by the built bundle and serves stdin/stdout
+ *           JSON-RPC instead of starting the HTTP server.
+ *  - #451 — `runStdio()` forces the no-op server, so the fixture's configured
+ *           http port (3151) stays closed while stdio is connected.
+ */
+
+import { isTcpPortListening, McpClient, McpStdioClientTransport } from '@frontmcp/testing';
+
+import { ensureBuild, getCliBundlePath } from './helpers/exec-cli';
+
+// The fixture configures `http: { port: 3151 }`. In stdio mode nothing should
+// listen there; if the HTTP server were (wrongly) started it would bind it.
+const HTTP_PORT = 3151;
+
+describe('CLI built bundle — stdio mode (--stdio)', () => {
+  let client: McpClient | null = null;
+  let transport: McpStdioClientTransport | null = null;
+
+  beforeAll(async () => {
+    await ensureBuild();
+  }, 180000);
+
+  afterEach(async () => {
+    if (client) {
+      try {
+        await client.close();
+      } catch {
+        /* already exited */
+      }
+      client = null;
+    }
+    if (transport) {
+      try {
+        await transport.close();
+      } catch {
+        /* already exited */
+      }
+      transport = null;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 250));
+  });
+
+  async function connectStdio(): Promise<void> {
+    transport = new McpStdioClientTransport({
+      command: 'node',
+      args: [getCliBundlePath(), '--stdio'],
+      env: { ...process.env, PORT: String(HTTP_PORT) } as Record<string, string>,
+    });
+    client = new McpClient({ name: 'cli-stdio-client', version: '1.0.0' }, { capabilities: {} });
+    await client.connect(transport);
+  }
+
+  it('lists tools over stdio and binds NO HTTP port', async () => {
+    await connectStdio();
+
+    const tools = await client!.listTools();
+    const names = tools.tools.map((t) => t.name);
+    expect(names).toContain('add');
+    expect(names).toContain('greet');
+
+    // stdio mode must not open the configured HTTP listener.
+    expect(await isTcpPortListening(HTTP_PORT)).toBe(false);
+  }, 60000);
+
+  it('calls a tool over stdio and returns a structured result', async () => {
+    await connectStdio();
+
+    const result = await client!.callTool({ name: 'add', arguments: { a: 2, b: 3 } });
+    expect(result.isError).not.toBe(true);
+
+    const textContent = result.content.find((c: { type: string }) => c.type === 'text');
+    expect(textContent).toBeDefined();
+    expect((textContent as { text: string }).text).toContain('5');
+  }, 60000);
+});

--- a/apps/e2e/demo-e2e-stdio-transport/e2e/stdio-no-http-port.e2e.spec.ts
+++ b/apps/e2e/demo-e2e-stdio-transport/e2e/stdio-no-http-port.e2e.spec.ts
@@ -1,0 +1,101 @@
+/**
+ * E2E: stdio transport binds NO HTTP/TCP port, and runStdio accepts a class.
+ *
+ * Regression coverage for three linked issues:
+ *
+ *  - #451 — running over stdio used to ALSO bind 0.0.0.0:3000 (the @FrontMcp
+ *           decorator auto-bootstrapped an HTTP server at import time).
+ *  - #450 — `FrontMcpInstance.runStdio(MyServerClass)` threw a Zod error
+ *           because it only accepted a config object, not a decorated class.
+ *  - #448 — the built `node` runner now serves stdio via FRONTMCP_STDIO=1, which
+ *           is the same env flag the decorated-class path below exercises.
+ *
+ * Each case connects a real MCP client over stdio, then asserts that the
+ * server's HTTP port is NOT listening — proving stdio mode never opens a socket.
+ */
+
+import { join } from 'path';
+
+import { isTcpPortListening, McpClient, McpStdioClientTransport } from '@frontmcp/testing';
+
+// A high, unlikely-used port. If the HTTP server were (wrongly) started, the
+// decorator would bind PORT here; in stdio mode nothing should listen on it.
+const TEST_PORT = 39917;
+const projectPath = join(__dirname, '..');
+
+describe('Stdio Transport — no HTTP port bound (#448, #450, #451)', () => {
+  let client: McpClient | null = null;
+  let transport: McpStdioClientTransport | null = null;
+
+  afterEach(async () => {
+    if (client) {
+      try {
+        await client.close();
+      } catch {
+        /* process may have exited */
+      }
+      client = null;
+    }
+    if (transport) {
+      try {
+        await transport.close();
+      } catch {
+        /* process may have exited */
+      }
+      transport = null;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 250));
+  });
+
+  async function connect(entry: string, extraEnv: Record<string, string> = {}): Promise<void> {
+    transport = new McpStdioClientTransport({
+      command: 'npx',
+      args: ['tsx', join(projectPath, entry)],
+      env: { ...process.env, PORT: String(TEST_PORT), ...extraEnv } as Record<string, string>,
+      cwd: projectPath,
+    });
+    client = new McpClient({ name: 'stdio-noport-client', version: '1.0.0' }, { capabilities: {} });
+    await client.connect(transport);
+  }
+
+  // ── #451 / #448 — decorated class served over stdio via FRONTMCP_STDIO=1 ──
+  // This mirrors what the built `node dist/<name> --stdio` runner does: it sets
+  // FRONTMCP_STDIO=1, so the @FrontMcp decorator connects stdio instead of HTTP.
+  describe('decorated class with FRONTMCP_STDIO=1 (the --stdio runner flow)', () => {
+    it('serves MCP over stdio and binds NO TCP port', async () => {
+      await connect('src/main.ts', { FRONTMCP_STDIO: '1' });
+
+      const tools = await client!.listTools();
+      expect(tools.tools.map((t) => t.name)).toContain('create-note');
+
+      // Decorator served stdio (not HTTP) — the configured port must be free.
+      expect(await isTcpPortListening(TEST_PORT)).toBe(false);
+    }, 30000);
+  });
+
+  // ── #451 — runStdio(serverConfig) with a plain config object ──
+  describe('runStdio(serverConfig) — plain config object', () => {
+    it('serves over stdio and binds NO TCP port', async () => {
+      await connect('src/stdio-entrypoint.ts');
+
+      const tools = await client!.listTools();
+      expect(tools.tools.length).toBeGreaterThan(0);
+
+      expect(await isTcpPortListening(TEST_PORT)).toBe(false);
+    }, 30000);
+  });
+
+  // ── #450 — runStdio(DecoratedClass) resolves @FrontMcp metadata ──
+  describe('runStdio(DecoratedClass) — accepts a @FrontMcp class', () => {
+    it('resolves config from the class, serves over stdio, binds NO TCP port', async () => {
+      // Would reject during connect() if runStdio still threw the Zod
+      // "apps expected array" error on a class input.
+      await connect('src/stdio-class-entrypoint.ts');
+
+      const tools = await client!.listTools();
+      expect(tools.tools.map((t) => t.name)).toContain('create-note');
+
+      expect(await isTcpPortListening(TEST_PORT)).toBe(false);
+    }, 30000);
+  });
+});

--- a/apps/e2e/demo-e2e-stdio-transport/src/stdio-class-entrypoint.ts
+++ b/apps/e2e/demo-e2e-stdio-transport/src/stdio-class-entrypoint.ts
@@ -1,0 +1,31 @@
+/**
+ * Stdio entry that passes the @FrontMcp-decorated CLASS to runStdio (#450).
+ *
+ * The SDK JSDoc historically showed `FrontMcpInstance.runStdio(MyServer)` with
+ * the decorated class, which used to throw a Zod error ("apps expected array").
+ * This entry proves runStdio now accepts a class by resolving its stored
+ * `@FrontMcp` metadata.
+ *
+ * FRONTMCP_SCHEMA_EXTRACT=1 suppresses the decorator's import-time auto-bootstrap
+ * while we load the class (exactly what the generated CLI/`--stdio` entries do),
+ * so the only server started is the explicit runStdio(class) call below.
+ */
+import 'reflect-metadata';
+
+import { FrontMcpInstance } from '@frontmcp/sdk';
+
+async function main(): Promise<void> {
+  process.env['FRONTMCP_SCHEMA_EXTRACT'] = '1';
+  const mod = await import('./main.js');
+  delete process.env['FRONTMCP_SCHEMA_EXTRACT'];
+
+  const ServerClass = (mod as Record<string, unknown>)['StdioTransportE2EServer'];
+  // Pass the decorated CLASS (not a config object) — runStdio resolves its
+  // @FrontMcp metadata and serves over stdio with no TCP port bound.
+  await FrontMcpInstance.runStdio(ServerClass as never);
+}
+
+main().catch((err) => {
+  console.error('Failed to start stdio (class) server:', err);
+  process.exit(1);
+});

--- a/docs/frontmcp/deployment/mcp-clients.mdx
+++ b/docs/frontmcp/deployment/mcp-clients.mdx
@@ -27,6 +27,10 @@ Stdio is the most common transport for MCP servers. The client spawns your serve
 In stdio mode, **stdout is reserved for MCP protocol messages**. All logs are automatically redirected to stderr and `~/.frontmcp/logs/`. You don't need to configure anything — FrontMCP handles this automatically when `--stdio` is passed.
 </Info>
 
+<Info>
+Stdio mode binds **no TCP port** — the HTTP server is disabled entirely. You can run multiple stdio instances of the same server on one machine without an `EADDRINUSE` conflict.
+</Info>
+
 ### Using npx (npm package)
 
 The simplest way to distribute your MCP server. Publish to npm, then users can run it with `npx`:
@@ -105,18 +109,37 @@ If you built your server with `frontmcp build --target cli`, point directly to t
 
 ### Using Node.js Directly
 
-Run the JS bundle directly with Node.js:
+Run the **CLI bundle** (`frontmcp build --target cli`) directly with Node.js. The CLI bundle parses `--stdio` itself before any framework initialization:
 
 ```json
 {
   "mcpServers": {
     "my-server": {
       "command": "node",
-      "args": ["/path/to/my-server.bundle.js", "--stdio"]
+      "args": ["/path/to/my-server-cli.bundle.js", "--stdio"]
     }
   }
 }
 ```
+
+### Using the Server Runner (`--target node`)
+
+`frontmcp build --target node` emits a runner script at `dist/node/<name>`. Pass `--stdio` to serve over stdin/stdout instead of starting the HTTP server — the runner sets `FRONTMCP_STDIO=1`, so the server connects over stdio and binds no port:
+
+```json
+{
+  "mcpServers": {
+    "my-server": {
+      "command": "/path/to/dist/node/my-server",
+      "args": ["--stdio"]
+    }
+  }
+}
+```
+
+<Warning>
+Don't run the raw `--target node` bundle as `node dist/node/my-server.bundle.js --stdio` — that bundle is your `@FrontMcp` server module, which starts the HTTP server on import. Use the runner above (or set `FRONTMCP_STDIO=1` yourself before the bundle loads).
+</Warning>
 
 ### With Environment Variables
 

--- a/docs/frontmcp/sdk-reference/core/frontmcp-instance.mdx
+++ b/docs/frontmcp/sdk-reference/core/frontmcp-instance.mdx
@@ -109,24 +109,35 @@ scopes.forEach(scope => {
 });
 ```
 
-### runStdio(options)
+### runStdio(optionsOrClass)
 
-Run the server with stdio transport.
+Run the server over **stdio** (stdin/stdout JSON-RPC). **No HTTP/TCP port is bound** — the HTTP server is disabled for this entry point.
 
 ```typescript
-static async runStdio(options: FrontMcpConfigInput): Promise<void>
+static async runStdio(optionsOrClass: ConfigOrServerClass): Promise<void>
 ```
 
-Best for: Claude Desktop, stdio-based MCP clients.
+Best for: Claude Desktop, Claude Code, Cursor, and other stdio MCP clients.
+
+Accepts **either** a `@FrontMcp`-decorated class **or** the same config object you pass to `@FrontMcp()`.
 
 ```typescript
-// bin/cli.ts
+// stdio.ts — config kept in its own module (no @FrontMcp decorator imported here)
 import { FrontMcpInstance } from '@frontmcp/sdk';
-import config from '../src/server';
+import { serverConfig } from './server-config';
 
-await FrontMcpInstance.runStdio(config);
-// Never returns until connection closes
+await FrontMcpInstance.runStdio(serverConfig);
+// Never returns until the connection closes
 ```
+
+<Warning>
+Importing a `@FrontMcp`-decorated class starts an HTTP server at import time
+unless `FRONTMCP_STDIO=1` is set **before** the import. For a hand-written stdio
+entry, keep the config object in its own module (as above) so no decorated class
+is evaluated. For built servers, use the `--stdio` runner (`./dist/node/<name>
+--stdio`) or a `--target cli` binary (`<bin> --stdio`) — both set the flag for
+you, so the decorated server connects over stdio and binds no port.
+</Warning>
 
 ## Instance Methods
 
@@ -242,7 +253,7 @@ describe('MCP Server', () => {
   "mcpServers": {
     "my-server": {
       "command": "node",
-      "args": ["dist/cli.js"],
+      "args": ["dist/stdio.js"],
       "cwd": "/path/to/server"
     }
   }
@@ -250,12 +261,27 @@ describe('MCP Server', () => {
 ```
 
 ```typescript
-// src/cli.ts
-import { FrontMcpInstance } from '@frontmcp/sdk';
-import config from './server';
-
-FrontMcpInstance.runStdio(config).catch(console.error);
+// src/server-config.ts — a plain object; do NOT add @FrontMcp here
+export const serverConfig = {
+  info: { name: 'my-server', version: '1.0.0' },
+  apps: [MyApp],
+};
 ```
+
+```typescript
+// src/stdio.ts — imports only the config, so nothing auto-starts an HTTP server
+import { FrontMcpInstance } from '@frontmcp/sdk';
+import { serverConfig } from './server-config';
+
+FrontMcpInstance.runStdio(serverConfig).catch(console.error);
+```
+
+<Tip>
+Keep `serverConfig` separate from your `@FrontMcp`-decorated `main.ts`. The
+decorator starts an HTTP server when its module is imported, so a stdio entry
+that imports the decorated class would bind a port alongside stdio. Importing
+just the config object avoids that.
+</Tip>
 
 ## Related
 

--- a/docs/frontmcp/sdk-reference/decorators/frontmcp.mdx
+++ b/docs/frontmcp/sdk-reference/decorators/frontmcp.mdx
@@ -45,6 +45,15 @@ function FrontMcp(providedMetadata: FrontMcpMetadata): ClassDecorator
 | `serve`  | `boolean`          | `true`  | Auto-start HTTP server    |
 | `http`   | `HttpOptionsInput` | -       | HTTP server configuration |
 
+<Warning>
+With `serve: true` (the default), the decorated server **starts when its module
+is imported**. To serve over **stdio** instead — with no HTTP port bound — set
+`FRONTMCP_STDIO=1` before the module loads; the decorator then connects the
+stdio transport rather than starting HTTP. The built `--stdio` runner and
+`--target cli` binaries set this flag for you. Set `serve: false` to opt out of
+auto-starting entirely (use `FrontMcpInstance.bootstrap`/`runStdio` explicitly).
+</Warning>
+
 ```typescript
 @FrontMcp({
   info: { name: 'My Server', version: '1.0.0' },
@@ -291,10 +300,12 @@ export default FrontMcpInstance.createHandler(config);
 
 ```typescript
 import { FrontMcpInstance } from '@frontmcp/sdk';
-import config from './server';
+// Import the config object, NOT the @FrontMcp-decorated class — importing the
+// decorated class would auto-start an HTTP server alongside stdio.
+import { serverConfig } from './server-config';
 
-// Connect via stdio (for Claude Desktop)
-await FrontMcpInstance.runStdio(config);
+// Connect via stdio (for Claude Desktop). Binds no HTTP port.
+await FrontMcpInstance.runStdio(serverConfig);
 ```
 
 ### Direct Client

--- a/libs/cli/src/commands/build/exec/__tests__/runner-script.spec.ts
+++ b/libs/cli/src/commands/build/exec/__tests__/runner-script.spec.ts
@@ -125,6 +125,45 @@ describe('runner-script', () => {
     });
   });
 
+  // #448 / #451 — the node-target runner now honors `--stdio`: it exports
+  // FRONTMCP_STDIO=1 (so the @FrontMcp decorator serves over stdio instead of
+  // binding a TCP port) and execs the bundle/binary. CLI-mode runners delegate
+  // `--stdio` to the CLI bundle's own parser instead.
+  describe('generateRunnerScript (--stdio)', () => {
+    it('routes --stdio to FRONTMCP_STDIO=1 in the JS server runner', () => {
+      const config: FrontmcpExecConfig = { name: 'demo', version: '0.1.0' };
+      const script = generateRunnerScript(config, /* cliMode */ false, /* seaMode */ false);
+      expect(script).toContain('--stdio)');
+      expect(script).toContain('export FRONTMCP_STDIO=1');
+    });
+
+    it('routes --stdio to FRONTMCP_STDIO=1 in the SEA server runner', () => {
+      const config: FrontmcpExecConfig = { name: 'demo', version: '0.1.0' };
+      const script = generateRunnerScript(config, /* cliMode */ false, /* seaMode */ true);
+      expect(script).toContain('--stdio)');
+      expect(script).toContain('export FRONTMCP_STDIO=1');
+    });
+
+    it('documents --stdio in the server runner --help output', () => {
+      const config: FrontmcpExecConfig = { name: 'demo', version: '0.1.0' };
+      const script = generateRunnerScript(config, false, false);
+      expect(script).toMatch(/--stdio.*stdin\/stdout JSON-RPC/i);
+    });
+
+    it('notes --stdio as an allowed exception in the rejection message', () => {
+      const config: FrontmcpExecConfig = { name: 'demo' };
+      const script = generateRunnerScript(config, false, false);
+      expect(script).toContain('except --stdio');
+    });
+
+    it('does NOT add a --stdio interceptor in CLI mode (the CLI bundle parses it)', () => {
+      const config: FrontmcpExecConfig = { name: 'demo' };
+      const cliScript = generateRunnerScript(config, /* cliMode */ true, /* seaMode */ false);
+      expect(cliScript).not.toContain('--stdio)');
+      expect(cliScript).not.toContain('export FRONTMCP_STDIO=1');
+    });
+  });
+
   describe('extractMinMajor fallback', () => {
     it('should default min Node major to 22 when version has no digits', () => {
       const config: FrontmcpExecConfig = { name: 'app', nodeVersion: 'latest' };

--- a/libs/cli/src/commands/build/exec/runner-script.ts
+++ b/libs/cli/src/commands/build/exec/runner-script.ts
@@ -34,15 +34,19 @@ case "\${1:-}" in
     cat <<EOF
 ${name} v${version} — FrontMCP server
 
-This binary starts a long-running MCP HTTP server.
+This binary starts a long-running MCP HTTP server, or an MCP stdio server with --stdio.
 
 Usage:
-  ${name}                       Start the server
+  ${name}                       Start the HTTP server
+  ${name} --stdio               Serve over stdio (stdin/stdout JSON-RPC); binds no TCP port
   ${name} --help                Show this help
   ${name} --version             Show version
   ${name} --print-manifest      Print the deployment manifest as JSON
 
 Configure via environment variables, .env, or frontmcp.config.
+
+Use --stdio for local MCP clients (Claude Desktop, Cursor). Example config:
+  { "command": "${name}", "args": ["--stdio"] }
 
 For a CLI-style binary that exposes tools/resources/prompts as subcommands,
 build with: frontmcp build --target cli
@@ -57,10 +61,18 @@ EOF
     cat "\${SCRIPT_DIR}/${name}.manifest.json"
     exit 0
     ;;
+  --stdio)
+    # Serve over stdio (stdin/stdout JSON-RPC) instead of starting the HTTP
+    # server. FRONTMCP_STDIO=1 makes the @FrontMcp decorator connect the stdio
+    # transport and bind no TCP port (#448, #451); logs go to stderr and
+    # ~/.frontmcp/logs. Drop the flag and fall through to the exec below.
+    export FRONTMCP_STDIO=1
+    shift
+    ;;
   --*)
     echo "Error: unsupported flag '\${1}' on the server runner."
-    echo "This binary is a long-running HTTP server; flag-style invocation is reserved." >&2
-    echo "Run with no args to start, or build with --target cli for a CLI binary." >&2
+    echo "This binary is a long-running HTTP server; flag-style invocation is reserved (except --stdio)." >&2
+    echo "Run with no args to start, --stdio to serve over stdio, or build with --target cli for a CLI binary." >&2
     exit 2
     ;;
 esac

--- a/libs/sdk/src/common/decorators/__tests__/front-mcp-stdio.decorator.spec.ts
+++ b/libs/sdk/src/common/decorators/__tests__/front-mcp-stdio.decorator.spec.ts
@@ -1,0 +1,95 @@
+/**
+ * @FrontMcp decorator — stdio auto-serve routing (#448 / #451).
+ *
+ * When `FRONTMCP_STDIO=1` is set before the decorated server module is
+ * imported (as the `--stdio` runner does), the decorator must serve over stdio
+ * via `FrontMcpInstance.runStdio()` instead of starting the HTTP server via
+ * `FrontMcpInstance.bootstrap()` — so a stdio server never binds a TCP port.
+ */
+import 'reflect-metadata';
+
+import { FrontMcp } from '../front-mcp.decorator';
+
+const runStdioMock = jest.fn().mockResolvedValue(undefined);
+const bootstrapMock = jest.fn().mockResolvedValue(undefined);
+const createHandlerMock = jest.fn().mockResolvedValue(undefined);
+
+// Mock the lazily-required front-mcp barrel so we can observe which entry point
+// the decorator routes to without booting a real server. Resolves to the same
+// module the decorator's `require('../../front-mcp')` targets.
+jest.mock('../../../front-mcp', () => ({
+  FrontMcpInstance: {
+    runStdio: runStdioMock,
+    bootstrap: bootstrapMock,
+    createHandler: createHandlerMock,
+  },
+}));
+
+const STDIO = 'FRONTMCP_STDIO';
+const SERVERLESS = 'FRONTMCP_SERVERLESS';
+const SCHEMA_EXTRACT = 'FRONTMCP_SCHEMA_EXTRACT';
+const TASK_ID = 'FRONTMCP_RUN_TASK_ID';
+
+describe('FrontMcp decorator — stdio auto-serve (FRONTMCP_STDIO)', () => {
+  const saved: Record<string, string | undefined> = {};
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    for (const k of [STDIO, SERVERLESS, SCHEMA_EXTRACT, TASK_ID]) {
+      saved[k] = process.env[k];
+      delete process.env[k];
+    }
+  });
+
+  afterEach(() => {
+    for (const k of [STDIO, SERVERLESS, SCHEMA_EXTRACT, TASK_ID]) {
+      if (saved[k] === undefined) delete process.env[k];
+      else process.env[k] = saved[k];
+    }
+  });
+
+  const config = { info: { name: 'stdio-dec-test', version: '1.0.0' }, apps: [] };
+
+  it('serves over stdio (not HTTP) when FRONTMCP_STDIO=1', () => {
+    process.env[STDIO] = '1';
+
+    @FrontMcp(config as never)
+    class S {}
+    void S;
+
+    expect(runStdioMock).toHaveBeenCalledTimes(1);
+    expect(bootstrapMock).not.toHaveBeenCalled();
+  });
+
+  it('bootstraps the HTTP server when FRONTMCP_STDIO is unset', () => {
+    @FrontMcp(config as never)
+    class S {}
+    void S;
+
+    expect(bootstrapMock).toHaveBeenCalledTimes(1);
+    expect(runStdioMock).not.toHaveBeenCalled();
+  });
+
+  it('does not auto-serve at all when serve:false, even with FRONTMCP_STDIO=1', () => {
+    process.env[STDIO] = '1';
+
+    @FrontMcp({ ...config, serve: false } as never)
+    class S {}
+    void S;
+
+    expect(runStdioMock).not.toHaveBeenCalled();
+    expect(bootstrapMock).not.toHaveBeenCalled();
+  });
+
+  it('lets schema-extract take precedence over stdio (metadata only, no serve)', () => {
+    process.env[STDIO] = '1';
+    process.env[SCHEMA_EXTRACT] = '1';
+
+    @FrontMcp(config as never)
+    class S {}
+    void S;
+
+    expect(runStdioMock).not.toHaveBeenCalled();
+    expect(bootstrapMock).not.toHaveBeenCalled();
+  });
+});

--- a/libs/sdk/src/common/decorators/front-mcp.decorator.ts
+++ b/libs/sdk/src/common/decorators/front-mcp.decorator.ts
@@ -120,6 +120,7 @@ export function FrontMcp(providedMetadata: FrontMcpMetadata): ClassDecorator {
 
     const isServerless = getEnvFlag('FRONTMCP_SERVERLESS');
     const isSchemaExtract = getEnvFlag('FRONTMCP_SCHEMA_EXTRACT');
+    const isStdio = getEnvFlag('FRONTMCP_STDIO');
     const taskWorkerId = typeof process !== 'undefined' ? process.env?.['FRONTMCP_RUN_TASK_ID'] : undefined;
 
     if (taskWorkerId && metadata.serve !== false) {
@@ -141,6 +142,20 @@ export function FrontMcp(providedMetadata: FrontMcpMetadata): ClassDecorator {
 
     if (isSchemaExtract) {
       // Schema extraction mode — metadata already stored above, skip bootstrap
+    } else if (isStdio) {
+      // Stdio mode (FRONTMCP_STDIO=1): serve over stdin/stdout instead of HTTP.
+      // The `--stdio` runner (`node dist/main.js --stdio`) — or the user, before
+      // importing the server — sets this flag so the decorated server connects
+      // over stdio and never binds a TCP port (#448, #451). `serve: false` opts
+      // out of auto-serving entirely, matching the HTTP branch below.
+      if (metadata.serve) {
+        getFrontMcpInstance()
+          .runStdio(metadata)
+          .catch((err: unknown) => {
+            console.error('[FrontMCP] stdio server failed:', err);
+            process.exit(1);
+          });
+      }
     } else if (isServerless) {
       // Serverless mode: bootstrap, prepare (no listen), store handler globally
       // Uses direct relative imports to avoid circular dependency with @frontmcp/sdk

--- a/libs/sdk/src/front-mcp/__tests__/run-stdio-input.spec.ts
+++ b/libs/sdk/src/front-mcp/__tests__/run-stdio-input.spec.ts
@@ -1,0 +1,28 @@
+/**
+ * FrontMcpInstance.runStdio() input resolution (#450).
+ *
+ * runStdio accepts either a `@FrontMcp`-decorated class or the config object.
+ * A plain class with no `@FrontMcp` metadata is a misuse and must fail fast
+ * with a guiding error. The resolve step runs FIRST in runStdio — before any
+ * global side effects (console redirection, the stdio connection) — so this
+ * error path is safe to assert without hijacking the test runner's stdio.
+ *
+ * The happy paths (class + config object actually serving over stdio) are
+ * covered by the e2e suites (apps/e2e/demo-e2e-stdio-transport,
+ * apps/e2e/demo-e2e-cli-exec).
+ */
+import 'reflect-metadata';
+
+import { InternalMcpError } from '../../errors';
+import { FrontMcpInstance } from '../front-mcp';
+
+describe('FrontMcpInstance.runStdio — input resolution (#450)', () => {
+  it('rejects a class with no @FrontMcp() metadata with a guiding error', async () => {
+    class NotDecorated {}
+
+    const err = await FrontMcpInstance.runStdio(NotDecorated as never).catch((e: unknown) => e);
+
+    expect(err).toBeInstanceOf(InternalMcpError);
+    expect((err as Error).message).toMatch(/without @FrontMcp\(\) metadata/);
+  });
+});

--- a/libs/sdk/src/front-mcp/front-mcp.ts
+++ b/libs/sdk/src/front-mcp/front-mcp.ts
@@ -4,6 +4,7 @@ import {
   FrontMcpLogger,
   frontMcpMetadataSchema,
   FrontMcpServer,
+  getDecoratorConfig,
   parseFrontMcpConfigLite,
   type FrontMcpConfigInput,
   type FrontMcpConfigType,
@@ -24,6 +25,44 @@ import { type FrontMcpServerInstance } from '../server/server.instance';
 import { buildChannelInstructions, composeInitializeInstructions } from '../skill/skill-instructions.helper';
 import { computeTaskCapabilities } from '../task';
 import { createMcpGlobalProviders } from './front-mcp.providers';
+
+/**
+ * A `@FrontMcp`-decorated server class, or the raw config object it wraps.
+ * Entry points that accept either resolve a class to its stored config via
+ * {@link resolveConfigInput}.
+ */
+export type ConfigOrServerClass = FrontMcpConfigInput | (abstract new (...args: never[]) => unknown);
+
+/**
+ * Tracks whether a stdio server has already connected in this process. stdio
+ * owns the single stdin/stdout pair, so only one connection can exist — a
+ * second `runStdio()` (e.g. the `@FrontMcp` decorator auto-serving plus an
+ * explicit call) is ignored rather than corrupting the JSON-RPC stream by
+ * attaching a second transport to stdin.
+ */
+let stdioServing = false;
+
+/**
+ * Normalize an argument that may be either a raw FrontMCP config object or a
+ * `@FrontMcp`-decorated class. Mirrors `connect()` so every entry point accepts
+ * the same inputs (#450). A class is resolved to the config the decorator
+ * stored under its reflect-metadata key.
+ */
+function resolveConfigInput(optionsOrClass: ConfigOrServerClass): FrontMcpConfigInput {
+  if (typeof optionsOrClass === 'function') {
+    const stored = getDecoratorConfig(optionsOrClass);
+    // `getDecoratorConfig` returns the decorator's already-parsed metadata
+    // (schema output), which is a valid input to `frontMcpMetadataSchema.parse`
+    // — the same round-trip `bootstrap()` relies on. The cast bridges the
+    // output→input shape; callers re-parse it, so it is safe.
+    if (stored) return stored as unknown as FrontMcpConfigInput;
+    throw new InternalMcpError(
+      'runStdio() received a class without @FrontMcp() metadata. Pass a ' +
+        '@FrontMcp-decorated class, or the same config object you pass to @FrontMcp().',
+    );
+  }
+  return optionsOrClass;
+}
 
 export class FrontMcpInstance implements FrontMcpInterface {
   config: FrontMcpConfigType;
@@ -321,48 +360,22 @@ export class FrontMcpInstance implements FrontMcpInterface {
   }
 
   /**
-   * Runs the FrontMCP server using stdio transport for use with Claude Code
-   * or other MCP clients that support stdio communication.
-   *
-   * This method connects the server to stdin/stdout and handles MCP protocol
-   * messages directly. It does not return until the connection is closed.
-   *
-   * @example
-   * ```typescript
-   * // In your CLI entrypoint
-   * import { FrontMcpInstance } from '@frontmcp/sdk';
-   * import MyServer from './my-server';
-   *
-   * FrontMcpInstance.runStdio(MyServer);
-   * ```
-   *
-   * @example
-   * ```bash
-   * # In Claude Desktop config:
-   * {
-   *   "mcpServers": {
-   *     "my-server": {
-   *       "command": "node",
-   *       "args": ["./dist/main.js", "--stdio"]
-   *     }
-   *   }
-   * }
-   * ```
-   */
-  /**
    * Runs the FrontMCP server on a Unix socket for local-only access.
    *
    * This enables a persistent background FrontMCP server accessible only via
    * a Unix `.sock` file. The entire HTTP feature set (streamable HTTP, SSE,
    * elicitation, sessions) works unchanged over Unix sockets.
    *
+   * Pass the same config object you give to `@FrontMcp()` (not the decorated
+   * class — spreading a class yields no config) plus the socket path.
+   *
    * @example
    * ```typescript
    * import { FrontMcpInstance } from '@frontmcp/sdk';
-   * import MyServer from './my-server';
+   * import { serverConfig } from './server-config';
    *
    * const handle = await FrontMcpInstance.runUnixSocket({
-   *   ...MyServer,
+   *   ...serverConfig,
    *   socketPath: '/tmp/my-app.sock',
    *   sqlite: { path: '~/.frontmcp/data/my-app.sqlite' },
    * });
@@ -427,7 +440,53 @@ export class FrontMcpInstance implements FrontMcpInterface {
     return { close };
   }
 
-  public static async runStdio(options: FrontMcpConfigInput): Promise<void> {
+  /**
+   * Runs the FrontMCP server over **stdio** (stdin/stdout JSON-RPC) for local
+   * MCP clients such as Claude Desktop, Claude Code, and Cursor. Connects the
+   * transport and returns only when the connection closes. **No TCP port is
+   * bound** — the HTTP server is disabled for this entry point (#451).
+   *
+   * Accepts either a `@FrontMcp`-decorated class or the same config object you
+   * pass to `@FrontMcp()` (#450).
+   *
+   * IMPORTANT — importing a `@FrontMcp`-decorated class starts an HTTP server at
+   * import time unless `FRONTMCP_STDIO=1` is set *before* the import. Two safe
+   * patterns avoid that:
+   *
+   * 1. Built bundles — `frontmcp build --target node`, then run the emitted
+   *    runner with `--stdio` (it sets `FRONTMCP_STDIO=1` for you, so the
+   *    decorator serves over stdio). A `--target cli` binary supports
+   *    `<bin> --stdio` the same way.
+   * 2. Hand-written entry — keep the config object in its own module (no
+   *    decorated class in the import graph) and pass it directly, as below.
+   *
+   * @example Hand-written stdio entry (config kept separate from the class)
+   * ```typescript
+   * // server-config.ts — a plain object, no @FrontMcp decorator here
+   * export const serverConfig = { info: { name: 'my-server', version: '0.1.0' }, apps: [MyApp] };
+   *
+   * // stdio.ts
+   * import { FrontMcpInstance } from '@frontmcp/sdk';
+   * import { serverConfig } from './server-config';
+   * FrontMcpInstance.runStdio(serverConfig);
+   * ```
+   *
+   * @example Claude Desktop config (built `--target node` runner)
+   * ```json
+   * {
+   *   "mcpServers": {
+   *     "my-server": { "command": "/abs/path/dist/node/my-server", "args": ["--stdio"] }
+   *   }
+   * }
+   * ```
+   */
+  public static async runStdio(optionsOrClass: ConfigOrServerClass): Promise<void> {
+    // Resolve a decorated class to its stored config, or accept a raw config
+    // object (#450). Done FIRST — before any global side effects (console
+    // redirection, env flags) — so invalid input fails fast and a failed
+    // resolve never trips the single-connection guard below.
+    const options = resolveConfigInput(optionsOrClass);
+
     // ── Stdio stdout protection ──────────────────────────────────────────
     // In stdio mode, stdout is the MCP JSON-RPC channel. ANY non-protocol
     // output (logs, warnings, debug prints) on stdout corrupts the wire.
@@ -448,14 +507,29 @@ export class FrontMcpInstance implements FrontMcpInterface {
     console.count = stderrConsole.count.bind(stderrConsole);
     // console.warn and console.error already go to stderr — leave them.
 
+    // Mark stdio mode so any @FrontMcp decorator imported from here on serves
+    // over stdio rather than binding an HTTP port (#451). Guard against a
+    // second stdio connection (decorator auto-serve plus an explicit call),
+    // which would corrupt the JSON-RPC stream by attaching two transports to
+    // the single stdin/stdout pair.
+    process.env['FRONTMCP_STDIO'] = '1';
+    if (stdioServing) {
+      console.error('[FrontMCP] runStdio() called more than once; ignoring the duplicate stdio connection.');
+      return;
+    }
+    stdioServing = true;
+
     // Dynamically import to avoid bundling issues
     const { StdioServerTransport, McpServer } = await import('@frontmcp/protocol');
 
-    // Parse config: disable HTTP server, disable console logging, enable file logging.
-    // All structured logs go to ~/.frontmcp/logs/ — stdout stays clean for MCP protocol.
+    // Parse config: disable the HTTP server, disable console logging, enable
+    // file logging. `serve: false` selects the no-op server so no Express
+    // adapter is constructed and no TCP port can ever bind (#451). All
+    // structured logs go to ~/.frontmcp/logs/ — stdout stays clean for MCP.
     const parsedConfig = frontMcpMetadataSchema.parse({
       ...options,
       http: undefined,
+      serve: false,
     });
     // Force console logging off and file transport on (same pattern as createForCli)
     if (parsedConfig.logging) {

--- a/libs/sdk/src/index.ts
+++ b/libs/sdk/src/index.ts
@@ -20,6 +20,7 @@ import { FlowHooksOf } from './common';
 })();
 
 export { FrontMcpInstance, FrontMcpConfig } from './front-mcp';
+export type { ConfigOrServerClass } from './front-mcp';
 export {
   getServerlessHandler,
   getServerlessHandlerAsync,

--- a/libs/skills/catalog/frontmcp-auth-ui/SKILL.md
+++ b/libs/skills/catalog/frontmcp-auth-ui/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: frontmcp-auth-ui
-description: 'Use when you want to customize, brand, or replace the built-in FrontMCP login / consent / federated / incremental / error pages with your own React component. Covers the `auth.ui` slot→file map + `auth.extras` name→handler map on the auth config (no decorator, no class), the `@frontmcp/ui/auth` React hooks + `<AuthPageWrapper>` + `mountAuthPage` (client-rendered via an esm.sh import-map + a server-side per-file transform — no bundling, no SSR), and the framework-owned CSRF + CSP. The skill for CUSTOM AUTHORIZATION UI.'
+description: 'Use when customizing, branding, or replacing the built-in FrontMCP OAuth pages (the login, consent, federated-select, incremental-authorization, and error pages) with your own React components. Covers the auth.ui slot-to-file map and auth.extras name-to-handler map on the auth config (no decorator, no class); the @frontmcp/ui/auth React hooks, the AuthPageWrapper component, and mountAuthPage (client-rendered via an esm.sh import-map plus a per-file server-side transform, with no bundling and no SSR); and the framework-owned CSRF and CSP. Triggers: custom login page, brand the consent screen, replace the OAuth UI, custom authorization UI, style the auth pages, multi-step login. The skill for CUSTOM AUTHORIZATION UI (distinct from auth config in frontmcp-config and permissions in frontmcp-authorities).'
 tags: [auth, auth-ui, login, consent, custom-ui, react, oauth, guide]
 category: config
 targets: [all]

--- a/libs/skills/catalog/frontmcp-authorities/SKILL.md
+++ b/libs/skills/catalog/frontmcp-authorities/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: frontmcp-authorities
-description: 'Use when implementing authorization, access control, RBAC, ABAC, or ReBAC for tools, resources, prompts, or skills. Covers JWT claims mapping, authority profiles, and policy enforcement.'
+description: 'Use when implementing authorization and access control for FrontMCP tools, resources, prompts, or skills, deciding who may invoke what. Covers the RBAC, ABAC, and ReBAC models and when to choose each; JWT claims mapping per identity provider (Auth0, Keycloak, Okta, Cognito, Frontegg); reusable named authority profiles; and custom authority evaluators for domain-specific policy. This is about who-can-do-what (permissions, roles, scopes), distinct from configuring auth modes and login (see frontmcp-config) and custom login UI (see frontmcp-auth-ui). Triggers: authorization, access control, RBAC, ABAC, ReBAC, permissions, roles, scopes, policy enforcement, JWT claims, restrict who can call a tool.'
 tags: [authorization, rbac, abac, rebac, security, permissions, roles, access-control, authorities, jwt]
 category: development
 targets: [all]

--- a/libs/skills/catalog/frontmcp-channels/SKILL.md
+++ b/libs/skills/catalog/frontmcp-channels/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: frontmcp-channels
-description: 'Use when you want to push real-time notifications into Claude Code sessions. Build webhook channels, chat bridges (WhatsApp, Telegram, Slack), agent completion alerts, job status notifications, or error forwarding. The skill for CHANNELS and NOTIFICATIONS.'
+description: 'Use when pushing real-time notifications or events into Claude Code (or another MCP client) sessions, or building two-way chat bridges. Covers channel source types: incoming webhooks (such as GitHub), app error events, agent-completion and job-completion alerts, service connectors, file watchers, and replay buffers; plus two-way conversational bridges connecting WhatsApp, Telegram, Slack, and Discord to a Claude Code session. Triggers: push notifications, real-time alerts, webhook channel, chat bridge, WhatsApp / Telegram / Slack / Discord, agent completion alert, job status notification, error forwarding, server-to-client messaging. The skill for CHANNELS and NOTIFICATIONS.'
 tags: [channels, notifications, claude-code, webhooks, messaging, real-time, two-way]
 category: development
 targets: [all]

--- a/libs/skills/catalog/frontmcp-config/SKILL.md
+++ b/libs/skills/catalog/frontmcp-config/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: frontmcp-config
-description: 'Use when you want to configure auth, set up CORS, add rate limiting, throttle requests, manage sessions, choose transport, set HTTP options, add authentication, configure JWT, or set up OAuth. The skill for server CONFIGURATION.'
+description: 'Use when configuring a FrontMCP server through frontmcp.config or the @FrontMcp options. Covers auth modes (public, transparent, local, remote), OAuth plus credential vault and secureStore, CORS, HTTP port / entry-path prefix / unix socket, security headers (CSP, HSTS, X-Frame-Options, X-Content-Type-Options), rate limiting / throttling / concurrency / timeout / IP filtering (GuardConfig), session storage (Redis, Vercel KV), client transport protocols (SSE, Streamable HTTP, stateless, protocol presets), elicitation, multi-target build config, and skillsConfig (HTTP catalog, caching, audit log, instruction injection). Triggers: configure auth, set up CORS, add rate limiting, throttle requests, manage sessions, choose transport, set HTTP options, configure JWT or OAuth. The skill for server CONFIGURATION.'
 tags: [router, config, transport, http, auth, session, redis, sqlite, throttle, guide]
 category: config
 targets: [all]

--- a/libs/skills/catalog/frontmcp-deployment/SKILL.md
+++ b/libs/skills/catalog/frontmcp-deployment/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: frontmcp-deployment
-description: 'Use when you need to deploy, build for production, containerize, or ship a FrontMCP server. Covers Vercel, Lambda, Cloudflare, Docker, edge runtime, serverless, bundle for CLI, and Node targets. Triggers: deploy, build for production, dockerize, serverless, go live.'
+description: 'Use when deploying, building for production, packaging, or shipping a FrontMCP server. Covers build targets (node, cli SEA binary, browser, embeddable SDK, mcpb archive for Claude Desktop, serverless) and deploying to Vercel (with Vercel KV), AWS Lambda (API Gateway, SAM, CDK), Cloudflare Workers (KV, D1, Durable Objects, v1.3 skills-only), and Node (multi-stage Docker, docker-compose, PM2, nginx). Also the frontmcp.deploy.yaml manifest plus GitHub Action push-resync, and MCP client integration / .mcp.json for Claude Desktop, Claude Code, Cursor, and VS Code over stdio or HTTP. Triggers: deploy, build for production, dockerize, containerize, serverless, edge runtime, go live, ship it.'
 tags: [router, deployment, node, vercel, lambda, cloudflare, cli, browser, sdk, guide]
 category: deployment
 targets: [all]

--- a/libs/skills/catalog/frontmcp-deployment/references/mcp-client-integration.md
+++ b/libs/skills/catalog/frontmcp-deployment/references/mcp-client-integration.md
@@ -109,6 +109,8 @@ The most common transport. The MCP client spawns your server as a child process 
 - All logs are automatically redirected to stderr and `~/.frontmcp/logs/`
 - stdout contains ONLY MCP JSON-RPC protocol messages
 - One client per process (no multiplexing)
+- **Stdio binds no TCP port** — the HTTP server is disabled, so multiple stdio
+  instances of the same server run without an `EADDRINUSE` conflict
 
 ### npx (published npm package)
 
@@ -139,18 +141,42 @@ The most common transport. The MCP client spawns your server as a child process 
 }
 ```
 
-### Node.js bundle
+### Node.js CLI bundle
+
+Run the **CLI bundle** (`frontmcp build --target cli`) — it parses `--stdio`
+itself before any framework initialization:
 
 ```json
 {
   "mcpServers": {
     "my-server": {
       "command": "node",
-      "args": ["/path/to/my-server.bundle.js", "--stdio"]
+      "args": ["/path/to/my-server-cli.bundle.js", "--stdio"]
     }
   }
 }
 ```
+
+### Server runner (`--target node`)
+
+`frontmcp build --target node` emits a runner at `dist/node/<name>`. Pass
+`--stdio` to serve over stdin/stdout instead of HTTP — the runner sets
+`FRONTMCP_STDIO=1`, so the server connects over stdio and binds no port:
+
+```json
+{
+  "mcpServers": {
+    "my-server": {
+      "command": "/path/to/dist/node/my-server",
+      "args": ["--stdio"]
+    }
+  }
+}
+```
+
+> Do not run the raw `--target node` bundle as `node dist/node/my-server.bundle.js --stdio`
+> — that bundle is your `@FrontMcp` server module and starts the HTTP server on
+> import. Use the runner above, or set `FRONTMCP_STDIO=1` before the bundle loads.
 
 ## HTTP Transport
 

--- a/libs/skills/catalog/frontmcp-development/SKILL.md
+++ b/libs/skills/catalog/frontmcp-development/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: frontmcp-development
-description: 'Use when you want to create a tool, add a resource, build a prompt, write a provider, implement an adapter, add OpenAPI integration, create a plugin, agent, job, or workflow. The skill for BUILDING any FrontMCP component.'
+description: 'Use when building any FrontMCP server component other than a tool (for tools, use create-tool). Covers @Resource static resources and parameterized URI templates; @Prompt reusable prompts (RAG, multi-turn); @Provider singleton dependency-injection providers (database pools, API clients); @Agent autonomous LLM agents (Anthropic, OpenAI) and swarms; @Job background jobs (retry, progress, permissions) and @Workflow DAG pipelines; framework adapters and the OpenAPI adapter (turn OpenAPI 3.x specs into MCP tools with auth, polling, transforms); plugins, plugin lifecycle hooks (before / after / around / stage), and the official plugins; instruction-only skills and skills that reference tools; and the hierarchical decorator system from @FrontMcp down to @App. Triggers: create a resource, build a prompt, write a provider, add an agent, job, workflow, plugin, adapter, or OpenAPI integration.'
 tags: [router, development, tools, resources, prompts, agents, skills, guide]
 category: development
 targets: [all]

--- a/libs/skills/catalog/frontmcp-extensibility/SKILL.md
+++ b/libs/skills/catalog/frontmcp-extensibility/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: frontmcp-extensibility
-description: 'Extend FrontMCP servers with external npm packages and libraries. Covers VectoriaDB for semantic search, and patterns for integrating third-party services into providers and tools. Use when adding search, ML, database, or external API capabilities beyond the core SDK.'
+description: 'Use when extending FrontMCP beyond the core SDK by integrating external npm packages, libraries, or third-party services into providers and tools. Covers VectoriaDB for in-memory semantic and vector search (ML-based embeddings or TF-IDF keyword engines, with persistence) and the tamper-evident, hash-chained skill audit log (pluggable signer and store, with chain verification). Triggers: add semantic search, vector search, embeddings, similarity search, recommendations, ML features, audit logging, or integrate an external library, database, or API beyond the built-in SDK.'
 tags: [extensibility, vectoriadb, search, integration, npm, provider, external-services]
 category: extensibility
 targets: [all]

--- a/libs/skills/catalog/frontmcp-guides/SKILL.md
+++ b/libs/skills/catalog/frontmcp-guides/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: frontmcp-guides
-description: 'Tutorials, walkthroughs, and end-to-end examples for building FrontMCP servers. Use when you want a getting started guide, how to build a complete project, learn best practices, or follow a step-by-step example. Triggers: tutorial, walkthrough, how to build, getting started, learn FrontMCP.'
+description: 'Tutorials, end-to-end walkthroughs, and complete reference projects for FrontMCP. Use when you want a getting-started guide, a full worked example, or to learn best practices by following a step-by-step build rather than a single API reference. Includes a beginner weather-API server (tool plus static resource, Zod schemas, E2E tests), an authenticated task manager (CRUD tools, Redis storage, OAuth, Vercel deploy, authenticated E2E tests), and a multi-app knowledge base (vector search, semantic resources, an AI research agent, audit logging). Triggers: tutorial, walkthrough, how do I build, getting started, end-to-end example, sample project, learn FrontMCP, full app example.'
 tags: [guides, examples, best-practices, architecture, walkthrough, end-to-end]
 category: guides
 targets: [all]

--- a/libs/skills/catalog/frontmcp-observability/SKILL.md
+++ b/libs/skills/catalog/frontmcp-observability/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: frontmcp-observability
-description: 'Use when you want to add tracing, structured logging, or monitoring to your FrontMCP server. Covers OpenTelemetry instrumentation, vendor integrations (Coralogix, Datadog, Logz.io, Grafana), this.telemetry API for custom spans, structured JSON logging with sinks, and testing observability. Triggers: observability, telemetry, tracing, logging, monitoring, opentelemetry, otel, spans, datadog, coralogix, logz, grafana, winston, pino.'
+description: 'Use when adding tracing, structured logging, metrics, or monitoring to a FrontMCP server. Covers zero-config OpenTelemetry distributed tracing across all flows; the this.telemetry API for custom spans, events, and attributes in tools, plugins, agents, and skills; structured JSON logging with trace correlation and configurable sinks (Winston, Pino, stdout); the off-by-default /metrics endpoint (process and framework metrics, Prometheus-compatible); vendor integrations (Coralogix, Datadog, Logz.io, Grafana Cloud, or any OTLP backend); and testing spans, log correlation, and instrumentation. Triggers: observability, telemetry, tracing, logging, monitoring, OpenTelemetry, OTel, spans, metrics, Prometheus, Datadog, Coralogix, Logz.io, Grafana, Winston, Pino.'
 tags: [router, observability, telemetry, tracing, logging, monitoring, opentelemetry, otel, spans]
 category: observability
 targets: [all]

--- a/libs/skills/catalog/frontmcp-production-readiness/SKILL.md
+++ b/libs/skills/catalog/frontmcp-production-readiness/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: frontmcp-production-readiness
-description: 'Pre-production audit and checklist for FrontMCP servers. Use before go-live to verify security hardening, performance checks, observability, monitoring, and health checks. Triggers: production ready, security audit, performance check, production checklist, hardening, go live.'
+description: 'Pre-production audit, hardening, and go-live checklists for FrontMCP servers. Use before shipping to verify security hardening, performance, reliability, and observability, and for target-specific production checklists: Node server (Docker, graceful shutdown, Redis session scaling), Vercel and edge (cold-start, stateless design), AWS Lambda (cold start, scaling, monitoring), Cloudflare Workers (KV, Durable Objects, runtime limits), CLI binary and local daemon (stdio and socket transport), browser SDK bundle, and embedded npm SDK. Also configuring /healthz and /readyz health and readiness endpoints with custom probes, and distributed high-availability (multi-pod heartbeat, session takeover, notification relay). Triggers: production ready, security audit, hardening, performance check, production checklist, go live, pre-launch review.'
 tags: [production, security, performance, reliability, observability, audit, best-practices]
 category: production
 targets: [all]

--- a/libs/skills/catalog/frontmcp-setup/SKILL.md
+++ b/libs/skills/catalog/frontmcp-setup/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: frontmcp-setup
-description: "Domain router for project setup, scaffolding, and organization. Use this skill whenever someone asks to create a new FrontMCP project, set up an Nx monorepo, configure Redis or SQLite storage, organize project structure, compose multiple apps into one server, or manage the skills system. Also triggers for questions like 'how do I start', 'project layout', 'folder structure', 'add redis', 'set up database', or 'create a new app'."
+description: 'Use when starting, scaffolding, or organizing a FrontMCP project. Covers creating a new project (CLI scaffold or manual) for Node, Vercel, and other targets; standalone versus Nx-monorepo layout, naming conventions, generators, and dependency rules; composing multiple @App classes, ESM packages, and remote MCP servers into one server; provisioning session and storage backends (Redis, Vercel KV, SQLite with WAL and optional encryption); generating deployment-target-aware README files; and searching, installing, and managing the FrontMCP skill catalog for AI agents (Claude Code, Codex). Triggers: create a new project, how do I start, scaffold, project layout, folder structure, Nx monorepo, add Redis, set up SQLite or a database, compose apps, create a new app, manage skills.'
 tags: [router, setup, scaffold, project, nx, redis, sqlite, structure, guide]
 category: setup
 targets: [all]

--- a/libs/skills/catalog/frontmcp-testing/SKILL.md
+++ b/libs/skills/catalog/frontmcp-testing/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: frontmcp-testing
-description: 'Use when you want to write tests, run tests, add e2e tests, improve test coverage, test a tool, test a resource, or learn how to test any FrontMCP component. The skill for ALL testing needs.'
+description: 'Use for anything about testing FrontMCP servers: writing or running unit, integration, and E2E tests and reaching the 95%+ coverage bar. Covers Jest setup and coverage gating; unit-testing a ToolContext execute() with mock context, inputs, and Zod schema validation; testing resources and prompts; in-memory testing via create() and connectOpenAI / connectClaude (no HTTP); full MCP-protocol E2E over HTTP with McpTestClient and TestServer; authenticated tests with TestTokenFactory, MockOAuthServer, and role-based access; browser-bundle validation with Playwright; and CLI-binary / SEA startup tests. Triggers: write tests, run tests, add e2e tests, improve coverage, test a tool / resource / prompt, mock auth, jest config. The skill for ALL testing needs.'
 tags: [router, testing, jest, e2e, coverage, quality, guide]
 category: testing
 targets: [all]

--- a/libs/skills/catalog/skills-manifest.json
+++ b/libs/skills/catalog/skills-manifest.json
@@ -462,7 +462,7 @@
     {
       "name": "frontmcp-auth-ui",
       "category": "config",
-      "description": "Use when you want to customize, brand, or replace the built-in FrontMCP login / consent / federated / incremental / error pages with your own React component. Covers the `auth.ui` slot→file map + `auth.extras` name→handler map on the auth config (no decorator, no class), the `@frontmcp/ui/auth` React hooks + `<AuthPageWrapper>` + `mountAuthPage` (client-rendered via an esm.sh import-map + a server-side per-file transform — no bundling, no SSR), and the framework-owned CSRF + CSP. The skill for CUSTOM AUTHORIZATION UI.",
+      "description": "Use when customizing, branding, or replacing the built-in FrontMCP OAuth pages (the login, consent, federated-select, incremental-authorization, and error pages) with your own React components. Covers the auth.ui slot-to-file map and auth.extras name-to-handler map on the auth config (no decorator, no class); the @frontmcp/ui/auth React hooks, the AuthPageWrapper component, and mountAuthPage (client-rendered via an esm.sh import-map plus a per-file server-side transform, with no bundling and no SSR); and the framework-owned CSRF and CSP. Triggers: custom login page, brand the consent screen, replace the OAuth UI, custom authorization UI, style the auth pages, multi-step login. The skill for CUSTOM AUTHORIZATION UI (distinct from auth config in frontmcp-config and permissions in frontmcp-authorities).",
       "path": "frontmcp-auth-ui",
       "targets": ["all"],
       "hasResources": true,
@@ -506,7 +506,7 @@
     {
       "name": "frontmcp-config",
       "category": "config",
-      "description": "Use when you want to configure auth, set up CORS, add rate limiting, throttle requests, manage sessions, choose transport, set HTTP options, add authentication, configure JWT, or set up OAuth. The skill for server CONFIGURATION.",
+      "description": "Use when configuring a FrontMCP server through frontmcp.config or the @FrontMcp options. Covers auth modes (public, transparent, local, remote), OAuth plus credential vault and secureStore, CORS, HTTP port / entry-path prefix / unix socket, security headers (CSP, HSTS, X-Frame-Options, X-Content-Type-Options), rate limiting / throttling / concurrency / timeout / IP filtering (GuardConfig), session storage (Redis, Vercel KV), client transport protocols (SSE, Streamable HTTP, stateless, protocol presets), elicitation, multi-target build config, and skillsConfig (HTTP catalog, caching, audit log, instruction injection). Triggers: configure auth, set up CORS, add rate limiting, throttle requests, manage sessions, choose transport, set HTTP options, configure JWT or OAuth. The skill for server CONFIGURATION.",
       "path": "frontmcp-config",
       "targets": ["all"],
       "hasResources": true,
@@ -1089,7 +1089,7 @@
     {
       "name": "frontmcp-deployment",
       "category": "deployment",
-      "description": "Use when you need to deploy, build for production, containerize, or ship a FrontMCP server. Covers Vercel, Lambda, Cloudflare, Docker, edge runtime, serverless, bundle for CLI, and Node targets. Triggers: deploy, build for production, dockerize, serverless, go live.",
+      "description": "Use when deploying, building for production, packaging, or shipping a FrontMCP server. Covers build targets (node, cli SEA binary, browser, embeddable SDK, mcpb archive for Claude Desktop, serverless) and deploying to Vercel (with Vercel KV), AWS Lambda (API Gateway, SAM, CDK), Cloudflare Workers (KV, D1, Durable Objects, v1.3 skills-only), and Node (multi-stage Docker, docker-compose, PM2, nginx). Also the frontmcp.deploy.yaml manifest plus GitHub Action push-resync, and MCP client integration / .mcp.json for Claude Desktop, Claude Code, Cursor, and VS Code over stdio or HTTP. Triggers: deploy, build for production, dockerize, containerize, serverless, edge runtime, go live, ship it.",
       "path": "frontmcp-deployment",
       "targets": ["all"],
       "hasResources": true,
@@ -1486,7 +1486,7 @@
     {
       "name": "frontmcp-development",
       "category": "development",
-      "description": "Use when you want to create a tool, add a resource, build a prompt, write a provider, implement an adapter, add OpenAPI integration, create a plugin, agent, job, or workflow. The skill for BUILDING any FrontMCP component.",
+      "description": "Use when building any FrontMCP server component other than a tool (for tools, use create-tool). Covers @Resource static resources and parameterized URI templates; @Prompt reusable prompts (RAG, multi-turn); @Provider singleton dependency-injection providers (database pools, API clients); @Agent autonomous LLM agents (Anthropic, OpenAI) and swarms; @Job background jobs (retry, progress, permissions) and @Workflow DAG pipelines; framework adapters and the OpenAPI adapter (turn OpenAPI 3.x specs into MCP tools with auth, polling, transforms); plugins, plugin lifecycle hooks (before / after / around / stage), and the official plugins; instruction-only skills and skills that reference tools; and the hierarchical decorator system from @FrontMcp down to @App. Triggers: create a resource, build a prompt, write a provider, add an agent, job, workflow, plugin, adapter, or OpenAPI integration.",
       "path": "frontmcp-development",
       "targets": ["all"],
       "hasResources": true,
@@ -2148,7 +2148,7 @@
     {
       "name": "frontmcp-extensibility",
       "category": "extensibility",
-      "description": "Extend FrontMCP servers with external npm packages and libraries. Covers VectoriaDB for semantic search, and patterns for integrating third-party services into providers and tools. Use when adding search, ML, database, or external API capabilities beyond the core SDK.",
+      "description": "Use when extending FrontMCP beyond the core SDK by integrating external npm packages, libraries, or third-party services into providers and tools. Covers VectoriaDB for in-memory semantic and vector search (ML-based embeddings or TF-IDF keyword engines, with persistence) and the tamper-evident, hash-chained skill audit log (pluggable signer and store, with chain verification). Triggers: add semantic search, vector search, embeddings, similarity search, recommendations, ML features, audit logging, or integrate an external library, database, or API beyond the built-in SDK.",
       "path": "frontmcp-extensibility",
       "targets": ["all"],
       "hasResources": true,
@@ -2237,7 +2237,7 @@
     {
       "name": "frontmcp-guides",
       "category": "guides",
-      "description": "Tutorials, walkthroughs, and end-to-end examples for building FrontMCP servers. Use when you want a getting started guide, how to build a complete project, learn best practices, or follow a step-by-step example. Triggers: tutorial, walkthrough, how to build, getting started, learn FrontMCP.",
+      "description": "Tutorials, end-to-end walkthroughs, and complete reference projects for FrontMCP. Use when you want a getting-started guide, a full worked example, or to learn best practices by following a step-by-step build rather than a single API reference. Includes a beginner weather-API server (tool plus static resource, Zod schemas, E2E tests), an authenticated task manager (CRUD tools, Redis storage, OAuth, Vercel deploy, authenticated E2E tests), and a multi-app knowledge base (vector search, semantic resources, an AI research agent, audit logging). Triggers: tutorial, walkthrough, how do I build, getting started, end-to-end example, sample project, learn FrontMCP, full app example.",
       "path": "frontmcp-guides",
       "targets": ["all"],
       "hasResources": true,
@@ -2383,7 +2383,7 @@
     {
       "name": "frontmcp-production-readiness",
       "category": "production",
-      "description": "Pre-production audit and checklist for FrontMCP servers. Use before go-live to verify security hardening, performance checks, observability, monitoring, and health checks. Triggers: production ready, security audit, performance check, production checklist, hardening, go live.",
+      "description": "Pre-production audit, hardening, and go-live checklists for FrontMCP servers. Use before shipping to verify security hardening, performance, reliability, and observability, and for target-specific production checklists: Node server (Docker, graceful shutdown, Redis session scaling), Vercel and edge (cold-start, stateless design), AWS Lambda (cold start, scaling, monitoring), Cloudflare Workers (KV, Durable Objects, runtime limits), CLI binary and local daemon (stdio and socket transport), browser SDK bundle, and embedded npm SDK. Also configuring /healthz and /readyz health and readiness endpoints with custom probes, and distributed high-availability (multi-pod heartbeat, session takeover, notification relay). Triggers: production ready, security audit, hardening, performance check, production checklist, go live, pre-launch review.",
       "path": "frontmcp-production-readiness",
       "targets": ["all"],
       "hasResources": true,
@@ -2827,7 +2827,7 @@
     {
       "name": "frontmcp-setup",
       "category": "setup",
-      "description": "Domain router for project setup, scaffolding, and organization. Use this skill whenever someone asks to create a new FrontMCP project, set up an Nx monorepo, configure Redis or SQLite storage, organize project structure, compose multiple apps into one server, or manage the skills system. Also triggers for questions like 'how do I start', 'project layout', 'folder structure', 'add redis', 'set up database', or 'create a new app'.",
+      "description": "Use when starting, scaffolding, or organizing a FrontMCP project. Covers creating a new project (CLI scaffold or manual) for Node, Vercel, and other targets; standalone versus Nx-monorepo layout, naming conventions, generators, and dependency rules; composing multiple @App classes, ESM packages, and remote MCP servers into one server; provisioning session and storage backends (Redis, Vercel KV, SQLite with WAL and optional encryption); generating deployment-target-aware README files; and searching, installing, and managing the FrontMCP skill catalog for AI agents (Claude Code, Codex). Triggers: create a new project, how do I start, scaffold, project layout, folder structure, Nx monorepo, add Redis, set up SQLite or a database, compose apps, create a new app, manage skills.",
       "path": "frontmcp-setup",
       "targets": ["all"],
       "hasResources": true,
@@ -3198,7 +3198,7 @@
     {
       "name": "frontmcp-testing",
       "category": "testing",
-      "description": "Use when you want to write tests, run tests, add e2e tests, improve test coverage, test a tool, test a resource, or learn how to test any FrontMCP component. The skill for ALL testing needs.",
+      "description": "Use for anything about testing FrontMCP servers: writing or running unit, integration, and E2E tests and reaching the 95%+ coverage bar. Covers Jest setup and coverage gating; unit-testing a ToolContext execute() with mock context, inputs, and Zod schema validation; testing resources and prompts; in-memory testing via create() and connectOpenAI / connectClaude (no HTTP); full MCP-protocol E2E over HTTP with McpTestClient and TestServer; authenticated tests with TestTokenFactory, MockOAuthServer, and role-based access; browser-bundle validation with Playwright; and CLI-binary / SEA startup tests. Triggers: write tests, run tests, add e2e tests, improve coverage, test a tool / resource / prompt, mock auth, jest config. The skill for ALL testing needs.",
       "path": "frontmcp-testing",
       "targets": ["all"],
       "hasResources": true,
@@ -3469,7 +3469,7 @@
     {
       "name": "frontmcp-observability",
       "category": "observability",
-      "description": "Use when you want to add tracing, structured logging, or monitoring to your FrontMCP server. Covers OpenTelemetry instrumentation, vendor integrations (Coralogix, Datadog, Logz.io, Grafana), this.telemetry API for custom spans, structured JSON logging with sinks, and testing observability. Triggers: observability, telemetry, tracing, logging, monitoring, opentelemetry, otel, spans, datadog, coralogix, logz, grafana, winston, pino.",
+      "description": "Use when adding tracing, structured logging, metrics, or monitoring to a FrontMCP server. Covers zero-config OpenTelemetry distributed tracing across all flows; the this.telemetry API for custom spans, events, and attributes in tools, plugins, agents, and skills; structured JSON logging with trace correlation and configurable sinks (Winston, Pino, stdout); the off-by-default /metrics endpoint (process and framework metrics, Prometheus-compatible); vendor integrations (Coralogix, Datadog, Logz.io, Grafana Cloud, or any OTLP backend); and testing spans, log correlation, and instrumentation. Triggers: observability, telemetry, tracing, logging, monitoring, OpenTelemetry, OTel, spans, metrics, Prometheus, Datadog, Coralogix, Logz.io, Grafana, Winston, Pino.",
       "path": "frontmcp-observability",
       "targets": ["all"],
       "hasResources": true,
@@ -3665,7 +3665,7 @@
     {
       "name": "frontmcp-channels",
       "category": "development",
-      "description": "Use when you want to push real-time notifications into Claude Code sessions. Build webhook channels, chat bridges (WhatsApp, Telegram, Slack), agent completion alerts, job status notifications, or error forwarding. The skill for CHANNELS and NOTIFICATIONS.",
+      "description": "Use when pushing real-time notifications or events into Claude Code (or another MCP client) sessions, or building two-way chat bridges. Covers channel source types: incoming webhooks (such as GitHub), app error events, agent-completion and job-completion alerts, service connectors, file watchers, and replay buffers; plus two-way conversational bridges connecting WhatsApp, Telegram, Slack, and Discord to a Claude Code session. Triggers: push notifications, real-time alerts, webhook channel, chat bridge, WhatsApp / Telegram / Slack / Discord, agent completion alert, job status notification, error forwarding, server-to-client messaging. The skill for CHANNELS and NOTIFICATIONS.",
       "path": "frontmcp-channels",
       "targets": ["all"],
       "hasResources": true,
@@ -3793,7 +3793,7 @@
     {
       "name": "frontmcp-authorities",
       "category": "development",
-      "description": "Use when implementing authorization, access control, RBAC, ABAC, or ReBAC for tools, resources, prompts, or skills. Covers JWT claims mapping, authority profiles, and policy enforcement.",
+      "description": "Use when implementing authorization and access control for FrontMCP tools, resources, prompts, or skills, deciding who may invoke what. Covers the RBAC, ABAC, and ReBAC models and when to choose each; JWT claims mapping per identity provider (Auth0, Keycloak, Okta, Cognito, Frontegg); reusable named authority profiles; and custom authority evaluators for domain-specific policy. This is about who-can-do-what (permissions, roles, scopes), distinct from configuring auth modes and login (see frontmcp-config) and custom login UI (see frontmcp-auth-ui). Triggers: authorization, access control, RBAC, ABAC, ReBAC, permissions, roles, scopes, policy enforcement, JWT claims, restrict who can call a tool.",
       "path": "frontmcp-authorities",
       "targets": ["all"],
       "hasResources": true,

--- a/libs/testing/src/index.ts
+++ b/libs/testing/src/index.ts
@@ -318,7 +318,7 @@ export {
 // RAW MCP CLIENT (for low-level e2e testing)
 // ═══════════════════════════════════════════════════════════════════
 
-export { McpClient, McpStdioClientTransport } from './raw-client';
+export { McpClient, McpStdioClientTransport, isTcpPortListening } from './raw-client';
 
 export type {
   // Memory & CPU Types

--- a/libs/testing/src/raw-client/index.ts
+++ b/libs/testing/src/raw-client/index.ts
@@ -4,3 +4,4 @@
  */
 export { Client as McpClient } from '@frontmcp/protocol';
 export { StdioClientTransport as McpStdioClientTransport } from '@frontmcp/protocol';
+export { isTcpPortListening } from './port-probe';

--- a/libs/testing/src/raw-client/port-probe.ts
+++ b/libs/testing/src/raw-client/port-probe.ts
@@ -1,0 +1,42 @@
+/**
+ * TCP port probe for low-level e2e tests.
+ *
+ * Primarily used to assert that a server running in **stdio mode binds no HTTP
+ * port** — connect once and report whether anything is listening.
+ */
+import net from 'node:net';
+
+/**
+ * Resolve `true` iff a TCP server is currently accepting connections on
+ * `host:port`, otherwise `false`.
+ *
+ * A refused connection (`ECONNREFUSED`) or a timeout resolves to `false`; a
+ * successful connect resolves to `true` and the probe socket is closed
+ * immediately. Probing loopback makes "nothing listening" fail fast, so the
+ * timeout only guards against a silently-dropped connection.
+ *
+ * @param port - TCP port to probe
+ * @param host - Host/interface to probe (default `127.0.0.1`)
+ * @param timeoutMs - Max time to wait for a connection (default `1500`)
+ */
+export function isTcpPortListening(port: number, host = '127.0.0.1', timeoutMs = 1500): Promise<boolean> {
+  return new Promise((resolve) => {
+    const socket = net.connect({ port, host });
+    // The probe is fire-and-forget: never let its socket (or idle timer) keep
+    // the event loop alive or delay a test run from exiting.
+    socket.unref();
+    socket.setTimeout(timeoutMs);
+
+    let settled = false;
+    const finish = (listening: boolean): void => {
+      if (settled) return;
+      settled = true;
+      socket.destroy();
+      resolve(listening);
+    };
+
+    socket.once('connect', () => finish(true));
+    socket.once('error', () => finish(false));
+    socket.once('timeout', () => finish(false));
+  });
+}


### PR DESCRIPTION
Fixes: 
- #448 
- #450 
- #451 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Stdio transport mode: stdio disables HTTP/TCP binding so multiple instances can run without port conflicts.
  * `runStdio` now accepts either a decorated server class or a plain config; decorator startup honors stdio mode.

* **Documentation**
  * Expanded deployment and SDK docs with clear stdio/CLI examples and warnings to avoid unintended HTTP startup.
  * Updated skill catalog descriptions for several areas.

* **Tests**
  * Added E2E and unit tests validating stdio behavior and TCP-port non-binding.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->