### PR TITLE
fix: enhance SSRF protection in OpenAPI polling to block internal addresses by default and allow configuration for trusted environments

### DIFF
--- a/docs/frontmcp/adapters/openapi-adapter.mdx
+++ b/docs/frontmcp/adapters/openapi-adapter.mdx
@@ -1019,6 +1019,10 @@ When a spec change is detected (via content hash, ETag, or auto strategy), the a
 2. Calls `fetch()` to regenerate all tools
 3. Notifies subscribers via `onUpdate()`
 
+<Note>
+  Polling re-fetches the same spec `url` on a timer through the **same SSRF guard** as the initial load (GHSA-65h7-9wrw-629c) — it inherits your `loadOptions.refResolution` policy, so internal/loopback spec servers stay blocked unless you set `refResolution.allowInternalIPs: true`. See [Spec Loading & $ref Resolution Security](#spec-loading--ref-resolution-security-ssrf).
+</Note>
+
 Subscribe to updates for logging, metrics, or downstream notifications:
 
 ```ts

--- a/docs/frontmcp/adapters/openapi-polling.mdx
+++ b/docs/frontmcp/adapters/openapi-polling.mdx
@@ -158,6 +158,10 @@ The polling pipeline has two independent concerns:
 
 1. **Change detection** — The `OpenApiSpecPoller` fetches raw spec text from the URL and computes a SHA-256 content hash. If the hash differs from the last known hash, it fires `onChanged`.
 
+<Warning>
+  **The poll re-fetch is SSRF-guarded (GHSA-65h7-9wrw-629c).** Because polling re-fetches the same attacker-influenceable spec `url` on a timer, it runs through the exact same SSRF guard as the initial load — it inherits your `loadOptions.refResolution` policy, validates the *resolved IP* (not just the hostname), pins the connection to it, and re-validates redirect hops (`followRedirects` defaults to `false`). By default, loopback / private / internal targets are blocked; a poll to a blocked host fails closed (no fetch, no update) and is logged. To poll an internal or localhost spec server, opt in with `loadOptions.refResolution: { allowInternalIPs: true }` — trusted/local environments only. See [Spec Loading & $ref Resolution Security](/frontmcp/adapters/openapi-adapter#spec-loading--ref-resolution-security-ssrf).
+</Warning>
+
 2. **Tool rebuild** — When `onChanged` fires, the adapter resets its internal generator, calls `fetch()` to regenerate all tools from scratch, and notifies subscribers via the `updateCallback`.
 
 ```
@@ -330,6 +334,8 @@ export default class MultiApiApp {}
 
   <Accordion title="Test polling in CI">
     Use short intervals (100ms) and real HTTP servers in integration tests to verify the full pipeline. See the [Testing OpenAPI Adapter](/frontmcp/guides/testing-openapi-adapter) guide for patterns.
+
+    Test servers bind to `localhost`, which the SSRF guard blocks by default. Add `loadOptions: { refResolution: { allowInternalIPs: true } }` to the adapter under test so the poller can reach the local spec server.
   </Accordion>
 </AccordionGroup>
 
@@ -382,6 +388,13 @@ export default class MultiApiApp {}
     2. Check if authentication headers are needed in `polling.headers`
     3. Increase `fetchTimeoutMs` if the server is slow
     4. Increase `retry.maxRetries` for transient failures
+
+  </Accordion>
+
+  <Accordion title="Poll errors: host maps to a blocked internal address">
+    **Cause:** The spec `url` is a loopback / private / internal target (or a DNS name that resolves to one). The SSRF guard blocks it on every poll — the same guard that protects the initial spec load — so no fetch happens and no updates fire.
+
+    **Solution:** For a genuinely internal or localhost spec server in a trusted environment, opt in with `loadOptions: { refResolution: { allowInternalIPs: true } }`. Never enable this for untrusted spec URLs in production — it re-exposes SSRF.
 
   </Accordion>
 </AccordionGroup>

--- a/libs/adapters/src/openapi/__tests__/openapi-polling-e2e.spec.ts
+++ b/libs/adapters/src/openapi/__tests__/openapi-polling-e2e.spec.ts
@@ -8,21 +8,29 @@
  */
 
 import * as http from 'node:http';
+
+import { FrontMcpToolTokens, type FrontMcpAdapterResponse } from '@frontmcp/sdk';
+
+import { OpenApiSpecPoller } from '../openapi-spec-poller';
 import OpenapiAdapter from '../openapi.adapter';
 import { createMockLogger, spyOnConsole } from './fixtures';
-import { FrontMcpToolTokens, FrontMcpAdapterResponse } from '@frontmcp/sdk';
 
-// Mock mcp-from-openapi (same pattern as openapi-adapter.spec.ts)
-jest.mock('mcp-from-openapi', () => ({
-  OpenAPIToolGenerator: {
-    fromURL: jest.fn(),
-    fromJSON: jest.fn(),
-  },
-  SecurityResolver: jest.fn().mockImplementation(() => ({
-    resolve: jest.fn().mockResolvedValue({ headers: {}, query: {}, cookies: {} }),
-  })),
-  createSecurityContext: jest.fn((context) => context),
-}));
+// Mock only the tool generator; keep the real SSRF guard (safeFetch /
+// normalizeSsrfOptions) so the poller's fetch path is exercised for real.
+jest.mock('mcp-from-openapi', () => {
+  const actual = jest.requireActual('mcp-from-openapi');
+  return {
+    ...actual,
+    OpenAPIToolGenerator: {
+      fromURL: jest.fn(),
+      fromJSON: jest.fn(),
+    },
+    SecurityResolver: jest.fn().mockImplementation(() => ({
+      resolve: jest.fn().mockResolvedValue({ headers: {}, query: {}, cookies: {} }),
+    })),
+    createSecurityContext: jest.fn((context) => context),
+  };
+});
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -246,6 +254,7 @@ describe('OpenAPI Adapter — Polling E2E', () => {
           baseUrl: url,
           url: `${url}/openapi.json`,
           polling: { enabled: true, intervalMs: 100 },
+          loadOptions: { refResolution: { allowInternalIPs: true } },
           logger: createMockLogger(),
         });
 
@@ -304,6 +313,7 @@ describe('OpenAPI Adapter — Polling E2E', () => {
           baseUrl: url,
           url: `${url}/openapi.json`,
           polling: { enabled: true, intervalMs: 100 },
+          loadOptions: { refResolution: { allowInternalIPs: true } },
           logger: createMockLogger(),
         });
 
@@ -346,6 +356,7 @@ describe('OpenAPI Adapter — Polling E2E', () => {
           baseUrl: url,
           url: `${url}/openapi.json`,
           polling: { enabled: true, intervalMs: 100 },
+          loadOptions: { refResolution: { allowInternalIPs: true } },
           logger: createMockLogger(),
         });
 
@@ -388,6 +399,7 @@ describe('OpenAPI Adapter — Polling E2E', () => {
           baseUrl: url,
           url: `${url}/openapi.json`,
           polling: { enabled: true, intervalMs: 100 },
+          loadOptions: { refResolution: { allowInternalIPs: true } },
           logger: createMockLogger(),
         });
 
@@ -448,6 +460,7 @@ describe('OpenAPI Adapter — Polling E2E', () => {
           baseUrl: url,
           url: `${url}/openapi.json`,
           polling: { enabled: true, intervalMs: 100 },
+          loadOptions: { refResolution: { allowInternalIPs: true } },
           logger: createMockLogger(),
         });
 
@@ -532,6 +545,7 @@ describe('OpenAPI Adapter — Polling E2E', () => {
           baseUrl: url,
           url: `${url}/openapi.json`,
           polling: { enabled: true, intervalMs: 100 },
+          loadOptions: { refResolution: { allowInternalIPs: true } },
           logger: createMockLogger(),
         });
 
@@ -612,6 +626,7 @@ describe('OpenAPI Adapter — Polling E2E', () => {
           baseUrl: url,
           url: `${url}/openapi.json`,
           polling: { enabled: true, intervalMs: 100 },
+          loadOptions: { refResolution: { allowInternalIPs: true } },
           logger: createMockLogger(),
         });
 
@@ -663,6 +678,7 @@ describe('OpenAPI Adapter — Polling E2E', () => {
           baseUrl: url,
           url: `${url}/openapi.json`,
           polling: { enabled: true, intervalMs: 100 },
+          loadOptions: { refResolution: { allowInternalIPs: true } },
           logger: createMockLogger(),
         });
 
@@ -695,6 +711,87 @@ describe('OpenAPI Adapter — Polling E2E', () => {
         expect(tracker.allUpdates).toHaveLength(countBefore);
 
         adapter.stopPolling();
+      } finally {
+        await specServer.stop();
+      }
+    });
+  });
+
+  // ---------- SSRF Protection ----------
+
+  describe('SSRF Protection', () => {
+    it('fails closed on a loopback spec URL by default (never fetches, onChanged not called)', async () => {
+      const onChanged = jest.fn();
+      const onError = jest.fn();
+
+      const poller = new OpenApiSpecPoller(
+        'http://127.0.0.1:9/openapi.json',
+        { retry: { maxRetries: 0 } },
+        { onChanged, onError },
+      );
+
+      await poller.poll();
+
+      expect(onChanged).not.toHaveBeenCalled();
+      expect(onError).toHaveBeenCalledTimes(1);
+      const error = onError.mock.calls[0][0] as Error;
+      expect(error.message).toMatch(/blocked internal address|not in the allowed-hosts/i);
+    });
+
+    it('fetches an internal spec URL only when allowInternalIPs is opted in', async () => {
+      const specServer = createSpecServer();
+      const url = await specServer.start();
+
+      try {
+        specServer.setSpec(makeSpec([{ method: 'get', path: '/users', operationId: 'listUsers' }]));
+
+        const onChanged = jest.fn();
+        const onError = jest.fn();
+
+        const poller = new OpenApiSpecPoller(
+          `${url}/openapi.json`,
+          { retry: { maxRetries: 0 }, ssrf: { allowedHosts: [], blockedHosts: [], allowInternalIPs: true } },
+          { onChanged, onError },
+        );
+
+        await poller.poll();
+
+        expect(onError).not.toHaveBeenCalled();
+        expect(onChanged).toHaveBeenCalledTimes(1);
+      } finally {
+        await specServer.stop();
+      }
+    });
+
+    it('surfaces the SSRF block through the adapter poller when internal IPs are not allowed', async () => {
+      const specServer = createSpecServer();
+      const url = await specServer.start();
+
+      try {
+        specServer.setSpec(makeSpec([{ method: 'get', path: '/users', operationId: 'listUsers' }]));
+        configureMockGenerator([createMockTool('listUsers', 'get', '/users')]);
+
+        const logger = createMockLogger();
+        const adapter = new OpenapiAdapter({
+          name: 'test-api',
+          baseUrl: url,
+          url: `${url}/openapi.json`,
+          polling: { enabled: true, intervalMs: 100, retry: { maxRetries: 0 } },
+          logger,
+        });
+
+        const tracker = createUpdateTracker(adapter);
+        adapter.startPolling();
+
+        await delay(400);
+
+        expect(tracker.allUpdates).toHaveLength(0);
+        expect(logger.warn).toHaveBeenCalled();
+        const warned = logger.warn.mock.calls.map((call) => String(call[0])).join('\n');
+        expect(warned).toMatch(/blocked internal address|SSRF|allowed-hosts/i);
+
+        adapter.stopPolling();
+        tracker.unsubscribe();
       } finally {
         await specServer.stop();
       }

--- a/libs/adapters/src/openapi/openapi-spec-poller.ts
+++ b/libs/adapters/src/openapi/openapi-spec-poller.ts
@@ -8,13 +8,16 @@
  * @packageDocumentation
  */
 
+import { normalizeSsrfOptions, safeFetch, type ResolvedSsrfOptions } from 'mcp-from-openapi';
+
 import { sha256Hex } from '@frontmcp/utils';
+
 import type {
-  SpecPollerOptions,
-  SpecPollerCallbacks,
-  SpecPollerStats,
-  SpecPollerRetryConfig,
   PollerHealthStatus,
+  SpecPollerCallbacks,
+  SpecPollerOptions,
+  SpecPollerRetryConfig,
+  SpecPollerStats,
 } from './openapi-spec-poller.types';
 import { OpenAPIFetchError } from './openapi.errors';
 
@@ -37,6 +40,8 @@ export class OpenApiSpecPoller {
   private readonly retry: Required<SpecPollerRetryConfig>;
   private readonly unhealthyThreshold: number;
   private readonly headers: Record<string, string>;
+  private readonly ssrf: ResolvedSsrfOptions;
+  private readonly followRedirects: boolean;
   private readonly callbacks: SpecPollerCallbacks;
 
   private intervalTimer: ReturnType<typeof setInterval> | null = null;
@@ -56,6 +61,8 @@ export class OpenApiSpecPoller {
     this.retry = { ...DEFAULT_RETRY, ...options.retry };
     this.unhealthyThreshold = options.unhealthyThreshold ?? 3;
     this.headers = options.headers ?? {};
+    this.ssrf = options.ssrf ?? normalizeSsrfOptions(undefined);
+    this.followRedirects = options.followRedirects ?? false;
     this.callbacks = callbacks;
   }
 
@@ -158,44 +165,40 @@ export class OpenApiSpecPoller {
       }
     }
 
-    const controller = new AbortController();
-    const timeout = setTimeout(() => controller.abort(), this.fetchTimeoutMs);
+    // SECURITY (GHSA-65h7-9wrw-629c): guard the polled spec URL like fromURL() instead of raw fetch.
+    const response = await safeFetch(this.url, {
+      headers,
+      timeoutMs: this.fetchTimeoutMs,
+      followRedirects: this.followRedirects,
+      ssrf: this.ssrf,
+    });
 
-    try {
-      const response = await fetch(this.url, {
-        headers,
-        signal: controller.signal,
-      });
-
-      // HTTP 304: Not Modified
-      if (response.status === 304) {
-        this.callbacks.onUnchanged?.();
-        return;
-      }
-
-      if (!response.ok) {
-        throw new OpenAPIFetchError(this.url, response.status, response.statusText);
-      }
-
-      // Store ETag and Last-Modified for next request
-      const etag = response.headers.get('etag');
-      const lastModified = response.headers.get('last-modified');
-      if (etag) this.lastEtag = etag;
-      if (lastModified) this.lastModified = lastModified;
-
-      const body = await response.text();
-      const hash = sha256Hex(body);
-
-      if (this.lastHash && this.lastHash === hash) {
-        this.callbacks.onUnchanged?.();
-        return;
-      }
-
-      this.lastHash = hash;
-      this.callbacks.onChanged?.(body, hash);
-    } finally {
-      clearTimeout(timeout);
+    // HTTP 304: Not Modified
+    if (response.status === 304) {
+      this.callbacks.onUnchanged?.();
+      return;
     }
+
+    if (!response.ok) {
+      throw new OpenAPIFetchError(this.url, response.status, response.statusText);
+    }
+
+    // Store ETag and Last-Modified for next request
+    const etag = response.headers.get('etag');
+    const lastModified = response.headers.get('last-modified');
+    if (etag) this.lastEtag = etag;
+    if (lastModified) this.lastModified = lastModified;
+
+    const body = await response.text();
+    const hash = sha256Hex(body);
+
+    if (this.lastHash && this.lastHash === hash) {
+      this.callbacks.onUnchanged?.();
+      return;
+    }
+
+    this.lastHash = hash;
+    this.callbacks.onChanged?.(body, hash);
   }
 
   /**

--- a/libs/adapters/src/openapi/openapi-spec-poller.types.ts
+++ b/libs/adapters/src/openapi/openapi-spec-poller.types.ts
@@ -6,6 +6,8 @@
  * @packageDocumentation
  */
 
+import type { ResolvedSsrfOptions } from 'mcp-from-openapi';
+
 /**
  * Change detection strategy.
  */
@@ -46,6 +48,18 @@ export interface SpecPollerOptions {
   unhealthyThreshold?: number;
   /** Additional headers for fetch requests */
   headers?: Record<string, string>;
+  /**
+   * SSRF policy applied to the spec URL on every poll, matching the guard used
+   * for the initial `OPENAPIToolGenerator.fromURL()` load. The adapter injects
+   * this from `loadOptions.refResolution`; standalone callers may set it
+   * directly. Defaults to blocking internal/private addresses.
+   */
+  ssrf?: ResolvedSsrfOptions;
+  /**
+   * Follow (and re-validate) redirect hops when polling. Mirrors the adapter's
+   * spec-load redirect policy. @default false
+   */
+  followRedirects?: boolean;
 }
 
 /**

--- a/libs/adapters/src/openapi/openapi.adapter.ts
+++ b/libs/adapters/src/openapi/openapi.adapter.ts
@@ -1,4 +1,4 @@
-import { OpenAPIToolGenerator, type McpOpenAPITool } from 'mcp-from-openapi';
+import { normalizeSsrfOptions, OpenAPIToolGenerator, type McpOpenAPITool } from 'mcp-from-openapi';
 
 import { Adapter, DynamicAdapter, type FrontMcpAdapterResponse, type FrontMcpLogger } from '@frontmcp/sdk';
 
@@ -914,7 +914,14 @@ export default class OpenapiAdapter extends DynamicAdapter<OpenApiAdapterOptions
     const polling = this.options.polling;
     if (!polling?.enabled || !('url' in this.options)) return;
 
-    this.poller = new OpenApiSpecPoller(this.options.url, polling, {
+    // SECURITY (GHSA-65h7-9wrw-629c): poller re-fetches the same URL, so carry fromURL()'s SSRF policy.
+    const pollingOptions: typeof polling = {
+      ...polling,
+      ssrf: normalizeSsrfOptions(this.resolveRefResolution()),
+      followRedirects: this.options.loadOptions?.followRedirects ?? false,
+    };
+
+    this.poller = new OpenApiSpecPoller(this.options.url, pollingOptions, {
       onChanged: (_spec: string, _hash: string) => {
         // Serialize rebuilds to prevent races
         this.rebuildChain = this.rebuildChain.then(async () => {

--- a/libs/skills/catalog/frontmcp-development/references/openapi-adapter.md
+++ b/libs/skills/catalog/frontmcp-development/references/openapi-adapter.md
@@ -137,6 +137,13 @@ OpenapiAdapter.init({
 });
 ```
 
+> **SSRF (GHSA-65h7-9wrw-629c):** the poll re-fetches the same attacker-influenceable
+> spec `url` on a timer, so it runs through the **same SSRF guard** as the initial load —
+> it inherits `loadOptions.refResolution` (validates the resolved IP, pins the connection,
+> re-validates redirects). Loopback/private/internal spec servers are blocked by default;
+> a blocked poll fails closed (no fetch, no update) and is logged. To poll an internal or
+> localhost spec, set `loadOptions.refResolution.allowInternalIPs: true` — trusted/local only.
+
 ## Inline Spec
 
 Provide the OpenAPI spec directly instead of fetching from URL:
@@ -292,7 +299,7 @@ OpenapiAdapter.init({
 > vector. Hostname-string denylists are bypassable via DNS names that resolve to
 > internal IPs (e.g. `http://127.0.0.1.nip.io/`), redirects, and IPv4-mapped IPv6.
 > **Use `mcp-from-openapi` ≥ 2.5.0**, which resolves DNS and validates the
-> *resolved IP*, guards the spec-URL fetch (not just `$ref`s), and re-validates
+> _resolved IP_, guards the spec-URL fetch (not just `$ref`s), and re-validates
 > every redirect hop.
 
 FrontMCP's secure defaults:
@@ -350,12 +357,12 @@ OpenapiAdapter.init({
 
 These apply to **both** the spec-URL fetch and external `$ref` resolution (`mcp-from-openapi` ≥ 2.5.0):
 
-| Option             | Type       | Default (FrontMCP) | Description                                                                                         |
-| ------------------ | ---------- | ------------------ | -------------------------------------------------------------------------------------------------- |
+| Option             | Type       | Default (FrontMCP) | Description                                                                                                                           |
+| ------------------ | ---------- | ------------------ | ------------------------------------------------------------------------------------------------------------------------------------- |
 | `allowedProtocols` | `string[]` | `[]`               | Protocols allowed for external `$ref` resolution. **FrontMCP defaults to `[]`** (external refs off); set `['http','https']` to enable |
-| `allowedHosts`     | `string[]` | `undefined`        | When set, only the spec URL / `$ref` URLs to these hostnames are allowed                            |
-| `blockedHosts`     | `string[]` | `undefined`        | Additional hostnames/IPs to block beyond the built-in internal-address list                        |
-| `allowInternalIPs` | `boolean`  | `false`            | Allow loopback/private/internal targets for the spec URL **and** `$ref`s (skips ranges + DNS recheck). Trusted/local only |
+| `allowedHosts`     | `string[]` | `undefined`        | When set, only the spec URL / `$ref` URLs to these hostnames are allowed                                                              |
+| `blockedHosts`     | `string[]` | `undefined`        | Additional hostnames/IPs to block beyond the built-in internal-address list                                                           |
+| `allowInternalIPs` | `boolean`  | `false`            | Allow loopback/private/internal targets for the spec URL **and** `$ref`s (skips ranges + DNS recheck). Trusted/local only             |
 
 > `followRedirects` (a `loadOptions` field, not `refResolution`) defaults to `false` in FrontMCP.
 
@@ -379,15 +386,15 @@ OpenapiAdapter.init({
 
 ## Common Patterns
 
-| Pattern              | Correct                                                    | Incorrect                                           | Why                                             |
-| -------------------- | ---------------------------------------------------------- | --------------------------------------------------- | ----------------------------------------------- |
-| Adapter registration | `OpenapiAdapter.init({ ... })` in `adapters` array         | Placing adapter in `plugins` array                  | Adapters go in `adapters`, not `plugins`        |
-| Tool naming          | Tools auto-named as `<name>:<operationId>`                 | Expecting flat names like `listPets`                | Adapter name prevents collisions                |
-| Auth configuration   | `staticAuth: { jwt: process.env.API_TOKEN! }`              | Hardcoding secrets: `staticAuth: { jwt: 'sk-xxx' }` | Always use environment variables                |
-| Spec source          | Use `url` for hosted specs or `spec` for inline            | Using both `url` and `spec` simultaneously          | Only one source; `spec` takes precedence        |
-| Multiple APIs        | Separate `OpenapiAdapter.init()` with unique `name` values | Same `name` for different adapters                  | Duplicate names cause tool collisions           |
-| Spec/$ref SSRF       | Keep secure defaults (external refs off, redirects off, internal targets blocked) on `mcp-from-openapi` ≥ 2.5.0 | Setting `allowInternalIPs: true` in production; forwarding untrusted spec URLs without an `allowedHosts` allow-list | Defaults protect against SSRF (incl. DNS-name-to-internal) |
-| Format resolution    | `generateOptions: { resolveFormats: true }`                | Writing manual patterns for standard formats        | Built-in resolvers handle uuid, date-time, etc. |
+| Pattern              | Correct                                                                                                         | Incorrect                                                                                                           | Why                                                                                                     |
+| -------------------- | --------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------- |
+| Adapter registration | `OpenapiAdapter.init({ ... })` in `adapters` array                                                              | Placing adapter in `plugins` array                                                                                  | Adapters go in `adapters`, not `plugins`                                                                |
+| Tool naming          | Tools auto-named as `<name>:<operationId>`                                                                      | Expecting flat names like `listPets`                                                                                | Adapter name prevents collisions                                                                        |
+| Auth configuration   | `staticAuth: { jwt: process.env.API_TOKEN! }`                                                                   | Hardcoding secrets: `staticAuth: { jwt: 'sk-xxx' }`                                                                 | Always use environment variables                                                                        |
+| Spec source          | Use `url` for hosted specs or `spec` for inline                                                                 | Using both `url` and `spec` simultaneously                                                                          | Only one source; `spec` takes precedence                                                                |
+| Multiple APIs        | Separate `OpenapiAdapter.init()` with unique `name` values                                                      | Same `name` for different adapters                                                                                  | Duplicate names cause tool collisions                                                                   |
+| Spec/$ref SSRF       | Keep secure defaults (external refs off, redirects off, internal targets blocked) on `mcp-from-openapi` ≥ 2.5.0 | Setting `allowInternalIPs: true` in production; forwarding untrusted spec URLs without an `allowedHosts` allow-list | Defaults protect against SSRF (incl. DNS-name-to-internal); the spec **poller inherits the same guard** |
+| Format resolution    | `generateOptions: { resolveFormats: true }`                                                                     | Writing manual patterns for standard formats                                                                        | Built-in resolvers handle uuid, date-time, etc.                                                         |
 
 ## Verification Checklist
 
@@ -414,26 +421,27 @@ OpenapiAdapter.init({
 
 ## Troubleshooting
 
-| Problem                            | Cause                                                  | Solution                                                                                                  |
-| ---------------------------------- | ------------------------------------------------------ | --------------------------------------------------------------------------------------------------------- |
-| No tools generated from spec       | Spec URL returns non-OpenAPI content or is unreachable | Verify URL returns valid OpenAPI 3.x JSON; check network access                                           |
-| Authentication errors on API calls | Wrong auth config or missing credentials               | Configure `staticAuth`, `securityResolver`, `authProviderMapper`, or `additionalHeaders`; verify env vars |
-| Duplicate tool name error          | Two adapters with the same `name`                      | Give each adapter a unique `name`                                                                         |
-| Stale tools after API update       | Spec polling not configured                            | Add `polling: { intervalMs: 300000 }`                                                                     |
-| External $refs not resolving       | External refs are **disabled by default** in FrontMCP  | Set `loadOptions.refResolution.allowedProtocols: ['http','https']` (add `allowedHosts` to restrict)        |
-| Spec URL / $ref to internal host blocked | Target is loopback/private, or a DNS name resolving to one (SSRF guard) | Use `refResolution.allowInternalIPs: true` only in trusted/local environments              |
-| Spec URL redirect not followed     | `followRedirects` defaults to `false`                  | Set `loadOptions.followRedirects: true` (each hop is re-validated on `mcp-from-openapi` ≥ 2.5.0)           |
-| TypeScript error importing adapter | Wrong import path                                      | Import from `@frontmcp/adapters`                                                                          |
+| Problem                                                      | Cause                                                                    | Solution                                                                                                  |
+| ------------------------------------------------------------ | ------------------------------------------------------------------------ | --------------------------------------------------------------------------------------------------------- |
+| No tools generated from spec                                 | Spec URL returns non-OpenAPI content or is unreachable                   | Verify URL returns valid OpenAPI 3.x JSON; check network access                                           |
+| Authentication errors on API calls                           | Wrong auth config or missing credentials                                 | Configure `staticAuth`, `securityResolver`, `authProviderMapper`, or `additionalHeaders`; verify env vars |
+| Duplicate tool name error                                    | Two adapters with the same `name`                                        | Give each adapter a unique `name`                                                                         |
+| Stale tools after API update                                 | Spec polling not configured                                              | Add `polling: { intervalMs: 300000 }`                                                                     |
+| External $refs not resolving                                 | External refs are **disabled by default** in FrontMCP                    | Set `loadOptions.refResolution.allowedProtocols: ['http','https']` (add `allowedHosts` to restrict)       |
+| Spec URL / $ref to internal host blocked                     | Target is loopback/private, or a DNS name resolving to one (SSRF guard)  | Use `refResolution.allowInternalIPs: true` only in trusted/local environments                             |
+| Polling never updates from an internal/localhost spec server | The poll re-fetch is SSRF-guarded and blocks internal targets by default | Set `loadOptions.refResolution.allowInternalIPs: true` (trusted/local only)                               |
+| Spec URL redirect not followed                               | `followRedirects` defaults to `false`                                    | Set `loadOptions.followRedirects: true` (each hop is re-validated on `mcp-from-openapi` ≥ 2.5.0)          |
+| TypeScript error importing adapter                           | Wrong import path                                                        | Import from `@frontmcp/adapters`                                                                          |
 
 ## Examples
 
-| Example                                                                                                           | Level        | Description                                                                                                                                                   |
-| ----------------------------------------------------------------------------------------------------------------- | ------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| [`basic-openapi-adapter`](../examples/openapi-adapter/basic-openapi-adapter.md)                                   | Basic        | Demonstrates converting an OpenAPI specification into MCP tools automatically using `OpenapiAdapter` with minimal configuration.                              |
-| [`authenticated-adapter-with-polling`](../examples/openapi-adapter/authenticated-adapter-with-polling.md)         | Intermediate | Demonstrates configuring authentication (API key and bearer token) and automatic spec polling for OpenAPI adapters.                                           |
-| [`format-resolution-and-custom-resolvers`](../examples/openapi-adapter/format-resolution-and-custom-resolvers.md) | Intermediate | Demonstrates using built-in and custom format resolvers to enrich tool input schemas with concrete constraints from OpenAPI format values.                    |
-| [`ref-security-and-filtering`](../examples/openapi-adapter/ref-security-and-filtering.md)                         | Intermediate | Demonstrates configuring $ref / spec-URL resolution security to prevent SSRF attacks (GHSA-65h7-9wrw-629c) and filtering which API operations become MCP tools.                                |
-| [`multi-api-hub-with-inline-spec`](../examples/openapi-adapter/multi-api-hub-with-inline-spec.md)                 | Advanced     | Demonstrates registering multiple OpenAPI adapters from different APIs in a single app, including one with an inline spec definition instead of a remote URL. |
+| Example                                                                                                           | Level        | Description                                                                                                                                                     |
+| ----------------------------------------------------------------------------------------------------------------- | ------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| [`basic-openapi-adapter`](../examples/openapi-adapter/basic-openapi-adapter.md)                                   | Basic        | Demonstrates converting an OpenAPI specification into MCP tools automatically using `OpenapiAdapter` with minimal configuration.                                |
+| [`authenticated-adapter-with-polling`](../examples/openapi-adapter/authenticated-adapter-with-polling.md)         | Intermediate | Demonstrates configuring authentication (API key and bearer token) and automatic spec polling for OpenAPI adapters.                                             |
+| [`format-resolution-and-custom-resolvers`](../examples/openapi-adapter/format-resolution-and-custom-resolvers.md) | Intermediate | Demonstrates using built-in and custom format resolvers to enrich tool input schemas with concrete constraints from OpenAPI format values.                      |
+| [`ref-security-and-filtering`](../examples/openapi-adapter/ref-security-and-filtering.md)                         | Intermediate | Demonstrates configuring $ref / spec-URL resolution security to prevent SSRF attacks (GHSA-65h7-9wrw-629c) and filtering which API operations become MCP tools. |
+| [`multi-api-hub-with-inline-spec`](../examples/openapi-adapter/multi-api-hub-with-inline-spec.md)                 | Advanced     | Demonstrates registering multiple OpenAPI adapters from different APIs in a single app, including one with an inline spec definition instead of a remote URL.   |
 
 > See all examples in [`examples/openapi-adapter/`](../examples/openapi-adapter/)
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * OpenAPI specification polling now applies the same SSRF protection as initial specification loading.
  * Redirects are revalidated during polling, and blocked internal or loopback addresses fail safely without applying updates.
  * Polling errors now provide clearer warnings when a host resolves to a blocked internal address.

* **Documentation**
  * Expanded guidance for enabling polling against internal or localhost specification servers.
  * Added troubleshooting and CI testing notes for SSRF-protected polling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->