### PR TITLE
fix: refresh yarn.lock to match bumped versions after release versioning (#493)

### DIFF
--- a/.github/workflows/create-release-branch.yml
+++ b/.github/workflows/create-release-branch.yml
@@ -181,6 +181,22 @@ jobs:
           echo "Updating all synchronized libraries to v$VERSION..."
           npx nx release version "$VERSION" --git-tag=false --git-commit=false
 
+      - name: Refresh yarn.lock to match bumped versions
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          # The normalize + nx release version steps above rewrite every internal
+          # @frontmcp/* version pin across libs/*/package.json and plugins/*/package.json.
+          # Yarn stores those exact pins in yarn.lock (workspace peerDependencies are
+          # recorded verbatim), so the lockfile is now stale. Commit it as-is and the
+          # first push to the new release branch runs `yarn install --immutable`
+          # (package-e2e and others) and fails with YN0028 "The lockfile would have been
+          # modified by this install, which is explicitly forbidden." --mode=update-lockfile
+          # resolves offline (bumped packages are workspace soft-links) and only rewrites
+          # the recorded pins so the committed lockfile is consistent.
+          yarn install --mode=update-lockfile
+
       - name: Update CHANGELOG.md files
         shell: bash
         run: |

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -218,6 +218,22 @@ jobs:
           console.log(`Normalized ${totalChanged} package.json file(s) to v${VERSION}`);
           NODE
 
+      - name: Refresh yarn.lock to match bumped versions
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          # nx release version + the normalize step above rewrite every internal
+          # @frontmcp/* version pin in libs/*/package.json and plugins/*/package.json.
+          # Yarn records those exact pins inside yarn.lock (workspace peerDependencies
+          # are stored verbatim), so the lockfile is now stale relative to the manifests.
+          # If we commit without refreshing it, the next push to the release branch runs
+          # `yarn install --immutable` (package-e2e + others) and fails with YN0028
+          # "The lockfile would have been modified by this install, which is explicitly
+          # forbidden." --mode=update-lockfile resolves offline (the bumped packages are
+          # workspace soft-links) and only rewrites the recorded pins — no fetch/link.
+          yarn install --mode=update-lockfile
+
       - name: Commit version bump
         env:
           BRANCH: ${{ steps.context.outputs.branch }}


### PR DESCRIPTION
* docs: update documentation for v1.2.0 features and clarify unsupported functionalities

* fix: refresh yarn.lock to match bumped versions after release versioning

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved CI/CD release workflows to enhance dependency synchronization. Updated build and publish processes now automatically synchronize dependency lockfiles with updated package configurations, ensuring consistency between package manifests and lockfiles during version updates. This reduces potential build failures and improves overall release reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->