### PR TITLE
chore: update @enclave-vm/core and @enclave-vm/ast dependencies to version 2.15.2 in package.json and yarn.lock

### DIFF
--- a/.github/workflows/cherry-pick-prompt.yml
+++ b/.github/workflows/cherry-pick-prompt.yml
@@ -133,6 +133,7 @@ jobs:
         with:
           node-version-file: ".nvmrc"
           install: "false"
+          cache: ""
 
       - name: Re-pin internal versions to the target branch line
         if: steps.prepare.outputs.conflict == 'false'

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -54,6 +54,7 @@ jobs:
         with:
           node-version: ${{ needs.setup.outputs.node-version }}
           install: "false"
+          cache: ""
 
       - name: Check internal @frontmcp/* version pins agree
         run: node scripts/normalize-internal-versions.mjs --check

--- a/libs/sdk/package.json
+++ b/libs/sdk/package.json
@@ -93,7 +93,7 @@
   },
   "peerDependencies": {
     "@anthropic-ai/sdk": "^0.30.0 || ^0.78.0",
-    "@enclave-vm/core": "^2.15.1",
+    "@enclave-vm/core": "^2.15.2",
     "@frontmcp/observability": "1.5.7",
     "@frontmcp/storage-sqlite": "1.5.7",
     "@opentelemetry/api": "^1.9.0",

--- a/libs/utils/package.json
+++ b/libs/utils/package.json
@@ -27,7 +27,7 @@
     "node": ">=24.0.0"
   },
   "dependencies": {
-    "@enclave-vm/ast": "^2.15.1",
+    "@enclave-vm/ast": "^2.15.2",
     "@noble/ciphers": "^2.1.1",
     "@noble/hashes": "^2.0.1"
   },

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   },
   "private": true,
   "dependencies": {
-    "@enclave-vm/core": "^2.15.1",
+    "@enclave-vm/core": "^2.15.2",
     "@huggingface/transformers": "^3.2.2",
     "@modelcontextprotocol/sdk": "1.29.0",
     "@noble/ciphers": "^2.2.0",

--- a/plugins/plugin-codecall/package.json
+++ b/plugins/plugin-codecall/package.json
@@ -49,7 +49,7 @@
     }
   },
   "dependencies": {
-    "@enclave-vm/core": "^2.15.1",
+    "@enclave-vm/core": "^2.15.2",
     "@frontmcp/protocol": "1.5.7",
     "@frontmcp/sdk": "1.5.7",
     "vectoriadb": "^2.3.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1900,25 +1900,25 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@enclave-vm/ast@npm:2.15.1, @enclave-vm/ast@npm:^2.15.1":
-  version: 2.15.1
-  resolution: "@enclave-vm/ast@npm:2.15.1"
+"@enclave-vm/ast@npm:2.15.2, @enclave-vm/ast@npm:^2.15.2":
+  version: 2.15.2
+  resolution: "@enclave-vm/ast@npm:2.15.2"
   dependencies:
     "@types/estree": "npm:1.0.8"
     acorn: "npm:8.15.0"
     acorn-walk: "npm:8.3.4"
     astring: "npm:1.9.0"
-  checksum: 10c0/9e69b72b1f8a90c5d311bb0f8ceacc874459df33bae633c6b2a218a26cb0281f34c6659ecf5772d0985b4379d52b95ef2fd398a87613c64e651cd3edee60062d
+  checksum: 10c0/e2bc2c5c4c68a9a38fb1fc5c54eea7b2372ad4a1ff227cb71d71513214efae13633587565086cdb4062f4b4804f1080a7ba5afbdf5038c081abcf2137637cd38
   languageName: node
   linkType: hard
 
-"@enclave-vm/core@npm:^2.15.1":
-  version: 2.15.1
-  resolution: "@enclave-vm/core@npm:2.15.1"
+"@enclave-vm/core@npm:^2.15.2":
+  version: 2.15.2
+  resolution: "@enclave-vm/core@npm:2.15.2"
   dependencies:
     "@babel/standalone": "npm:^7.29.0"
-    "@enclave-vm/ast": "npm:2.15.1"
-    "@enclave-vm/types": "npm:2.15.1"
+    "@enclave-vm/ast": "npm:2.15.2"
+    "@enclave-vm/types": "npm:2.15.2"
     "@types/estree": "npm:1.0.8"
     acorn: "npm:8.15.0"
     acorn-walk: "npm:8.3.4"
@@ -1932,16 +1932,16 @@ __metadata:
       optional: true
     vectoriadb:
       optional: true
-  checksum: 10c0/f57bfb3341bdab6a793b6edd99b9f1308acad318f6bdea0e44d514690e47a09ff67eee2bb720597f9f311207aa05d8139a1dbd0f509789efe67e8c1ce7b55161
+  checksum: 10c0/23bae8011c178d1fc3d99075714dec3432f69e93b1fb043eaeb1d84039bd20b86ca43f0c14f8a013b7ea40df20d78b029769f60ae302c726737f86c11c90ea01
   languageName: node
   linkType: hard
 
-"@enclave-vm/types@npm:2.15.1":
-  version: 2.15.1
-  resolution: "@enclave-vm/types@npm:2.15.1"
+"@enclave-vm/types@npm:2.15.2":
+  version: 2.15.2
+  resolution: "@enclave-vm/types@npm:2.15.2"
   dependencies:
     zod: "npm:^4.3.6"
-  checksum: 10c0/ffca7ae8a2f0d11484464626d22350c395c2128fafff2cbc31279ef27d974524b8fb502e4935c93e834bfa94ed7ad4b862687a65ca2e16df14fc4baaf7c2b02a
+  checksum: 10c0/15bb73565c1280b85c4ab8450d70414c450add3da30cd6ea6f577b6d39b92e019f386d6ba2c48ad0202eb75b1980a2f19fac2d71edac5f5ccf5bc2b2eb0ab863
   languageName: node
   linkType: hard
 
@@ -2556,7 +2556,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@frontmcp/plugin-codecall@workspace:plugins/plugin-codecall"
   dependencies:
-    "@enclave-vm/core": "npm:^2.15.1"
+    "@enclave-vm/core": "npm:^2.15.2"
     "@frontmcp/protocol": "npm:1.5.7"
     "@frontmcp/sdk": "npm:1.5.7"
     reflect-metadata: "npm:^0.2.2"
@@ -2698,7 +2698,7 @@ __metadata:
     typescript: "npm:^5.9.3"
   peerDependencies:
     "@anthropic-ai/sdk": ^0.30.0 || ^0.78.0
-    "@enclave-vm/core": ^2.15.1
+    "@enclave-vm/core": ^2.15.2
     "@frontmcp/observability": 1.5.7
     "@frontmcp/storage-sqlite": 1.5.7
     "@opentelemetry/api": ^1.9.0
@@ -2747,7 +2747,7 @@ __metadata:
     "@anthropic-ai/sdk": "npm:^0.104.1"
     "@emotion/react": "npm:^11.14.0"
     "@emotion/styled": "npm:^11.14.1"
-    "@enclave-vm/core": "npm:^2.15.1"
+    "@enclave-vm/core": "npm:^2.15.2"
     "@eslint/js": "npm:^10.0.1"
     "@huggingface/transformers": "npm:^3.2.2"
     "@ianvs/prettier-plugin-sort-imports": "npm:^4.7.1"
@@ -2965,7 +2965,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@frontmcp/utils@workspace:libs/utils"
   dependencies:
-    "@enclave-vm/ast": "npm:^2.15.1"
+    "@enclave-vm/ast": "npm:^2.15.2"
     "@noble/ciphers": "npm:^2.1.1"
     "@noble/hashes": "npm:^2.0.1"
     "@types/node": "npm:^24.0.0"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Maintenance**
  * Updated Enclave VM packages to version 2.15.2 for improved compatibility.
  * Adjusted automated setup workflows to disable dependency caching where required.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->