### PR TITLE
feat: add lazy-aware JSON Schema conversion and regression tests for zod integration

### DIFF
--- a/libs/lazy-zod/src/__tests__/to-json-schema.spec.ts
+++ b/libs/lazy-zod/src/__tests__/to-json-schema.spec.ts
@@ -1,0 +1,74 @@
+import { toJSONSchema, z } from '../index';
+
+// Regression guard for the lazy-Proxy ↔ zod `toJSONSchema` interaction.
+//
+// zod's converter walks and MUTATES the schema tree via internal `_def` nodes
+// (it writes a `ref` onto each visited node). A lazy-zod Proxy in any nested
+// position — a `z.union([...])` option, an `.optional()` inner type, an array
+// element — used to break those writes with:
+//   "TypeError: Cannot set properties of undefined (setting 'ref')"
+// The barrel's `toJSONSchema` now `forceMaterialize`s first, so callers get a
+// clean conversion without reaching for `forceMaterialize` themselves. This
+// reproduces the original failure (the `search_skill` tool schemas) and asserts
+// the JSON Schema is both produced AND correct.
+describe('toJSONSchema (lazy-aware)', () => {
+  it('converts a union nested under .optional() without throwing (the original repro)', () => {
+    // Mirrors searchSkillInputSchema.notQuery — the case that surfaced the bug.
+    const schema = z.object({
+      query: z.string().min(1).max(2048).describe('Natural-language search query'),
+      limit: z.number().int().positive().max(50).optional(),
+      notQuery: z
+        .union([z.string().min(1).max(2048), z.array(z.string().min(1).max(2048)).max(8)])
+        .optional()
+        .describe('Anti-query'),
+    });
+
+    const json = toJSONSchema(schema) as Record<string, any>;
+
+    expect(json['type']).toBe('object');
+    expect(Object.keys(json['properties'])).toEqual(['query', 'limit', 'notQuery']);
+    // The union must serialize to anyOf with both branches.
+    expect(json['properties']['notQuery']['description']).toBe('Anti-query');
+    expect(json['properties']['notQuery']['anyOf']).toHaveLength(2);
+    // Only `query` is required (the others are .optional()).
+    expect(json['required']).toEqual(['query']);
+  });
+
+  it('converts a nested array-of-objects with optional fields (search_skill output shape)', () => {
+    const schema = z.object({
+      skills: z.array(
+        z.object({
+          skillId: z.string(),
+          name: z.string(),
+          score: z.number(),
+          bundleVersion: z.string().optional(),
+        }),
+      ),
+    });
+
+    const json = toJSONSchema(schema) as Record<string, any>;
+
+    expect(json['type']).toBe('object');
+    const item = json['properties']['skills']['items'];
+    expect(item['type']).toBe('object');
+    expect(item['required']).toEqual(['skillId', 'name', 'score']);
+  });
+
+  it('is idempotent — converting the same lazy schema twice yields equal output', () => {
+    const schema = z.object({
+      mode: z.union([z.literal('a'), z.literal('b')]).optional(),
+      tags: z.array(z.string()).max(8).optional(),
+    });
+
+    const first = toJSONSchema(schema);
+    const second = toJSONSchema(schema);
+
+    expect(second).toEqual(first);
+  });
+
+  it('still converts plain (already-real) zod schemas', () => {
+    const json = toJSONSchema(z.string().min(2)) as Record<string, any>;
+    expect(json['type']).toBe('string');
+    expect(json['minLength']).toBe(2);
+  });
+});

--- a/libs/lazy-zod/src/__tests__/to-json-schema.spec.ts
+++ b/libs/lazy-zod/src/__tests__/to-json-schema.spec.ts
@@ -1,4 +1,6 @@
-import { toJSONSchema, z } from '../index';
+import { eagerZ, toJSONSchema, z } from '../index';
+
+type JsonObject = Record<string, unknown>;
 
 // Regression guard for the lazy-Proxy ↔ zod `toJSONSchema` interaction.
 //
@@ -23,13 +25,15 @@ describe('toJSONSchema (lazy-aware)', () => {
         .describe('Anti-query'),
     });
 
-    const json = toJSONSchema(schema) as Record<string, any>;
+    const json = toJSONSchema(schema) as JsonObject;
+    const properties = json['properties'] as Record<string, JsonObject>;
+    const notQuery = properties['notQuery'];
 
     expect(json['type']).toBe('object');
-    expect(Object.keys(json['properties'])).toEqual(['query', 'limit', 'notQuery']);
+    expect(Object.keys(properties)).toEqual(['query', 'limit', 'notQuery']);
     // The union must serialize to anyOf with both branches.
-    expect(json['properties']['notQuery']['description']).toBe('Anti-query');
-    expect(json['properties']['notQuery']['anyOf']).toHaveLength(2);
+    expect(notQuery['description']).toBe('Anti-query');
+    expect(notQuery['anyOf']).toHaveLength(2);
     // Only `query` is required (the others are .optional()).
     expect(json['required']).toEqual(['query']);
   });
@@ -46,10 +50,12 @@ describe('toJSONSchema (lazy-aware)', () => {
       ),
     });
 
-    const json = toJSONSchema(schema) as Record<string, any>;
+    const json = toJSONSchema(schema) as JsonObject;
+    const properties = json['properties'] as Record<string, JsonObject>;
+    const skills = properties['skills'];
+    const item = skills['items'] as JsonObject;
 
     expect(json['type']).toBe('object');
-    const item = json['properties']['skills']['items'];
     expect(item['type']).toBe('object');
     expect(item['required']).toEqual(['skillId', 'name', 'score']);
   });
@@ -67,7 +73,7 @@ describe('toJSONSchema (lazy-aware)', () => {
   });
 
   it('still converts plain (already-real) zod schemas', () => {
-    const json = toJSONSchema(z.string().min(2)) as Record<string, any>;
+    const json = toJSONSchema(eagerZ.string().min(2)) as JsonObject;
     expect(json['type']).toBe('string');
     expect(json['minLength']).toBe(2);
   });

--- a/libs/lazy-zod/src/index.ts
+++ b/libs/lazy-zod/src/index.ts
@@ -8,6 +8,10 @@
  *  - `isLazy`, `forceMaterialize`: runtime escape hatches.
  */
 
+import { toJSONSchema as zodToJSONSchema, type ZodType } from 'zod';
+
+import { forceMaterialize } from './utils';
+
 export { z } from './lazy-z';
 // Default export mirrors zod's own `export default z` so existing code
 // like `import type z from 'zod'` (namespace-default import) keeps working
@@ -19,10 +23,24 @@ export { eagerZ } from './eager-z';
 export { lazyZ, LazyZodSchema, LAZY_BRAND, LAZY_TARGET, type InferLazy } from './lazy-schema';
 export { isLazy, forceMaterialize } from './utils';
 
-// JSON-Schema conversion helpers from zod itself. Kept here so consumer
-// code never reaches past the `@frontmcp/lazy-zod` boundary into `zod/v4`
-// directly — one place to swap the upstream package if we ever fork.
-export { toJSONSchema } from 'zod';
+// JSON-Schema conversion. Kept here so consumer code never reaches past the
+// `@frontmcp/lazy-zod` boundary into `zod/v4` directly — one place to swap the
+// upstream package if we ever fork.
+//
+// IMPORTANT: zod's `toJSONSchema` walks and MUTATES the schema tree via internal
+// `_def` nodes (it writes a `ref` onto each visited node). A lazy-zod Proxy
+// sitting anywhere in that tree — e.g. a `z.union([...])` option or an
+// `.optional()` inner type — intercepts `_def` in a way that breaks those
+// writes, surfacing as `TypeError: Cannot set properties of undefined (setting
+// 'ref')`. We `forceMaterialize` first so the converter always sees real zod
+// nodes. Doing it HERE keeps the lazy Proxy fully transparent to every consumer
+// (tool/job/agent/elicitation schema conversion) instead of relying on each
+// call site remembering to materialize.
+export const toJSONSchema = ((schema: ZodType, params?: unknown) =>
+  (zodToJSONSchema as (s: ZodType, p?: unknown) => unknown)(
+    forceMaterialize(schema),
+    params,
+  )) as typeof zodToJSONSchema;
 export type { JSONSchema } from 'zod/v4/core';
 
 // Class values — Zod v4 exports these as classes (callable + `instanceof`).


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed JSON Schema generation for lazy Zod schemas by ensuring lazy/proxy schemas are fully realized before conversion, preventing failures and preserving expected schema structure.
* **Tests**
  * Added a new test suite covering lazy-aware `toJSONSchema` behavior, including optional/union handling, correct `required` fields for optional object properties, and idempotent conversion.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->